### PR TITLE
Allow cursor bot to work

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Skip workflow if triggered by Claude bot to prevent loops
-    if: github.actor != 'claude[bot]' && github.actor != 'claude'
+    # Skip workflow if triggered by Claude bot or Cursor bot to prevent loops
+    if: github.actor != 'claude[bot]' && github.actor != 'claude' && github.actor != 'cursor'
     
     # Optional: Filter by PR author
     # if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   claude:
     if: |
-      github.actor != 'claude[bot]' && github.actor != 'claude' && (
+      github.actor != 'claude[bot]' && github.actor != 'claude' && github.actor != 'cursor' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to prevent them from being triggered by the Cursor bot, in addition to the existing checks for the Claude bot. This helps avoid workflow loops and unnecessary runs when automated bots interact with the repository.

Workflow trigger improvements:

* [`.github/workflows/claude-code-review.yml`](diffhunk://#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30L15-R16): Updated the workflow condition to skip runs if triggered by the `cursor` bot, alongside the existing checks for `claude[bot]` and `claude`.
* [`.github/workflows/claude.yml`](diffhunk://#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342eL16-R16): Added `cursor` to the list of actors that are excluded from triggering the workflow, preventing it from running on bot activity.