### PR TITLE
Add FAL AI generator prompting to CLI

### DIFF
--- a/packages/cli-launcher/src/commands/up.ts
+++ b/packages/cli-launcher/src/commands/up.ts
@@ -288,6 +288,12 @@ async function promptForApiKeys(ctx: ProjectContext): Promise<void> {
     },
     {
       type: "text",
+      name: "FAL_KEY",
+      message: "Fal AI API Key (https://fal.ai/dashboard/keys):",
+      initial: "",
+    },
+    {
+      type: "text",
       name: "OPENAI_API_KEY",
       message: "OpenAI API Key (https://platform.openai.com/api-keys):",
       initial: "",
@@ -299,6 +305,10 @@ async function promptForApiKeys(ctx: ProjectContext): Promise<void> {
 
   if (response.REPLICATE_API_TOKEN && response.REPLICATE_API_TOKEN.trim()) {
     apiKeys.REPLICATE_API_TOKEN = response.REPLICATE_API_TOKEN.trim();
+  }
+
+  if (response.FAL_KEY && response.FAL_KEY.trim()) {
+    apiKeys.FAL_KEY = response.FAL_KEY.trim();
   }
 
   if (response.OPENAI_API_KEY && response.OPENAI_API_KEY.trim()) {


### PR DESCRIPTION
Update the CLI launcher to prompt users for FAL_KEY during initial setup, matching the existing prompts for REPLICATE_API_TOKEN and OPENAI_API_KEY. The key is saved to BOARDS_GENERATOR_API_KEYS in api/.env when provided.

This completes the fal.ai generator integration by ensuring users can configure their Fal AI API key through the interactive setup.