### PR TITLE
feat(backend): implement granular optional dependencies for generators and storage

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -15,21 +15,72 @@ Backend for the Boards open-source creative toolkit for AI-generated content.
 
 ## Installation
 
-```bash
-# Install from PyPI (includes core dependencies: Redis, PyJWT)
-pip install boards-backend
+### Minimal Install
 
-# Or with optional provider/storage dependencies
-pip install boards-backend[providers,storage-s3,storage-gcs]
+The minimal installation includes core functionality with local filesystem storage only:
+
+```bash
+pip install weirdfingers-boards
+```
+
+### Install with Specific Generators
+
+Install only the generator providers you need:
+
+```bash
+# OpenAI generators (DALL-E 3, Whisper)
+pip install weirdfingers-boards[generators-openai]
+
+# Replicate generators (Flux Pro, Lipsync)
+pip install weirdfingers-boards[generators-replicate]
+
+# fal.ai generators (nano-banana)
+pip install weirdfingers-boards[generators-fal]
+
+# Multiple generators
+pip install weirdfingers-boards[generators-openai,generators-replicate]
+
+# All generators
+pip install weirdfingers-boards[generators-all]
+```
+
+### Install with Storage Backends
+
+Add cloud storage providers as needed:
+
+```bash
+# S3 storage (AWS, MinIO, DigitalOcean Spaces)
+pip install weirdfingers-boards[storage-s3]
+
+# Supabase storage
+pip install weirdfingers-boards[storage-supabase]
+
+# Google Cloud Storage
+pip install weirdfingers-boards[storage-gcs]
+
+# All storage backends
+pip install weirdfingers-boards[storage-all]
+```
+
+### Full Installation
+
+Install everything (all generators and storage backends):
+
+```bash
+pip install weirdfingers-boards[all]
 ```
 
 ### Development Installation
 
+For local development with all providers for type checking and testing:
+
 ```bash
-# Clone the repository and install (includes all extras for typecheck)
+# Clone the repository
 git clone https://github.com/weirdfingers/boards.git
 cd boards/packages/backend
-uv sync  # Automatically installs dev dependencies including all providers/storage
+
+# Install with dev dependencies (includes all providers)
+uv sync
 ```
 
 ## Configuration

--- a/packages/backend/pyproject.toml
+++ b/packages/backend/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
 ]
 dependencies = [
     "sqlalchemy>=2.0.0",
-    "supabase>=2.0.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "httpx>=0.24.0",
@@ -60,6 +59,52 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Generator providers (per-provider)
+generators-replicate = ["replicate>=1.0.4"]
+generators-openai = ["openai>=1.60.1"]
+generators-fal = ["fal-client>=0.5.0"]
+generators-anthropic = ["anthropic>=0.25.0"]
+generators-together = ["together>=1.0.0"]
+
+# Convenience: all generators
+generators-all = [
+    "replicate>=1.0.4",
+    "openai>=1.60.1",
+    "fal-client>=0.5.0",
+    "anthropic>=0.25.0",
+    "together>=1.0.0",
+]
+
+# Storage providers (per-provider)
+storage-supabase = ["supabase>=2.0.0"]
+storage-s3 = ["boto3>=1.34.0", "aioboto3>=12.0.0"]
+storage-gcs = ["google-cloud-storage>=2.10.0"]
+
+# Convenience: all storage backends
+storage-all = [
+    "supabase>=2.0.0",
+    "boto3>=1.34.0",
+    "aioboto3>=12.0.0",
+    "google-cloud-storage>=2.10.0",
+]
+
+# Auth providers (only Supabase needs extra deps beyond core httpx/pyjwt)
+auth-supabase = ["supabase>=2.0.0"]
+
+# Convenience: everything
+all = [
+    "replicate>=1.0.4",
+    "openai>=1.60.1",
+    "fal-client>=0.5.0",
+    "anthropic>=0.25.0",
+    "together>=1.0.0",
+    "supabase>=2.0.0",
+    "boto3>=1.34.0",
+    "aioboto3>=12.0.0",
+    "google-cloud-storage>=2.10.0",
+]
+
+# Development dependencies
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
@@ -76,21 +121,13 @@ dev = [
     "together>=1.0.0",
     "fal-client>=0.5.0",
     # Include all storage deps for typecheck
+    "supabase>=2.0.0",
     "boto3>=1.34.0",
     "aioboto3>=12.0.0",
     "google-cloud-storage>=2.10.0",
     # Type stubs
     "types-redis>=4.6.0",
 ]
-providers = [
-    "openai>=1.60.1",
-    "anthropic>=0.25.0",
-    "replicate>=1.0.4",
-    "together>=1.0.0",
-    "fal-client>=0.5.0",
-]
-storage-s3 = ["boto3>=1.34.0", "aioboto3>=12.0.0"]
-storage-gcs = ["google-cloud-storage>=2.10.0"]
 
 [project.urls]
 Homepage = "https://github.com/weirdfingers/boards"

--- a/packages/backend/src/boards/generators/implementations/audio/whisper.py
+++ b/packages/backend/src/boards/generators/implementations/audio/whisper.py
@@ -35,7 +35,10 @@ class WhisperGenerator(BaseGenerator):
         try:
             from openai import AsyncOpenAI
         except ImportError as e:
-            raise ValueError("Required dependencies not available") from e
+            raise ImportError(
+                "OpenAI SDK is required for WhisperGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-openai]"
+            ) from e
 
         client = AsyncOpenAI()
 

--- a/packages/backend/src/boards/generators/implementations/image/dalle3.py
+++ b/packages/backend/src/boards/generators/implementations/image/dalle3.py
@@ -46,7 +46,10 @@ class DallE3Generator(BaseGenerator):
         try:
             from openai import AsyncOpenAI
         except ImportError as e:
-            raise ValueError("Required dependencies not available") from e
+            raise ImportError(
+                "OpenAI SDK is required for DallE3Generator. "
+                "Install with: pip install weirdfingers-boards[generators-openai]"
+            ) from e
 
         client = AsyncOpenAI()
 

--- a/packages/backend/src/boards/generators/implementations/image/flux_pro.py
+++ b/packages/backend/src/boards/generators/implementations/image/flux_pro.py
@@ -50,7 +50,10 @@ class FluxProGenerator(BaseGenerator):
             import replicate
             from replicate.helpers import FileOutput
         except ImportError as e:
-            raise ValueError("Required dependencies not available") from e
+            raise ImportError(
+                "Replicate SDK is required for FluxProGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-replicate]"
+            ) from e
 
         # Use Replicate SDK directly
         prediction: FileOutput | AsyncIterator[FileOutput] = await replicate.async_run(

--- a/packages/backend/src/boards/generators/implementations/image/nano_banana.py
+++ b/packages/backend/src/boards/generators/implementations/image/nano_banana.py
@@ -85,7 +85,10 @@ class NanoBananaGenerator(BaseGenerator):
         try:
             import fal_client
         except ImportError as e:
-            raise ValueError("Required dependencies not available. Install fal-client.") from e
+            raise ImportError(
+                "fal.ai SDK is required for NanoBananaGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
 
         # Prepare arguments for fal.ai API
         arguments = {

--- a/packages/backend/src/boards/generators/implementations/video/lipsync.py
+++ b/packages/backend/src/boards/generators/implementations/video/lipsync.py
@@ -37,7 +37,10 @@ class LipsyncGenerator(BaseGenerator):
         try:
             import replicate  # type: ignore
         except ImportError as e:
-            raise ValueError("Required dependencies not available") from e
+            raise ImportError(
+                "Replicate SDK is required for LipsyncGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-replicate]"
+            ) from e
 
         # Resolve artifacts via context
         audio_file = await context.resolve_artifact(inputs.audio_source)

--- a/packages/backend/src/boards/storage/factory.py
+++ b/packages/backend/src/boards/storage/factory.py
@@ -47,7 +47,10 @@ try:
 except ImportError:
     SupabaseStorageProvider = None
     _supabase_available = False
-    logger.warning("Supabase storage not available - install supabase-py to enable")
+    logger.warning(
+        "Supabase storage not available. "
+        "Install with: pip install weirdfingers-boards[storage-supabase]"
+    )
 
 try:
     from .implementations.s3 import S3StorageProvider
@@ -56,7 +59,9 @@ try:
 except ImportError:
     S3StorageProvider = None
     _s3_available = False
-    logger.warning("S3 storage not available - install boto3 and aioboto3 to enable")
+    logger.warning(
+        "S3 storage not available. " "Install with: pip install weirdfingers-boards[storage-s3]"
+    )
 
 try:
     from .implementations.gcs import GCSStorageProvider
@@ -65,7 +70,9 @@ try:
 except ImportError:
     GCSStorageProvider = None
     _gcs_available = False
-    logger.warning("GCS storage not available - install google-cloud-storage to enable")
+    logger.warning(
+        "GCS storage not available. " "Install with: pip install weirdfingers-boards[storage-gcs]"
+    )
 
 
 def create_storage_provider(provider_type: str, config: dict[str, Any]) -> StorageProvider:
@@ -88,19 +95,22 @@ def create_storage_provider(provider_type: str, config: dict[str, Any]) -> Stora
     elif provider_type == "supabase":
         if not _supabase_available:
             raise ImportError(
-                "Supabase storage requires supabase-py. Install with: pip install supabase"
+                "Supabase storage requires additional dependencies. "
+                "Install with: pip install weirdfingers-boards[storage-supabase]"
             )
         return _create_supabase_provider(config)
     elif provider_type == "s3":
         if not _s3_available:
             raise ImportError(
-                "S3 storage requires boto3 and aioboto3. Install with: pip install boto3 aioboto3"
+                "S3 storage requires additional dependencies. "
+                "Install with: pip install weirdfingers-boards[storage-s3]"
             )
         return _create_s3_provider(config)
     elif provider_type == "gcs":
         if not _gcs_available:
             raise ImportError(
-                "GCS storage package required. Install with: pip install google-cloud-storage"
+                "GCS storage requires additional dependencies. "
+                "Install with: pip install weirdfingers-boards[storage-gcs]"
             )
         return _create_gcs_provider(config)
     else:

--- a/packages/backend/tests/storage/test_factory.py
+++ b/packages/backend/tests/storage/test_factory.py
@@ -73,7 +73,7 @@ class TestCreateStorageProvider:
 
     @patch("boards.storage.factory._gcs_available", False)
     def test_create_gcs_not_available(self):
-        with pytest.raises(ImportError, match="GCS storage package required"):
+        with pytest.raises(ImportError, match="GCS storage requires"):
             create_storage_provider("gcs", {})
 
     @patch("boards.storage.factory._supabase_available", True)

--- a/packages/backend/uv.lock
+++ b/packages/backend/uv.lock
@@ -2706,11 +2706,24 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "strawberry-graphql", extra = ["fastapi"] },
     { name = "structlog" },
-    { name = "supabase" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "aioboto3" },
+    { name = "anthropic" },
+    { name = "boto3" },
+    { name = "fal-client" },
+    { name = "google-cloud-storage" },
+    { name = "openai" },
+    { name = "replicate" },
+    { name = "supabase" },
+    { name = "together" },
+]
+auth-supabase = [
+    { name = "supabase" },
+]
 dev = [
     { name = "aioboto3" },
     { name = "anthropic" },
@@ -2727,15 +2740,37 @@ dev = [
     { name = "pytest-postgresql" },
     { name = "replicate" },
     { name = "ruff" },
+    { name = "supabase" },
     { name = "together" },
     { name = "types-redis" },
 ]
-providers = [
+generators-all = [
     { name = "anthropic" },
     { name = "fal-client" },
     { name = "openai" },
     { name = "replicate" },
     { name = "together" },
+]
+generators-anthropic = [
+    { name = "anthropic" },
+]
+generators-fal = [
+    { name = "fal-client" },
+]
+generators-openai = [
+    { name = "openai" },
+]
+generators-replicate = [
+    { name = "replicate" },
+]
+generators-together = [
+    { name = "together" },
+]
+storage-all = [
+    { name = "aioboto3" },
+    { name = "boto3" },
+    { name = "google-cloud-storage" },
+    { name = "supabase" },
 ]
 storage-gcs = [
     { name = "google-cloud-storage" },
@@ -2743,6 +2778,9 @@ storage-gcs = [
 storage-s3 = [
     { name = "aioboto3" },
     { name = "boto3" },
+]
+storage-supabase = [
+    { name = "supabase" },
 ]
 
 [package.dev-dependencies]
@@ -2771,27 +2809,39 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aioboto3", marker = "extra == 'all'", specifier = ">=12.0.0" },
     { name = "aioboto3", marker = "extra == 'dev'", specifier = ">=12.0.0" },
+    { name = "aioboto3", marker = "extra == 'storage-all'", specifier = ">=12.0.0" },
     { name = "aioboto3", marker = "extra == 'storage-s3'", specifier = ">=12.0.0" },
     { name = "aiofiles", specifier = ">=23.0.0" },
     { name = "alembic", specifier = ">=1.13.2" },
+    { name = "anthropic", marker = "extra == 'all'", specifier = ">=0.25.0" },
     { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.25.0" },
-    { name = "anthropic", marker = "extra == 'providers'", specifier = ">=0.25.0" },
+    { name = "anthropic", marker = "extra == 'generators-all'", specifier = ">=0.25.0" },
+    { name = "anthropic", marker = "extra == 'generators-anthropic'", specifier = ">=0.25.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
+    { name = "boto3", marker = "extra == 'all'", specifier = ">=1.34.0" },
     { name = "boto3", marker = "extra == 'dev'", specifier = ">=1.34.0" },
+    { name = "boto3", marker = "extra == 'storage-all'", specifier = ">=1.34.0" },
     { name = "boto3", marker = "extra == 'storage-s3'", specifier = ">=1.34.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "dramatiq", extras = ["redis", "watch"], specifier = ">=1.15.0" },
+    { name = "fal-client", marker = "extra == 'all'", specifier = ">=0.5.0" },
     { name = "fal-client", marker = "extra == 'dev'", specifier = ">=0.5.0" },
-    { name = "fal-client", marker = "extra == 'providers'", specifier = ">=0.5.0" },
+    { name = "fal-client", marker = "extra == 'generators-all'", specifier = ">=0.5.0" },
+    { name = "fal-client", marker = "extra == 'generators-fal'", specifier = ">=0.5.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
+    { name = "google-cloud-storage", marker = "extra == 'all'", specifier = ">=2.10.0" },
     { name = "google-cloud-storage", marker = "extra == 'dev'", specifier = ">=2.10.0" },
+    { name = "google-cloud-storage", marker = "extra == 'storage-all'", specifier = ">=2.10.0" },
     { name = "google-cloud-storage", marker = "extra == 'storage-gcs'", specifier = ">=2.10.0" },
     { name = "httpx", specifier = ">=0.24.0" },
     { name = "numpy", specifier = ">=1.24.0" },
+    { name = "openai", marker = "extra == 'all'", specifier = ">=1.60.1" },
     { name = "openai", marker = "extra == 'dev'", specifier = ">=1.60.1" },
-    { name = "openai", marker = "extra == 'providers'", specifier = ">=1.60.1" },
+    { name = "openai", marker = "extra == 'generators-all'", specifier = ">=1.60.1" },
+    { name = "openai", marker = "extra == 'generators-openai'", specifier = ">=1.60.1" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "psutil", specifier = ">=7.0.0" },
@@ -2807,19 +2857,27 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "redis", specifier = ">=5.0.0" },
+    { name = "replicate", marker = "extra == 'all'", specifier = ">=1.0.4" },
     { name = "replicate", marker = "extra == 'dev'", specifier = ">=1.0.4" },
-    { name = "replicate", marker = "extra == 'providers'", specifier = ">=1.0.4" },
+    { name = "replicate", marker = "extra == 'generators-all'", specifier = ">=1.0.4" },
+    { name = "replicate", marker = "extra == 'generators-replicate'", specifier = ">=1.0.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.200.0" },
     { name = "structlog", specifier = ">=23.0.0" },
-    { name = "supabase", specifier = ">=2.0.0" },
+    { name = "supabase", marker = "extra == 'all'", specifier = ">=2.0.0" },
+    { name = "supabase", marker = "extra == 'auth-supabase'", specifier = ">=2.0.0" },
+    { name = "supabase", marker = "extra == 'dev'", specifier = ">=2.0.0" },
+    { name = "supabase", marker = "extra == 'storage-all'", specifier = ">=2.0.0" },
+    { name = "supabase", marker = "extra == 'storage-supabase'", specifier = ">=2.0.0" },
+    { name = "together", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "together", marker = "extra == 'dev'", specifier = ">=1.0.0" },
-    { name = "together", marker = "extra == 'providers'", specifier = ">=1.0.0" },
+    { name = "together", marker = "extra == 'generators-all'", specifier = ">=1.0.0" },
+    { name = "together", marker = "extra == 'generators-together'", specifier = ">=1.0.0" },
     { name = "types-redis", marker = "extra == 'dev'", specifier = ">=4.6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.23.0" },
 ]
-provides-extras = ["dev", "providers", "storage-s3", "storage-gcs"]
+provides-extras = ["generators-replicate", "generators-openai", "generators-fal", "generators-anthropic", "generators-together", "generators-all", "storage-supabase", "storage-s3", "storage-gcs", "storage-all", "auth-supabase", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Add per-provider optional dependencies (extras) to allow users to install only the SDK dependencies they need, following the industry-standard pattern used by Celery and SQLAlchemy.

## Changes

### Core Dependencies
- **Removed** `supabase>=2.0.0` from core dependencies (breaking change, pre-1.0.0)
- Minimal install now includes only local storage support

### New Optional Dependencies (Extras)

**Generator extras (per-provider):**
- `generators-replicate` - Replicate SDK for Flux Pro, Lipsync
- `generators-openai` - OpenAI SDK for DALL-E 3, Whisper
- `generators-fal` - fal.ai SDK for nano-banana
- `generators-anthropic` - Anthropic SDK (for future generators)
- `generators-together` - Together SDK (for future generators)
- `generators-all` - Convenience bundle for all generators

**Storage extras (per-provider):**
- `storage-supabase` - Supabase storage backend
- `storage-s3` - AWS S3, MinIO, DigitalOcean Spaces
- `storage-gcs` - Google Cloud Storage
- `storage-all` - Convenience bundle for all storage backends

**Auth extras:**
- `auth-supabase` - Supabase auth adapter

**Meta extras:**
- `all` - Install everything

### Improved Error Messages

All generators and storage providers now show helpful installation instructions when dependencies are missing:

```python
ImportError: Replicate SDK is required for FluxProGenerator. 
Install with: pip install weirdfingers-boards[generators-replicate]
```

### Documentation

Added comprehensive installation examples to README:

```bash
# Minimal install (local storage only)
pip install weirdfingers-boards

# Specific generators
pip install weirdfingers-boards[generators-openai,generators-replicate]

# With cloud storage
pip install weirdfingers-boards[storage-s3]

# Everything
pip install weirdfingers-boards[all]
```

## Design Pattern

Following the industry-standard pattern used by Celery, SQLAlchemy, and FastAPI:
- ✅ All source code ships in the main package
- ✅ Extras only control external SDK dependencies
- ✅ Lazy imports with helpful error messages

## Testing

- ✅ All 318 backend tests pass
- ✅ Type checking passes
- ✅ Verified extras are correctly defined in package metadata
- ✅ Confirmed Supabase removed from core dependencies

## Breaking Changes

- Users who `pip install weirdfingers-boards` will no longer get Supabase automatically
- This is acceptable as we're pre-1.0.0
- Users can install `weirdfingers-boards[storage-supabase]` or `weirdfingers-boards[all]` if needed