### PR TITLE
Fixes for baseboards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,3 +157,11 @@ build-docs: ## Build documentation for production
 serve-docs: ## Serve built documentation
 	@echo "Serving documentation..."
 	cd apps/docs && pnpm serve
+
+build-cli-launcher: ## Build CLI launcher (Node) only
+	@echo "Building CLI launcher..."
+	cd packages/cli-launcher && pnpm build
+
+run-cli-launcher: ## Run CLI launcher (Node) only
+	@echo "Running CLI launcher..."
+	cd packages/cli-launcher && node dist/index.js up ../../ungitable/test-project

--- a/packages/backend/src/boards/auth/adapters/__init__.py
+++ b/packages/backend/src/boards/auth/adapters/__init__.py
@@ -6,15 +6,22 @@ from .clerk import ClerkAuthAdapter
 from .jwt import JWTAuthAdapter
 from .none import NoAuthAdapter
 from .oidc import OIDCAdapter
-from .supabase import SupabaseAuthAdapter
 
+# Always available adapters
 __all__ = [
     "AuthAdapter",
     "Principal",
-    "SupabaseAuthAdapter",
     "JWTAuthAdapter",
     "NoAuthAdapter",
     "ClerkAuthAdapter",
     "Auth0OIDCAdapter",
     "OIDCAdapter",
 ]
+
+# Optional auth providers - imported conditionally to avoid import errors
+try:
+    from .supabase import SupabaseAuthAdapter
+
+    __all__.append("SupabaseAuthAdapter")
+except ImportError:
+    pass

--- a/packages/backend/src/boards/auth/factory.py
+++ b/packages/backend/src/boards/auth/factory.py
@@ -11,7 +11,15 @@ from .adapters.clerk import ClerkAuthAdapter
 from .adapters.jwt import JWTAuthAdapter
 from .adapters.none import NoAuthAdapter
 from .adapters.oidc import OIDCAdapter
-from .adapters.supabase import SupabaseAuthAdapter
+
+# Optional Supabase adapter - imported conditionally
+try:
+    from .adapters.supabase import SupabaseAuthAdapter
+
+    SUPABASE_AVAILABLE = True
+except ImportError:
+    SUPABASE_AVAILABLE = False
+    SupabaseAuthAdapter = None  # type: ignore
 
 
 def get_auth_adapter() -> AuthAdapter:
@@ -46,6 +54,12 @@ def get_auth_adapter() -> AuthAdapter:
         )
 
     elif provider == "supabase":
+        if not SUPABASE_AVAILABLE:
+            raise ValueError(
+                "Supabase auth provider is not available. "
+                "Install the supabase package: pip install 'weirdfingers-boards[auth-supabase]'"
+            )
+
         url = config.get("url") or os.getenv("SUPABASE_URL")
         service_role_key = config.get("service_role_key") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 
@@ -55,7 +69,7 @@ def get_auth_adapter() -> AuthAdapter:
                 "Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY or provide in config."
             )
 
-        return SupabaseAuthAdapter(url=url, service_role_key=service_role_key)
+        return SupabaseAuthAdapter(url=url, service_role_key=service_role_key)  # type: ignore
 
     elif provider == "clerk":
         secret_key = config.get("secret_key") or os.getenv("CLERK_SECRET_KEY")

--- a/packages/cli-launcher/src/utils.ts
+++ b/packages/cli-launcher/src/utils.ts
@@ -175,7 +175,7 @@ export function generateSecret(length = 32): string {
  */
 export function generatePassword(length = 24): string {
   const charset =
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*";
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#%^&*";
   let password = "";
   const bytes = crypto.randomBytes(length);
 

--- a/packages/cli-launcher/template-sources/Dockerfile.api
+++ b/packages/cli-launcher/template-sources/Dockerfile.api
@@ -14,8 +14,8 @@ RUN pip install --no-cache-dir uv
 # Copy application code first (needed for version detection in pyproject.toml)
 COPY . .
 
-# Install Python dependencies with provider support
-RUN uv pip install --system --no-cache-dir .[providers]
+# Install Python dependencies with all generator providers
+RUN uv pip install --system --no-cache-dir .[generators-all]
 
 # Create non-root user
 RUN useradd -m -u 1001 apiuser && chown -R apiuser:apiuser /app

--- a/packages/cli-launcher/tests/README.md
+++ b/packages/cli-launcher/tests/README.md
@@ -1,0 +1,85 @@
+# CLI Launcher Tests
+
+This directory contains manual tests for the `@weirdfingers/baseboards` CLI launcher package.
+
+## Test Structure
+
+These are **manual scripted tests** that can be run independently to validate different aspects of the CLI launcher functionality.
+
+## Available Tests
+
+### `test-dockerfile-api.sh`
+
+**Purpose:** Validates that the Dockerfile.api template can successfully build a Docker image with the correct Python optional dependency groups.
+
+**How it works:**
+1. Copies the real `Dockerfile.api` from `template-sources/`
+2. Copies the real `pyproject.toml` from `packages/backend/`
+3. Builds a Docker image and checks for uv warnings about missing extras
+4. Fails if any "does not have an extra named..." warnings are detected
+
+**What it tests:**
+- The Dockerfile.api references valid optional dependency groups from pyproject.toml
+- The uv pip install command can resolve all specified dependencies without warnings
+- Detects any warnings about missing extras (e.g., `does not have an extra named...`)
+- Common error: referencing non-existent groups like `[providers]` which was removed
+
+**How to run:**
+```bash
+cd packages/cli-launcher/tests
+./test-dockerfile-api.sh
+```
+
+**Current status:** ✅ **PASSING** - Dockerfile.api now uses valid `[generators-all]` group
+
+**Expected behavior:**
+- ✅ Should pass when no warnings about missing extras are found
+- ❌ Should fail if any "does not have an extra named..." warnings appear
+
+**Requirements:**
+- Docker must be installed and running
+- No other dependencies needed (test creates temporary environment)
+
+## Writing New Tests
+
+When adding new tests:
+
+1. Create a new `.sh` script in this directory
+2. Make it executable: `chmod +x test-*.sh`
+3. Follow the pattern:
+   - Clear test purpose in header comment
+   - Use `set -e` for fail-fast behavior
+   - Use `mktemp -d` for isolated test environments
+   - Clean up with trap: `trap cleanup EXIT`
+   - Output clear ✅/❌ messages
+4. Document the test in this README
+
+## Test Categories
+
+Current and planned test areas:
+
+- [x] **Template Validation** - Dockerfile.api dependency groups
+- [ ] **Template Processing** - prepare-templates.js output
+- [ ] **CLI Commands** - baseboards init/up/down/logs
+- [ ] **Docker Compose** - compose.yaml validation
+- [ ] **Environment Setup** - .env.example files are complete
+
+## Running All Tests
+
+To run all tests at once:
+
+```bash
+cd packages/cli-launcher/tests
+for test in test-*.sh; do
+  echo "Running $test..."
+  ./"$test"
+  echo ""
+done
+```
+
+## CI Integration
+
+These tests are currently manual. Future work could integrate them into:
+- Pre-publish checks (npm prepublishOnly script)
+- GitHub Actions workflow
+- Turborepo test pipeline

--- a/packages/cli-launcher/tests/test-dockerfile-api.sh
+++ b/packages/cli-launcher/tests/test-dockerfile-api.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -e
+
+# Test: Dockerfile.api builds successfully with correct dependencies
+# This test validates that the Dockerfile.api can install Python dependencies
+# without errors due to missing optional dependency groups.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE_SOURCES="$CLI_ROOT/template-sources"
+TEST_TEMP_DIR="$(mktemp -d)"
+
+echo "🧪 Testing Dockerfile.api build..."
+echo "📁 Test directory: $TEST_TEMP_DIR"
+
+cleanup() {
+  echo "🧹 Cleaning up..."
+  rm -rf "$TEST_TEMP_DIR"
+}
+trap cleanup EXIT
+
+# Copy necessary files to test directory
+echo "📦 Setting up test environment..."
+cp "$TEMPLATE_SOURCES/Dockerfile.api" "$TEST_TEMP_DIR/Dockerfile"
+
+# Copy the ACTUAL pyproject.toml from packages/backend
+BACKEND_PYPROJECT="$(cd "$CLI_ROOT/../../packages/backend" && pwd)/pyproject.toml"
+if [ ! -f "$BACKEND_PYPROJECT" ]; then
+  echo "❌ Error: Cannot find packages/backend/pyproject.toml at $BACKEND_PYPROJECT"
+  exit 1
+fi
+
+cp "$BACKEND_PYPROJECT" "$TEST_TEMP_DIR/pyproject.toml"
+echo "   ✓ Copied real pyproject.toml from packages/backend"
+
+# Create minimal app structure matching backend package
+mkdir -p "$TEST_TEMP_DIR/src/boards"
+cat > "$TEST_TEMP_DIR/src/boards/__init__.py" <<'EOF'
+__version__ = "0.1.0"
+EOF
+
+cd "$TEST_TEMP_DIR"
+
+echo "🔨 Attempting to build Dockerfile..."
+echo ""
+
+# Try to build the Dockerfile - build may succeed but should show warning about missing extra
+docker build -t test-boards-api:test . 2>&1 | tee build.log
+BUILD_EXIT_CODE=$?
+
+echo ""
+echo "📋 Checking build output..."
+
+# Check for any warnings about missing extras
+if grep -q "does not have an extra named" build.log; then
+  echo ""
+  echo "❌ TEST FAILED: Found warning about missing optional dependency extra!"
+  echo ""
+  echo "📋 Warning message:"
+  grep "does not have an extra named" build.log
+  echo ""
+  echo "💡 The Dockerfile.api references an optional dependency group that doesn't exist"
+  echo ""
+  echo "🔧 Available groups from packages/backend/pyproject.toml:"
+  echo "   - generators-replicate, generators-openai, generators-fal, generators-anthropic, generators-together"
+  echo "   - generators-all (recommended - includes all generators)"
+  echo "   - storage-supabase, storage-s3, storage-gcs, storage-all"
+  echo "   - auth-supabase"
+  echo "   - all (everything)"
+  docker rmi test-boards-api:test 2>/dev/null || true
+  exit 1
+else
+  echo ""
+  echo "✅ TEST PASSED: No warnings about missing extras!"
+  echo ""
+  echo "💡 Dockerfile.api successfully installed all requested optional dependencies"
+  docker rmi test-boards-api:test 2>/dev/null || true
+  exit 0
+fi


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to authentication adapter handling, CLI launcher tooling, and dependency management. The main highlights are improved support for optional authentication providers (especially Supabase), new CLI launcher build/run targets, and enhanced testing for Dockerfile templates to prevent dependency group errors.

**Authentication adapters (Python backend):**
- Made the import of `SupabaseAuthAdapter` optional in both `__init__.py` and `factory.py`, so the backend will not fail to start if Supabase dependencies are missing. Instead, a clear error message is shown if Supabase is selected but not installed. [[1]](diffhunk://#diff-5dcecc4e0e8b555413e5b24971b51753a7a86d53815d39aecf77843b0adc1793L9-R27) [[2]](diffhunk://#diff-9b1a968cc697889a695d308590676e6ae62fd117df3eb15e781f72cfe6d9730dR14-R23) [[3]](diffhunk://#diff-9b1a968cc697889a695d308590676e6ae62fd117df3eb15e781f72cfe6d9730dR57-R62) [[4]](diffhunk://#diff-9b1a968cc697889a695d308590676e6ae62fd117df3eb15e781f72cfe6d9730dL58-R72)

**CLI launcher tooling and documentation:**
- Added `build-cli-launcher` and `run-cli-launcher` targets to the root `Makefile` to simplify building and running the CLI launcher in Node environments.
- Added a comprehensive `README.md` in `packages/cli-launcher/tests` describing manual test structure, available tests, how to add new ones, and plans for future test coverage.
- Introduced a new shell test script `test-dockerfile-api.sh` that validates the Dockerfile template installs the correct Python dependency groups and fails if any missing extras are referenced.

**Dependency management and bug fixes:**
- Updated the Dockerfile template to use the `[generators-all]` dependency group instead of the outdated `[providers]` group, preventing installation errors due to missing extras.
- Fixed a typo in the password generator charset in the CLI launcher utility code.