### PR TITLE
Remove outputSchema that is no longer supported

### DIFF
--- a/apps/example-nextjs/src/components/boards/GeneratorSelector.tsx
+++ b/apps/example-nextjs/src/components/boards/GeneratorSelector.tsx
@@ -8,7 +8,6 @@ export interface GeneratorInfo {
   description: string;
   artifactType: string;
   inputSchema: Record<string, unknown>;
-  outputSchema: Record<string, unknown>;
 }
 
 interface GeneratorSelectorProps {

--- a/packages/frontend/src/graphql/operations.ts
+++ b/packages/frontend/src/graphql/operations.ts
@@ -114,7 +114,6 @@ export const GET_GENERATORS = gql`
       description
       artifactType
       inputSchema
-      outputSchema
     }
   }
 `;

--- a/packages/frontend/src/hooks/useGenerators.ts
+++ b/packages/frontend/src/hooks/useGenerators.ts
@@ -11,7 +11,6 @@ interface Generator {
   description: string;
   artifactType: ArtifactType;
   inputSchema: Record<string, unknown>;
-  outputSchema: Record<string, unknown>;
 }
 
 interface UseGeneratorsOptions {


### PR DESCRIPTION
This pull request removes the unused or unnecessary `outputSchema` property from generator-related interfaces and GraphQL queries in both the frontend and the Next.js app. This streamlines the data model and ensures consistency across the codebase.

Schema/interface cleanup:

* Removed the `outputSchema` property from the `GeneratorInfo` interface in `GeneratorSelector.tsx` to simplify the generator definition.
* Removed the `outputSchema` property from the `Generator` interface in `useGenerators.ts` for consistency.

GraphQL query update:

* Removed the `outputSchema` field from the `GET_GENERATORS` GraphQL query in `operations.ts` to align with the updated interfaces.