### PR TITLE
docs: update backend architecture to use urql instead of Apollo

### DIFF
--- a/design/round1/04-auth-authorization-detailed.md
+++ b/design/round1/04-auth-authorization-detailed.md
@@ -145,7 +145,7 @@ interface AuthState {
   - `@weirdfingers/auth-jwt`: local token storage with backend-issued JWT.
 
 ### Token Wiring
-- Apollo/urql `authLink` calls `getToken()`.
+- urql `authExchange` calls `getToken()`.
 - SSR/Next.js: support token storage via cookies; `getToken` reads from cookie when in server context.
 
 ### Multi-tenant Header


### PR DESCRIPTION
Updates backend architecture documentation to use urql instead of Apollo GraphQL client.

Changes:
- Updated tech stack section to specify urql for React
- Replaced Apollo Client configuration with urql client setup
- Updated auth token wiring documentation to use authExchange
- Removed references to Apollo/Apollo Client throughout docs

Fixes #26

Generated with [Claude Code](https://claude.ai/code)