### PR TITLE
Had the wrong name for the replicate api key env var

### DIFF
--- a/packages/cli-launcher/src/commands/up.ts
+++ b/packages/cli-launcher/src/commands/up.ts
@@ -99,7 +99,7 @@ export async function up(directory: string, options: UpOptions): Promise<void> {
     console.log(chalk.yellow("\n⚠️  Provider API keys not configured!"));
     console.log(chalk.gray("   Add at least one API key to api/.env:"));
     console.log(
-      chalk.cyan("   • REPLICATE_API_KEY") +
+      chalk.cyan("   • REPLICATE_API_TOKEN") +
         chalk.gray(" - https://replicate.com/account/api-tokens")
     );
     console.log(
@@ -282,7 +282,7 @@ async function promptForApiKeys(ctx: ProjectContext): Promise<void> {
   const response = await prompts([
     {
       type: "text",
-      name: "REPLICATE_API_KEY",
+      name: "REPLICATE_API_TOKEN",
       message: "Replicate API Key (https://replicate.com/account/api-tokens):",
       initial: "",
     },
@@ -297,8 +297,8 @@ async function promptForApiKeys(ctx: ProjectContext): Promise<void> {
   // Build the API keys dictionary (only include non-empty keys)
   const apiKeys: Record<string, string> = {};
 
-  if (response.REPLICATE_API_KEY && response.REPLICATE_API_KEY.trim()) {
-    apiKeys.REPLICATE_API_KEY = response.REPLICATE_API_KEY.trim();
+  if (response.REPLICATE_API_TOKEN && response.REPLICATE_API_TOKEN.trim()) {
+    apiKeys.REPLICATE_API_TOKEN = response.REPLICATE_API_TOKEN.trim();
   }
 
   if (response.OPENAI_API_KEY && response.OPENAI_API_KEY.trim()) {

--- a/packages/cli-launcher/src/utils.ts
+++ b/packages/cli-launcher/src/utils.ts
@@ -2,14 +2,14 @@
  * Utility functions for the Baseboards CLI
  */
 
-import { execa } from 'execa';
-import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import which from 'which';
-import type { Prerequisites, ProjectContext } from './types.js';
-import chalk from 'chalk';
-import crypto from 'crypto';
+import { execa } from "execa";
+import fs from "fs-extra";
+import path from "path";
+import { fileURLToPath } from "url";
+import which from "which";
+import type { Prerequisites, ProjectContext } from "./types.js";
+import chalk from "chalk";
+import crypto from "crypto";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -19,7 +19,7 @@ const __dirname = path.dirname(__filename);
  */
 export function getTemplatesDir(): string {
   // In built package, templates are at root level next to dist/
-  return path.join(__dirname, '../templates');
+  return path.join(__dirname, "../templates");
 }
 
 /**
@@ -34,11 +34,11 @@ export async function checkPrerequisites(): Promise<Prerequisites> {
 
   // Check Docker
   try {
-    const dockerPath = await which('docker');
+    const dockerPath = await which("docker");
     prereqs.docker.installed = !!dockerPath;
 
     if (dockerPath) {
-      const { stdout } = await execa('docker', ['--version']);
+      const { stdout } = await execa("docker", ["--version"]);
       const match = stdout.match(/Docker version ([\d.]+)/);
       if (match) {
         prereqs.docker.version = match[1];
@@ -46,9 +46,9 @@ export async function checkPrerequisites(): Promise<Prerequisites> {
 
       // Check Docker Compose
       try {
-        const { stdout: composeStdout } = await execa('docker', [
-          'compose',
-          'version',
+        const { stdout: composeStdout } = await execa("docker", [
+          "compose",
+          "version",
         ]);
         const composeMatch = composeStdout.match(/version v?([\d.]+)/);
         if (composeMatch) {
@@ -63,17 +63,20 @@ export async function checkPrerequisites(): Promise<Prerequisites> {
   }
 
   // Check Node version
-  const nodeVersion = process.version.replace('v', '');
+  const nodeVersion = process.version.replace("v", "");
   prereqs.node.version = nodeVersion;
 
-  const majorVersion = parseInt(nodeVersion.split('.')[0], 10);
+  const majorVersion = parseInt(nodeVersion.split(".")[0], 10);
   prereqs.node.satisfies = majorVersion >= 20;
 
   // Check if WSL
-  if (process.platform === 'linux') {
+  if (process.platform === "linux") {
     try {
-      const { stdout } = await execa('uname', ['-r']);
-      if (stdout.toLowerCase().includes('microsoft') || stdout.toLowerCase().includes('wsl')) {
+      const { stdout } = await execa("uname", ["-r"]);
+      if (
+        stdout.toLowerCase().includes("microsoft") ||
+        stdout.toLowerCase().includes("wsl")
+      ) {
         prereqs.platform.isWSL = true;
       }
     } catch (e) {
@@ -94,27 +97,27 @@ export async function assertPrerequisites(): Promise<void> {
 
   if (!prereqs.docker.installed) {
     errors.push(
-      '🐳 Docker is not installed.',
-      '   Install from: https://docs.docker.com/get-docker/'
+      "🐳 Docker is not installed.",
+      "   Install from: https://docs.docker.com/get-docker/"
     );
   } else if (!prereqs.docker.composeVersion) {
     errors.push(
-      '🐳 Docker Compose (v2) is not available.',
-      '   Update Docker to get Compose v2: https://docs.docker.com/compose/install/'
+      "🐳 Docker Compose (v2) is not available.",
+      "   Update Docker to get Compose v2: https://docs.docker.com/compose/install/"
     );
   }
 
   if (!prereqs.node.satisfies) {
     errors.push(
       `⚠️  Node.js ${prereqs.node.version} is too old (need v20+).`,
-      '   Install from: https://nodejs.org/'
+      "   Install from: https://nodejs.org/"
     );
   }
 
   if (errors.length > 0) {
-    console.error(chalk.red('\n❌ Prerequisites not met:\n'));
+    console.error(chalk.red("\n❌ Prerequisites not met:\n"));
     errors.forEach((err) => console.error(chalk.yellow(err)));
-    console.error('');
+    console.error("");
     process.exit(1);
   }
 }
@@ -124,11 +127,7 @@ export async function assertPrerequisites(): Promise<void> {
  */
 export function isScaffolded(dir: string): boolean {
   // Check for key files that indicate scaffolding
-  const keyFiles = [
-    'compose.yaml',
-    'web/package.json',
-    'api/pyproject.toml',
-  ];
+  const keyFiles = ["compose.yaml", "web/package.json", "api/pyproject.toml"];
 
   return keyFiles.every((file) => fs.existsSync(path.join(dir, file)));
 }
@@ -152,11 +151,11 @@ export async function findAvailablePort(
  * Check if a port is available
  */
 async function isPortAvailable(port: number): Promise<boolean> {
-  const { createServer } = await import('net');
+  const { createServer } = await import("net");
   return new Promise((resolve) => {
     const server = createServer();
-    server.once('error', () => resolve(false));
-    server.once('listening', () => {
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
       server.close();
       resolve(true);
     });
@@ -168,7 +167,7 @@ async function isPortAvailable(port: number): Promise<boolean> {
  * Generate a random secure string
  */
 export function generateSecret(length = 32): string {
-  return crypto.randomBytes(length).toString('hex');
+  return crypto.randomBytes(length).toString("hex");
 }
 
 /**
@@ -176,8 +175,8 @@ export function generateSecret(length = 32): string {
  */
 export function generatePassword(length = 24): string {
   const charset =
-    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*';
-  let password = '';
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*";
+  let password = "";
   const bytes = crypto.randomBytes(length);
 
   for (let i = 0; i < length; i++) {
@@ -200,11 +199,11 @@ export function parsePortsOption(portsStr: string): Partial<{
   const pairs = portsStr.split(/\s+/);
 
   for (const pair of pairs) {
-    const [service, port] = pair.split('=');
+    const [service, port] = pair.split("=");
     const portNum = parseInt(port, 10);
     if (
       service &&
-      ['web', 'api', 'db', 'redis'].includes(service) &&
+      ["web", "api", "db", "redis"].includes(service) &&
       !isNaN(portNum)
     ) {
       ports[service] = portNum;
@@ -218,8 +217,8 @@ export function parsePortsOption(portsStr: string): Partial<{
  * Read package.json version
  */
 export function getCliVersion(): string {
-  const packagePath = path.join(__dirname, '../package.json');
-  const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf-8'));
+  const packagePath = path.join(__dirname, "../package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf-8"));
   return packageJson.version;
 }
 
@@ -231,22 +230,22 @@ export function detectMissingProviderKeys(envPath: string): string[] {
     return [];
   }
 
-  const envContent = fs.readFileSync(envPath, 'utf-8');
+  const envContent = fs.readFileSync(envPath, "utf-8");
   const providerKeys = [
-    'REPLICATE_API_KEY',
-    'FAL_KEY',
-    'OPENAI_API_KEY',
-    'GOOGLE_API_KEY',
+    "REPLICATE_API_TOKEN",
+    "FAL_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
   ];
 
   const missingKeys: string[] = [];
 
   for (const key of providerKeys) {
-    const regex = new RegExp(`^${key}=(.*)$`, 'm');
+    const regex = new RegExp(`^${key}=(.*)$`, "m");
     const match = envContent.match(regex);
 
     // Key is missing if not found or if value is empty
-    if (!match || !match[1] || match[1].trim() === '') {
+    if (!match || !match[1] || match[1].trim() === "") {
       missingKeys.push(key);
     }
   }

--- a/packages/cli-launcher/template-sources/api-env.example
+++ b/packages/cli-launcher/template-sources/api-env.example
@@ -15,7 +15,7 @@ BOARDS_JWT_SECRET=
 # ============================================
 
 # Replicate - https://replicate.com/account/api-tokens
-REPLICATE_API_KEY=
+REPLICATE_API_TOKEN=
 
 # FAL - https://fal.ai/dashboard/keys
 FAL_KEY=


### PR DESCRIPTION
This pull request updates the Baseboards CLI to use `REPLICATE_API_TOKEN` instead of the deprecated `REPLICATE_API_KEY` for Replicate API authentication, and also standardizes string quoting throughout the codebase for consistency. The most important changes are grouped below.

**Provider Key Migration:**

* All references to `REPLICATE_API_KEY` in prompts, environment detection, and configuration have been replaced by `REPLICATE_API_TOKEN` in `up.ts`, `utils.ts`, and the example environment file. This ensures compatibility with Replicate's latest API requirements. [[1]](diffhunk://#diff-738d1909f17b2fe778856637b4bad537b573e5d5e54f0ad5f604257d27da3b1aL102-R102) [[2]](diffhunk://#diff-738d1909f17b2fe778856637b4bad537b573e5d5e54f0ad5f604257d27da3b1aL285-R285) [[3]](diffhunk://#diff-738d1909f17b2fe778856637b4bad537b573e5d5e54f0ad5f604257d27da3b1aL300-R301) [[4]](diffhunk://#diff-5e9feef3e491ee7b31798b4aee3614edfae8545c7f3555d323d6370e5fdd1f9bL234-R248) [[5]](diffhunk://#diff-8e765e66650b82dfcbbcbcd8d2c63916897f23e373446b907e9d9c51b88c3317L18-R18)

**Code Consistency and Style:**

* All single quotes have been replaced with double quotes in `utils.ts`, improving consistency with the project's preferred coding style.
* All path joins and file reads in `utils.ts` now use double quotes for string literals. [[1]](diffhunk://#diff-5e9feef3e491ee7b31798b4aee3614edfae8545c7f3555d323d6370e5fdd1f9bL22-R22) [[2]](diffhunk://#diff-5e9feef3e491ee7b31798b4aee3614edfae8545c7f3555d323d6370e5fdd1f9bL221-R221)
* All error and status messages in `utils.ts` use double quotes for clarity and consistency.

**Minor Improvements:**

* Service lists, port parsing, and password generation all use double quotes for string literals, aligning with the new style. [[1]](diffhunk://#diff-5e9feef3e491ee7b31798b4aee3614edfae8545c7f3555d323d6370e5fdd1f9bL127-R130) [[2]](diffhunk://#diff-5e9feef3e491ee7b31798b4aee3614edfae8545c7f3555d323d6370e5fdd1f9bL171-R179) [[3]](diffhunk://#diff-5e9feef3e491ee7b31798b4aee3614edfae8545c7f3555d323d6370e5fdd1f9bL203-R206)
* Docker and Node version checks use double quotes for command arguments and string manipulation. [[1]](diffhunk://#diff-5e9feef3e491ee7b31798b4aee3614edfae8545c7f3555d323d6370e5fdd1f9bL37-R51) [[2]](diffhunk://#diff-5e9feef3e491ee7b31798b4aee3614edfae8545c7f3555d323d6370e5fdd1f9bL66-R79)

These changes ensure the CLI remains up-to-date with provider requirements and maintains a consistent code style.