### PR TITLE
Fix claude workflows so they donot recurse

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,16 @@ on:
 
 jobs:
   claude-review:
+    # Skip workflow if triggered by Claude bot to prevent loops
+    if: github.actor != 'claude[bot]' && github.actor != 'claude'
+    
     # Optional: Filter by PR author
     # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    #   github.actor != 'claude[bot]' && github.actor != 'claude' && (
+    #     github.event.pull_request.user.login == 'external-contributor' ||
+    #     github.event.pull_request.user.login == 'new-developer' ||
+    #     github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    #   )
     
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,12 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor != 'claude[bot]' && github.actor != 'claude' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ logs/
 
 # Docker
 docker-compose.override.yml
+
+# Docusaurus
+apps/docs/.docusaurus/


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to prevent infinite loops and improve trigger filtering for Claude bot automation. The main focus is ensuring that workflows are not triggered by the Claude bot itself and, optionally, allowing for more granular filtering by pull request author.

Workflow trigger improvements:

* Added a condition to `.github/workflows/claude-code-review.yml` to skip the workflow if triggered by the Claude bot, preventing automation loops.
* Updated `.github/workflows/claude.yml` to only run the workflow if the actor is not the Claude bot and the event contains an `@claude` mention, improving both safety and relevance of workflow runs.