### PR TITLE
Dont always build docs; allow opt-out for claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,8 +13,9 @@ on:
 jobs:
   claude-review:
     # Skip workflow if triggered by Claude bot or Cursor bot to prevent loops
-    if: github.actor != 'claude[bot]' && github.actor != 'claude' && github.actor != 'cursor'
-    
+    if: |
+      github.actor != 'claude[bot]' && github.actor != 'claude' && github.actor != 'cursor' &&
+      !contains(github.event.pull_request.body, '[skip-claude-review]')
     # Optional: Filter by PR author
     # if: |
     #   github.actor != 'claude[bot]' && github.actor != 'claude' && (
@@ -22,14 +23,14 @@ jobs:
     #     github.event.pull_request.user.login == 'new-developer' ||
     #     github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     #   )
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -53,12 +54,12 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
-          
+
           # Optional: Customize review based on file types
           # direct_prompt: |
           #   Review this PR focusing on:
@@ -66,18 +67,17 @@ jobs:
           #   - For API endpoints: Security, input validation, and error handling
           #   - For React components: Performance, accessibility, and best practices
           #   - For tests: Coverage, edge cases, and test quality
-          
+
           # Optional: Different prompts for different authors
           # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
+          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
+
           # Optional: Add specific tools for running tests or linting
           # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
+
           # Optional: Skip review for certain conditions
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -2,9 +2,13 @@ name: Docs Build
 
 on:
   pull_request:
+    paths:
+      - "apps/docs/**"
   push:
     branches:
       - main
+    paths:
+      - "apps/docs/**"
 
 jobs:
   build-docs:


### PR DESCRIPTION
This pull request introduces improvements to the GitHub Actions workflows, focusing on optimizing when the workflows are triggered and adding more granular control over their execution. The most important changes include updating trigger conditions for both the code review and documentation build workflows.

**Workflow trigger optimization:**

* [`.github/workflows/claude-code-review.yml`](diffhunk://#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30L16-R18): Enhanced the conditional logic for running the Claude code review workflow by adding a check to skip execution if the pull request body contains `[skip-claude-review]`. This helps prevent unnecessary reviews and workflow loops.

**Documentation build workflow improvements:**

* [`.github/workflows/docs-build.yml`](diffhunk://#diff-5e741e7d81a58a7180a20b375f74ea941e3c6839eddd7688db425d9db6e1fe42R5-R11): Restricted the documentation build workflow to only run on changes affecting files under the `apps/docs/` directory, both for pull requests and pushes to the `main` branch. This reduces redundant workflow runs and speeds up CI for unrelated changes.

**Minor cleanup:**

* [`.github/workflows/claude-code-review.yml`](diffhunk://#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30L83): Removed an extraneous blank line for better formatting in the workflow file.