### PR TITLE
Replace default Docusaurus logo with custom logo120.png

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -76,7 +76,7 @@ const config: Config = {
       title: 'Boards',
       logo: {
         alt: 'Boards Logo',
-        src: 'img/logo.svg',
+        src: 'img/logo120.png',
       },
       items: [
         {


### PR DESCRIPTION
Replace the default Docusaurus logo with the custom logo120.png from assets directory.

## Changes
- Updated navbar logo configuration in docusaurus.config.ts
- Added logo120.png to static/img directory

Closes #21

Generated with [Claude Code](https://claude.ai/code)