### PR TITLE
Use trusted publishing for cli-launcher

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -126,8 +126,6 @@ jobs:
         run: |
           cd packages/frontend
           pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-cli-launcher:
     needs: bump-and-release
@@ -165,5 +163,3 @@ jobs:
         run: |
           cd packages/cli-launcher
           pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/version-bump.yml` file, removing the explicit setting of the `NODE_AUTH_TOKEN` environment variable from the publish steps for both the frontend and CLI launcher packages. This change likely streamlines the workflow or relies on a different mechanism for authentication.