### PR TITLE
fal-ai/flux-pro/v1.1-ultra

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -23,6 +23,9 @@ generators:
   - class: "boards.generators.implementations.fal.image.nano_banana_edit.FalNanoBananaEditGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.flux_pro_ultra.FalFluxProUltraGenerator"
+    enabled: true
+
   # OpenAI generators
   - class: "boards.generators.implementations.openai.image.dalle3.OpenAIDallE3Generator"
     enabled: true

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -1,9 +1,11 @@
 """Fal.ai image generators."""
 
+from .flux_pro_ultra import FalFluxProUltraGenerator
 from .nano_banana import FalNanoBananaGenerator
 from .nano_banana_edit import FalNanoBananaEditGenerator
 
 __all__ = [
+    "FalFluxProUltraGenerator",
     "FalNanoBananaGenerator",
     "FalNanoBananaEditGenerator",
 ]

--- a/packages/backend/src/boards/generators/implementations/fal/image/flux_pro_ultra.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/flux_pro_ultra.py
@@ -1,0 +1,197 @@
+"""
+fal.ai FLUX1.1 [pro] ultra text-to-image generator.
+
+High-quality image generation using fal.ai's FLUX1.1 [pro] ultra model with support for
+batch outputs and advanced controls.
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class FluxProUltraInput(BaseModel):
+    """Input schema for FLUX1.1 [pro] ultra image generation."""
+
+    prompt: str = Field(description="Text prompt for image generation")
+    aspect_ratio: Literal[
+        "21:9",
+        "16:9",
+        "4:3",
+        "3:2",
+        "1:1",
+        "2:3",
+        "3:4",
+        "9:16",
+        "9:21",
+    ] = Field(
+        default="16:9",
+        description="Image aspect ratio",
+    )
+    num_images: int = Field(
+        default=1,
+        ge=1,
+        le=4,
+        description="Number of images to generate in batch (max 4)",
+    )
+    enable_safety_checker: bool = Field(
+        default=True,
+        description="Enable safety checker to filter unsafe content",
+    )
+    safety_tolerance: int = Field(
+        default=2,
+        ge=1,
+        le=6,
+        description="Safety tolerance level (1 = most strict, 6 = most permissive)",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Random seed for reproducibility (optional)",
+    )
+    output_format: Literal["jpeg", "png"] = Field(
+        default="jpeg",
+        description="Output image format",
+    )
+    enhance_prompt: bool = Field(
+        default=False,
+        description="Whether to enhance the prompt for better results",
+    )
+    raw: bool = Field(
+        default=False,
+        description="Generate less processed, more natural-looking images",
+    )
+    sync_mode: bool = Field(
+        default=True,
+        description="Use synchronous mode (wait for completion)",
+    )
+
+
+class FalFluxProUltraGenerator(BaseGenerator):
+    """FLUX1.1 [pro] ultra image generator using fal.ai."""
+
+    name = "fal-flux-pro-ultra"
+    artifact_type = "image"
+    description = (
+        "Fal: FLUX1.1 [pro] ultra - high-quality text-to-image generation with advanced controls"
+    )
+
+    def get_input_schema(self) -> type[FluxProUltraInput]:
+        return FluxProUltraInput
+
+    async def generate(
+        self, inputs: FluxProUltraInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate images using fal.ai FLUX1.1 [pro] ultra model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalFluxProUltraGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "prompt": inputs.prompt,
+            "aspect_ratio": inputs.aspect_ratio,
+            "num_images": inputs.num_images,
+            "enable_safety_checker": inputs.enable_safety_checker,
+            "safety_tolerance": inputs.safety_tolerance,
+            "output_format": inputs.output_format,
+            "enhance_prompt": inputs.enhance_prompt,
+            "raw": inputs.raw,
+            "sync_mode": inputs.sync_mode,
+        }
+
+        # Add seed if provided
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/flux-pro/v1.1-ultra",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image URLs from result
+        # fal.ai returns: {"images": [{"url": "...", "width": ..., "height": ...}, ...]}
+        images = result.get("images", [])
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url = image_data.get("url")
+            width = image_data.get("width", 1024)
+            height = image_data.get("height", 1024)
+
+            if not image_url:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Store with appropriate output_index
+            artifact = await context.store_image_result(
+                storage_url=image_url,
+                format=inputs.output_format,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: FluxProUltraInput) -> float:
+        """Estimate cost for FLUX1.1 [pro] ultra generation.
+
+        FLUX1.1 [pro] ultra billing is based on megapixels (rounded up).
+        The aspect ratios map to different resolutions, all roughly in the 2-4MP range.
+        Estimated at approximately $0.04 per image based on typical resolutions.
+        """
+        # Approximate cost per image (varies slightly by resolution/megapixels)
+        # Most aspect ratios result in 2-4 megapixels
+        cost_per_image = 0.04
+        return cost_per_image * inputs.num_images

--- a/packages/backend/tests/generators/implementations/test_flux_pro_ultra.py
+++ b/packages/backend/tests/generators/implementations/test_flux_pro_ultra.py
@@ -1,0 +1,408 @@
+"""
+Tests for FalFluxProUltraGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.flux_pro_ultra import (
+    FalFluxProUltraGenerator,
+    FluxProUltraInput,
+)
+
+
+class TestFluxProUltraInput:
+    """Tests for FluxProUltraInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        input_data = FluxProUltraInput(
+            prompt="A serene mountain landscape",
+            aspect_ratio="16:9",
+            num_images=2,
+            safety_tolerance=3,
+            output_format="png",
+        )
+
+        assert input_data.prompt == "A serene mountain landscape"
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.num_images == 2
+        assert input_data.safety_tolerance == 3
+        assert input_data.output_format == "png"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = FluxProUltraInput(prompt="Test prompt")
+
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.num_images == 1
+        assert input_data.enable_safety_checker is True
+        assert input_data.safety_tolerance == 2
+        assert input_data.output_format == "jpeg"
+        assert input_data.enhance_prompt is False
+        assert input_data.raw is False
+        assert input_data.sync_mode is True
+        assert input_data.seed is None
+
+    def test_invalid_aspect_ratio(self):
+        """Test validation fails for invalid aspect ratio."""
+        with pytest.raises(ValidationError):
+            FluxProUltraInput(
+                prompt="Test",
+                aspect_ratio="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_output_format(self):
+        """Test validation fails for invalid output format."""
+        with pytest.raises(ValidationError):
+            FluxProUltraInput(
+                prompt="Test",
+                output_format="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_num_images_validation(self):
+        """Test validation for num_images constraints."""
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            FluxProUltraInput(prompt="Test", num_images=0)
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            FluxProUltraInput(prompt="Test", num_images=5)
+
+        # Test valid range (1-4)
+        for num in [1, 2, 3, 4]:
+            input_data = FluxProUltraInput(prompt="Test", num_images=num)
+            assert input_data.num_images == num
+
+    def test_safety_tolerance_validation(self):
+        """Test validation for safety_tolerance constraints."""
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            FluxProUltraInput(prompt="Test", safety_tolerance=0)
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            FluxProUltraInput(prompt="Test", safety_tolerance=7)
+
+        # Test valid range (1-6)
+        for tolerance in [1, 2, 3, 4, 5, 6]:
+            input_data = FluxProUltraInput(prompt="Test", safety_tolerance=tolerance)
+            assert input_data.safety_tolerance == tolerance
+
+    def test_aspect_ratio_options(self):
+        """Test all valid aspect ratio options."""
+        valid_ratios = ["21:9", "16:9", "4:3", "3:2", "1:1", "2:3", "3:4", "9:16", "9:21"]
+
+        for ratio in valid_ratios:
+            input_data = FluxProUltraInput(prompt="Test", aspect_ratio=ratio)  # type: ignore[arg-type]
+            assert input_data.aspect_ratio == ratio
+
+
+class TestFluxProUltraGenerator:
+    """Tests for FalFluxProUltraGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalFluxProUltraGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-flux-pro-ultra"
+        assert self.generator.artifact_type == "image"
+        assert "FLUX1.1 [pro] ultra" in self.generator.description
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == FluxProUltraInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = FluxProUltraInput(prompt="Test prompt")
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="Missing FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation of a single image."""
+        input_data = FluxProUltraInput(
+            prompt="A beautiful sunset over the ocean",
+            aspect_ratio="16:9",
+            num_images=1,
+            output_format="jpeg",
+        )
+
+        fake_image_url = "https://fal.media/files/fake-image-url.jpeg"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-token"}):
+            # Create mock fal_client module
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "fal-request-123"
+
+            # Create async generator for iter_events
+            async def mock_iter_events(with_logs=True):
+                # Yield some fake events
+                for i in range(5):
+                    event = MagicMock()
+                    event.logs = [f"Processing step {i}"]
+                    yield event
+
+            mock_handler.iter_events = mock_iter_events
+
+            # Mock get() to return the final result
+            async def mock_get():
+                return {
+                    "images": [
+                        {
+                            "url": fake_image_url,
+                            "width": 1920,
+                            "height": 1080,
+                            "content_type": "image/jpeg",
+                        }
+                    ],
+                    "seed": 12345,
+                }
+
+            mock_handler.get = mock_get
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_image_url,
+                width=1920,
+                height=1080,
+                format="jpeg",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify API calls
+            mock_fal_client.submit_async.assert_called_once()
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[0][0] == "fal-ai/flux-pro/v1.1-ultra"
+            assert call_args[1]["arguments"]["prompt"] == "A beautiful sunset over the ocean"
+            assert call_args[1]["arguments"]["aspect_ratio"] == "16:9"
+            assert call_args[1]["arguments"]["num_images"] == 1
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_batch(self):
+        """Test successful generation of multiple images in a batch."""
+        input_data = FluxProUltraInput(
+            prompt="A forest in autumn",
+            num_images=3,
+            output_format="png",
+        )
+
+        fake_image_urls = [
+            "https://fal.media/files/image1.png",
+            "https://fal.media/files/image2.png",
+            "https://fal.media/files/image3.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-token"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "fal-request-456"
+
+            # Create async generator for iter_events (empty for simplicity)
+            async def mock_iter_events(with_logs=True):
+                if False:
+                    yield
+
+            mock_handler.iter_events = mock_iter_events
+
+            # Mock get() to return the final result with 3 images
+            async def mock_get():
+                return {
+                    "images": [
+                        {"url": url, "width": 1024, "height": 1024, "content_type": "image/png"}
+                        for url in fake_image_urls
+                    ],
+                    "seed": 67890,
+                }
+
+            mock_handler.get = mock_get
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage results
+            stored_artifacts = []
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    artifact = ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url=kwargs["storage_url"],
+                        width=kwargs["width"],
+                        height=kwargs["height"],
+                        format=kwargs["format"],
+                    )
+                    stored_artifacts.append(artifact)
+                    return artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 3
+            assert len(stored_artifacts) == 3
+
+            # Verify each artifact was stored with the correct URL
+            for i, url in enumerate(fake_image_urls):
+                assert stored_artifacts[i].storage_url == url
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_single_image(self):
+        """Test cost estimation for a single image."""
+        input_data = FluxProUltraInput(prompt="Test prompt", num_images=1)
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        assert cost == 0.04  # Expected cost per image
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_batch(self):
+        """Test cost estimation for batch generation."""
+        input_data = FluxProUltraInput(prompt="Test prompt", num_images=4)
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        assert cost == 0.16  # 4 images * $0.04
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = FluxProUltraInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "aspect_ratio" in schema["properties"]
+        assert "num_images" in schema["properties"]
+        assert "safety_tolerance" in schema["properties"]
+
+        # Check that aspect_ratio has enum values
+        aspect_ratio_prop = schema["properties"]["aspect_ratio"]
+        assert "enum" in aspect_ratio_prop
+
+        # Check that num_images has constraints
+        num_images_prop = schema["properties"]["num_images"]
+        assert num_images_prop["minimum"] == 1
+        assert num_images_prop["maximum"] == 4
+        assert num_images_prop["default"] == 1
+
+        # Check that safety_tolerance has constraints
+        safety_prop = schema["properties"]["safety_tolerance"]
+        assert safety_prop["minimum"] == 1
+        assert safety_prop["maximum"] == 6
+        assert safety_prop["default"] == 2


### PR DESCRIPTION
This pull request adds support for a new image generator, "FalFluxProUltraGenerator", which uses fal.ai's FLUX1.1 [pro] ultra text-to-image model. The integration includes input schema definition, generator implementation, cost estimation, and registration in the system configuration.

**Fal.ai FLUX1.1 [pro] ultra generator integration:**

* Added a new generator implementation `FalFluxProUltraGenerator` in `flux_pro_ultra.py` for high-quality text-to-image generation, supporting advanced controls, batch outputs, and progress updates.
* Defined a comprehensive input schema `FluxProUltraInput` for the generator, allowing customization of prompt, aspect ratio, batch size, safety settings, output format, and other advanced options.
* Implemented cost estimation for the generator based on the number of images and typical resolution, with an estimated cost of $0.04 per image.

**System integration:**

* Registered the new `FalFluxProUltraGenerator` in the `generators.yaml` configuration file to make it available for use.
* Updated the fal image generators module (`__init__.py`) to import and expose the new generator class.