### PR TITLE
Make certain image and video fields optional; fix tests

### DIFF
--- a/.claude/skills/create-fal-generator.md
+++ b/.claude/skills/create-fal-generator.md
@@ -368,7 +368,7 @@ class Test{GeneratorName}GeneratorLive:
         # Verify artifact properties
         artifact = result.outputs[0]
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
+        # Storage URLs can be HTTPS URLs or other formats (data:, etc.)
         # Add artifact-specific assertions (width, height for images, etc.)
 
     @pytest.mark.asyncio

--- a/apps/docs/docs/generators/live-api-testing.md
+++ b/apps/docs/docs/generators/live-api-testing.md
@@ -309,7 +309,7 @@ class TestMyGeneratorLive:
         # Verify
         assert result.outputs is not None
         assert len(result.outputs) > 0
-        assert result.outputs[0].storage_url.startswith("https://")
+        assert result.outputs[0].storage_url is not None
 ```
 
 ### 3. Add Provider-Specific Skip Fixture (If New Provider)

--- a/apps/docs/docs/generators/testing.md
+++ b/apps/docs/docs/generators/testing.md
@@ -704,7 +704,7 @@ async def test_full_generation_flow(self):
     # Verify result structure
     assert isinstance(result, MyOutput)
     assert isinstance(result.image, ImageArtifact)
-    assert result.image.storage_url.startswith("https://")
+    assert result.image.storage_url is not None
     assert result.image.width > 0
     assert result.image.height > 0
     
@@ -944,7 +944,7 @@ class TestMyGeneratorLive:
         # Verify real response structure
         assert result.outputs is not None
         assert len(result.outputs) > 0
-        assert result.outputs[0].storage_url.startswith("https://")
+        assert result.outputs[0].storage_url is not None
 ```
 
 ### Cost Management

--- a/packages/backend/docs/TESTING_LIVE_APIS.md
+++ b/packages/backend/docs/TESTING_LIVE_APIS.md
@@ -309,7 +309,7 @@ class TestMyGeneratorLive:
         # Verify
         assert result.outputs is not None
         assert len(result.outputs) > 0
-        assert result.outputs[0].storage_url.startswith("https://")
+        assert result.outputs[0].storage_url is not None
 ```
 
 ### 3. Add Provider-Specific Skip Fixture (If New Provider)

--- a/packages/backend/src/boards/generators/artifact_resolution.py
+++ b/packages/backend/src/boards/generators/artifact_resolution.py
@@ -136,10 +136,6 @@ def _generation_to_artifact[T: (ImageArtifact, VideoArtifact, AudioArtifact, Tex
     if artifact_class == ImageArtifact:
         width = metadata.get("width")
         height = metadata.get("height")
-        if width is None or height is None:
-            raise ValueError(
-                f"Generation {generation.id} missing image dimensions in output_metadata"
-            )
         return ImageArtifact(
             generation_id=str(generation.id),
             storage_url=generation.storage_url,
@@ -151,10 +147,6 @@ def _generation_to_artifact[T: (ImageArtifact, VideoArtifact, AudioArtifact, Tex
     elif artifact_class == VideoArtifact:
         width = metadata.get("width")
         height = metadata.get("height")
-        if width is None or height is None:
-            raise ValueError(
-                f"Generation {generation.id} missing video dimensions in output_metadata"
-            )
         return VideoArtifact(
             generation_id=str(generation.id),
             storage_url=generation.storage_url,

--- a/packages/backend/src/boards/generators/artifacts.py
+++ b/packages/backend/src/boards/generators/artifacts.py
@@ -28,16 +28,16 @@ class VideoArtifact(DigitalArtifact):
     """Represents a video file artifact from a generation."""
 
     duration: float | None = Field(None, description="Duration in seconds")
-    width: int = Field(description="Video width in pixels")
-    height: int = Field(description="Video height in pixels")
+    width: int | None = Field(None, description="Video width in pixels")
+    height: int | None = Field(None, description="Video height in pixels")
     fps: float | None = Field(None, description="Frames per second")
 
 
 class ImageArtifact(DigitalArtifact):
     """Represents an image file artifact from a generation."""
 
-    width: int = Field(description="Image width in pixels")
-    height: int = Field(description="Image height in pixels")
+    width: int | None = Field(None, description="Image width in pixels")
+    height: int | None = Field(None, description="Image height in pixels")
 
 
 class TextArtifact(DigitalArtifact):

--- a/packages/backend/src/boards/generators/base.py
+++ b/packages/backend/src/boards/generators/base.py
@@ -94,8 +94,8 @@ class GeneratorExecutionContext(Protocol):
         self,
         storage_url: str,
         format: str,
-        width: int,
-        height: int,
+        width: int | None = None,
+        height: int | None = None,
         output_index: int = 0,
     ) -> ImageArtifact:
         """Store an image result to permanent storage."""
@@ -105,8 +105,8 @@ class GeneratorExecutionContext(Protocol):
         self,
         storage_url: str,
         format: str,
-        width: int,
-        height: int,
+        width: int | None = None,
+        height: int | None = None,
         duration: float | None = None,
         fps: float | None = None,
         output_index: int = 0,

--- a/packages/backend/src/boards/generators/implementations/fal/image/nano_banana.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/nano_banana.py
@@ -157,8 +157,8 @@ class FalNanoBananaGenerator(BaseGenerator):
         artifacts = []
         for idx, image_data in enumerate(images):
             image_url = image_data.get("url")
-            width = image_data.get("width", 1024)
-            height = image_data.get("height", 1024)
+            width = image_data.get("width")
+            height = image_data.get("height")
 
             if not image_url:
                 raise ValueError(f"Image {idx} missing URL in fal.ai response")

--- a/packages/backend/src/boards/generators/resolution.py
+++ b/packages/backend/src/boards/generators/resolution.py
@@ -304,8 +304,8 @@ async def store_image_result(
     board_id: str,
     storage_url: str,
     format: str,
-    width: int,
-    height: int,
+    width: int | None = None,
+    height: int | None = None,
 ) -> ImageArtifact:
     """
     Store an image result by downloading from provider URL and uploading to storage.
@@ -317,8 +317,8 @@ async def store_image_result(
         board_id: Board ID for organization
         storage_url: Provider's temporary URL to download from
         format: Image format (png, jpg, etc.)
-        width: Image width in pixels
-        height: Image height in pixels
+        width: Image width in pixels (optional)
+        height: Image height in pixels (optional)
 
     Returns:
         ImageArtifact with permanent storage URL
@@ -374,8 +374,8 @@ async def store_video_result(
     board_id: str,
     storage_url: str,
     format: str,
-    width: int,
-    height: int,
+    width: int | None = None,
+    height: int | None = None,
     duration: float | None = None,
     fps: float | None = None,
 ) -> VideoArtifact:
@@ -389,8 +389,8 @@ async def store_video_result(
         board_id: Board ID for organization
         storage_url: Provider's temporary URL to download from
         format: Video format (mp4, webm, etc.)
-        width: Video width in pixels
-        height: Video height in pixels
+        width: Video width in pixels (optional)
+        height: Video height in pixels (optional)
         duration: Video duration in seconds (optional)
         fps: Frames per second (optional)
 

--- a/packages/backend/src/boards/workers/context.py
+++ b/packages/backend/src/boards/workers/context.py
@@ -62,8 +62,8 @@ class GeneratorExecutionContext:
         self,
         storage_url: str,
         format: str,
-        width: int,
-        height: int,
+        width: int | None = None,
+        height: int | None = None,
         output_index: int = 0,
     ) -> ImageArtifact:
         """Store image generation result.
@@ -71,8 +71,8 @@ class GeneratorExecutionContext:
         Args:
             storage_url: URL to download the image from
             format: Image format (png, jpg, etc.)
-            width: Image width in pixels
-            height: Image height in pixels
+            width: Image width in pixels (optional)
+            height: Image height in pixels (optional)
             output_index: Index of this output in a batch (0 for primary, 1+ for additional)
 
         Returns:
@@ -111,8 +111,8 @@ class GeneratorExecutionContext:
         self,
         storage_url: str,
         format: str,
-        width: int,
-        height: int,
+        width: int | None = None,
+        height: int | None = None,
         duration: float | None = None,
         fps: float | None = None,
         output_index: int = 0,
@@ -122,8 +122,8 @@ class GeneratorExecutionContext:
         Args:
             storage_url: URL to download the video from
             format: Video format (mp4, webm, etc.)
-            width: Video width in pixels
-            height: Video height in pixels
+            width: Video width in pixels (optional)
+            height: Video height in pixels (optional)
             duration: Video duration in seconds (optional)
             fps: Frames per second (optional)
             output_index: Index of this output in a batch (0 for primary, 1+ for additional)

--- a/packages/backend/tests/generators/implementations/test_dalle3_live.py
+++ b/packages/backend/tests/generators/implementations/test_dalle3_live.py
@@ -70,7 +70,6 @@ class TestDallE3GeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
         assert artifact.width == 1024
         assert artifact.height == 1024
         assert artifact.format == "png"
@@ -107,7 +106,7 @@ class TestDallE3GeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.storage_url.startswith("https://")
+        assert artifact.storage_url is not None
         assert artifact.width == 1792
         assert artifact.height == 1024
         assert artifact.format == "png"
@@ -161,4 +160,4 @@ class TestDallE3GeneratorLive:
         # Verify result (style doesn't affect output structure)
         assert result.outputs is not None
         assert len(result.outputs) == 1
-        assert result.outputs[0].storage_url.startswith("https://")
+        assert result.outputs[0].storage_url is not None

--- a/packages/backend/tests/generators/implementations/test_flux_pro_kontext_live.py
+++ b/packages/backend/tests/generators/implementations/test_flux_pro_kontext_live.py
@@ -82,9 +82,11 @@ class TestFluxProKontextGeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
         assert artifact.format == "jpeg"
 
     @pytest.mark.asyncio
@@ -129,13 +131,17 @@ class TestFluxProKontextGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        assert artifact.storage_url is not None
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
 
         # 16:9 aspect ratio should have width > height
         # (though exact dimensions depend on the API's processing)
-        assert artifact.width > artifact.height
+        if artifact.width is not None and artifact.height is not None:
+            assert artifact.width > artifact.height
 
     @pytest.mark.asyncio
     async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
@@ -208,4 +214,4 @@ class TestFluxProKontextGeneratorLive:
         # Verify result (seed doesn't affect output structure, just determinism)
         assert result.outputs is not None
         assert len(result.outputs) == 1
-        assert result.outputs[0].storage_url.startswith("https://")
+        assert result.outputs[0].storage_url is not None

--- a/packages/backend/tests/generators/implementations/test_flux_pro_live.py
+++ b/packages/backend/tests/generators/implementations/test_flux_pro_live.py
@@ -69,9 +69,11 @@ class TestFluxProGeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
         assert artifact.format == "png"
 
     @pytest.mark.asyncio
@@ -107,9 +109,12 @@ class TestFluxProGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        assert artifact.storage_url is not None
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
 
         # Note: We don't verify exact dimensions because Replicate may not
         # return metadata about dimensions, but we verify the artifact is valid

--- a/packages/backend/tests/generators/implementations/test_imagen4_preview_fast_live.py
+++ b/packages/backend/tests/generators/implementations/test_imagen4_preview_fast_live.py
@@ -72,9 +72,11 @@ class TestImagen4PreviewFastGeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
         assert artifact.format == "png"
 
     @pytest.mark.asyncio
@@ -108,9 +110,12 @@ class TestImagen4PreviewFastGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        assert artifact.storage_url is not None
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
         assert artifact.format == "png"
 
     @pytest.mark.asyncio
@@ -145,7 +150,7 @@ class TestImagen4PreviewFastGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.storage_url.startswith("https://")
+        assert artifact.storage_url is not None
 
     @pytest.mark.asyncio
     async def test_generate_with_seed(self, skip_if_no_fal_key, dummy_context, cost_logger):
@@ -185,8 +190,8 @@ class TestImagen4PreviewFastGeneratorLive:
         artifact2 = result2.outputs[0]
         assert isinstance(artifact1, ImageArtifact)
         assert isinstance(artifact2, ImageArtifact)
-        assert artifact1.storage_url.startswith("https://")
-        assert artifact2.storage_url.startswith("https://")
+        assert artifact1.storage_url is not None
+        assert artifact2.storage_url is not None
 
     @pytest.mark.asyncio
     async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
@@ -242,7 +247,9 @@ class TestImagen4PreviewFastGeneratorLive:
         for artifact in result.outputs:
             assert isinstance(artifact, ImageArtifact)
             assert artifact.storage_url is not None
-            assert artifact.storage_url.startswith("https://")
-            assert artifact.width > 0
-            assert artifact.height > 0
+            # Dimensions are optional, but if present should be valid
+            if artifact.width is not None:
+                assert artifact.width > 0
+            if artifact.height is not None:
+                assert artifact.height > 0
             assert artifact.format == "png"

--- a/packages/backend/tests/generators/implementations/test_imagen4_preview_live.py
+++ b/packages/backend/tests/generators/implementations/test_imagen4_preview_live.py
@@ -70,7 +70,6 @@ class TestImagen4PreviewGeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
         assert artifact.width == 1024
         assert artifact.height == 1024
         assert artifact.format in ["jpeg", "png"]
@@ -106,9 +105,12 @@ class TestImagen4PreviewGeneratorLive:
 
         for artifact in result.outputs:
             assert isinstance(artifact, ImageArtifact)
-            assert artifact.storage_url.startswith("https://")
-            assert artifact.width > 0
-            assert artifact.height > 0
+            assert artifact.storage_url is not None
+            # Dimensions are optional, but if present should be valid
+            if artifact.width is not None:
+                assert artifact.width > 0
+            if artifact.height is not None:
+                assert artifact.height > 0
 
     @pytest.mark.asyncio
     async def test_generate_with_different_aspect_ratios(
@@ -144,7 +146,7 @@ class TestImagen4PreviewGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.storage_url.startswith("https://")
+        assert artifact.storage_url is not None
         assert artifact.width == 1024
         assert artifact.height == 576  # 16:9 ratio with 1K resolution
 
@@ -182,7 +184,7 @@ class TestImagen4PreviewGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.storage_url.startswith("https://")
+        assert artifact.storage_url is not None
         assert artifact.width == 2048
         assert artifact.height == 2048
 
@@ -214,7 +216,7 @@ class TestImagen4PreviewGeneratorLive:
         # Verify result (negative prompt doesn't affect output structure)
         assert result.outputs is not None
         assert len(result.outputs) == 1
-        assert result.outputs[0].storage_url.startswith("https://")
+        assert result.outputs[0].storage_url is not None
 
     @pytest.mark.asyncio
     async def test_generate_with_seed(self, skip_if_no_fal_key, dummy_context, cost_logger):
@@ -243,7 +245,7 @@ class TestImagen4PreviewGeneratorLive:
         # Verify result (seed doesn't affect output structure, just determinism)
         assert result.outputs is not None
         assert len(result.outputs) == 1
-        assert result.outputs[0].storage_url.startswith("https://")
+        assert result.outputs[0].storage_url is not None
 
     @pytest.mark.asyncio
     async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):

--- a/packages/backend/tests/generators/implementations/test_kling_video_v2_5_turbo_pro_text_to_video_live.py
+++ b/packages/backend/tests/generators/implementations/test_kling_video_v2_5_turbo_pro_text_to_video_live.py
@@ -71,9 +71,11 @@ class TestKlingVideoV25TurboProTextToVideoGeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, VideoArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
         assert artifact.format == "mp4"
         assert artifact.duration == 5.0
 
@@ -110,7 +112,7 @@ class TestKlingVideoV25TurboProTextToVideoGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, VideoArtifact)
-        assert artifact.storage_url.startswith("https://")
+        assert artifact.storage_url is not None
         assert artifact.width == 1920
         assert artifact.height == 1080
         assert artifact.format == "mp4"

--- a/packages/backend/tests/generators/implementations/test_minimax_music_v2_live.py
+++ b/packages/backend/tests/generators/implementations/test_minimax_music_v2_live.py
@@ -72,7 +72,6 @@ class TestMinimaxMusicV2GeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, AudioArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
         assert artifact.format == "mp3"
         # Default sample rate is 44100 when audio_setting is not provided
         assert artifact.sample_rate == 44100
@@ -112,7 +111,7 @@ class TestMinimaxMusicV2GeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, AudioArtifact)
-        assert artifact.storage_url.startswith("https://")
+        assert artifact.storage_url is not None
         # Should use default format (mp3) when not specified
         assert artifact.format == "mp3"
 

--- a/packages/backend/tests/generators/implementations/test_minimax_speech_2_6_turbo_live.py
+++ b/packages/backend/tests/generators/implementations/test_minimax_speech_2_6_turbo_live.py
@@ -68,7 +68,6 @@ class TestMinimaxSpeech26TurboGeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, AudioArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
         assert artifact.format == "mp3"
 
     @pytest.mark.asyncio
@@ -106,7 +105,7 @@ class TestMinimaxSpeech26TurboGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, AudioArtifact)
-        assert artifact.storage_url.startswith("https://")
+        assert artifact.storage_url is not None
         assert artifact.format == "mp3"
 
     @pytest.mark.asyncio
@@ -138,7 +137,7 @@ class TestMinimaxSpeech26TurboGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, AudioArtifact)
-        assert artifact.storage_url.startswith("https://")
+        assert artifact.storage_url is not None
 
     @pytest.mark.asyncio
     async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
@@ -196,4 +195,4 @@ class TestMinimaxSpeech26TurboGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, AudioArtifact)
-        assert artifact.storage_url.startswith("https://")
+        assert artifact.storage_url is not None

--- a/packages/backend/tests/generators/implementations/test_nano_banana_live.py
+++ b/packages/backend/tests/generators/implementations/test_nano_banana_live.py
@@ -70,9 +70,11 @@ class TestNanoBananaGeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
         assert artifact.format in ["jpeg", "png"]
 
     @pytest.mark.asyncio
@@ -106,9 +108,12 @@ class TestNanoBananaGeneratorLive:
 
         for artifact in result.outputs:
             assert isinstance(artifact, ImageArtifact)
-            assert artifact.storage_url.startswith("https://")
-            assert artifact.width > 0
-            assert artifact.height > 0
+            assert artifact.storage_url is not None
+            # Dimensions are optional, but if present should be valid
+            if artifact.width is not None:
+                assert artifact.width > 0
+            if artifact.height is not None:
+                assert artifact.height > 0
 
     @pytest.mark.asyncio
     async def test_generate_with_different_sizes(
@@ -144,9 +149,12 @@ class TestNanoBananaGeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, ImageArtifact)
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        assert artifact.storage_url is not None
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
 
         # Landscape should have width > height (though exact dims depend on size preset)
         # We don't verify exact aspect ratio as API might vary
@@ -199,4 +207,4 @@ class TestNanoBananaGeneratorLive:
         # Verify result (seed doesn't affect output structure, just determinism)
         assert result.outputs is not None
         assert len(result.outputs) == 1
-        assert result.outputs[0].storage_url.startswith("https://")
+        assert result.outputs[0].storage_url is not None

--- a/packages/backend/tests/generators/implementations/test_sync_lipsync_v2_live.py
+++ b/packages/backend/tests/generators/implementations/test_sync_lipsync_v2_live.py
@@ -95,9 +95,11 @@ class TestSyncLipsyncV2GeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, VideoArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
         assert artifact.format == "mp4"
 
     @pytest.mark.asyncio
@@ -150,9 +152,12 @@ class TestSyncLipsyncV2GeneratorLive:
 
         artifact = result.outputs[0]
         assert isinstance(artifact, VideoArtifact)
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        assert artifact.storage_url is not None
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
 
     @pytest.mark.asyncio
     async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):

--- a/packages/backend/tests/generators/implementations/test_veo31_first_last_frame_to_video_live.py
+++ b/packages/backend/tests/generators/implementations/test_veo31_first_last_frame_to_video_live.py
@@ -115,14 +115,17 @@ class TestVeo31FirstLastFrameToVideoGeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, VideoArtifact)
         assert artifact.storage_url is not None
-        assert artifact.storage_url.startswith("https://")
-        assert artifact.width > 0
-        assert artifact.height > 0
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
         assert artifact.duration is not None and artifact.duration > 0
         assert artifact.format == "mp4"
 
         # Verify expected dimensions for 720p
-        assert artifact.height == 720 or artifact.width == 1280
+        if artifact.height is not None and artifact.width is not None:
+            assert artifact.height == 720 or artifact.width == 1280
 
     @pytest.mark.asyncio
     async def test_estimate_cost_audio_discount(self, skip_if_no_fal_key, test_image_artifacts):

--- a/packages/backend/tests/generators/test_artifacts.py
+++ b/packages/backend/tests/generators/test_artifacts.py
@@ -74,18 +74,16 @@ class TestVideoArtifact:
         assert artifact.format == "mp4"
         assert artifact.fps == 30.0
 
-    def test_video_artifact_required_fields(self):
-        """Test video artifact with only required fields."""
+    def test_video_artifact_minimal(self):
+        """Test video artifact with only required fields (dimensions optional)."""
         artifact = VideoArtifact(  # type: ignore
             generation_id="gen_456",
             storage_url="https://example.com/video.mp4",
-            width=1920,
-            height=1080,
             format="mp4",
         )
 
-        assert artifact.width == 1920
-        assert artifact.height == 1080
+        assert artifact.width is None
+        assert artifact.height is None
         assert artifact.format == "mp4"
         assert artifact.duration is None
         assert artifact.fps is None
@@ -108,6 +106,20 @@ class TestImageArtifact:
         assert artifact.storage_url == "https://example.com/image.png"
         assert artifact.width == 1024
         assert artifact.height == 1024
+        assert artifact.format == "png"
+
+    def test_image_artifact_minimal(self):
+        """Test creating image artifact with only required fields (dimensions optional)."""
+        artifact = ImageArtifact(  # type: ignore
+            generation_id="gen_789",
+            storage_url="https://example.com/image.png",
+            format="png",
+        )
+
+        assert artifact.generation_id == "gen_789"
+        assert artifact.storage_url == "https://example.com/image.png"
+        assert artifact.width is None
+        assert artifact.height is None
         assert artifact.format == "png"
 
 
@@ -201,10 +213,11 @@ class TestArtifactValidation:
         assert "height" in schema["properties"]
         assert "format" in schema["properties"]
 
-        # Check required fields
+        # Check required fields (width/height are now optional)
         required_fields = schema["required"]
         assert "generation_id" in required_fields
         assert "storage_url" in required_fields
-        assert "width" in required_fields
-        assert "height" in required_fields
         assert "format" in required_fields
+        # width and height are optional
+        assert "width" not in required_fields
+        assert "height" not in required_fields


### PR DESCRIPTION
This pull request updates the handling of image and video artifact dimensions throughout the backend and testing codebase. The main change is that artifact width and height are now treated as optional fields, both in the backend models and in the functions that process and store artifacts. Tests and documentation have also been updated to reflect that dimensions may not always be present, and to relax requirements on storage URLs.

Key changes include:

**Backend Model and API Changes:**

* Made the `width` and `height` fields optional (`int | None`) in both `ImageArtifact` and `VideoArtifact` classes, and updated all related function signatures (such as `store_image_result` and `store_video_result`) to accept optional dimensions. This allows for artifacts where the provider does not supply dimensions. [[1]](diffhunk://#diff-4906fe22ffa8692a030ec82c8b61b088b49c455dbe07da1d613aae4190bfb675L31-R40) [[2]](diffhunk://#diff-5d986aeb61a3bfa32bb8394213e9ec954ff65c9e4f15c1761e249764cb2a73e9L97-R98) [[3]](diffhunk://#diff-5d986aeb61a3bfa32bb8394213e9ec954ff65c9e4f15c1761e249764cb2a73e9L108-R109) [[4]](diffhunk://#diff-78ec1f8a10e05612a6cce2d97d7b3f6df744ef9ae9d07805f5d71fd159ae2a50L307-R308) [[5]](diffhunk://#diff-78ec1f8a10e05612a6cce2d97d7b3f6df744ef9ae9d07805f5d71fd159ae2a50L320-R321) [[6]](diffhunk://#diff-78ec1f8a10e05612a6cce2d97d7b3f6df744ef9ae9d07805f5d71fd159ae2a50L377-R378) [[7]](diffhunk://#diff-78ec1f8a10e05612a6cce2d97d7b3f6df744ef9ae9d07805f5d71fd159ae2a50L392-R393) [[8]](diffhunk://#diff-a57e2689c8917905a1cc0cc146b6c4f1ef2c180848585edececada3c0697d8e6L65-R75) [[9]](diffhunk://#diff-a57e2689c8917905a1cc0cc146b6c4f1ef2c180848585edececada3c0697d8e6L114-R115) [[10]](diffhunk://#diff-a57e2689c8917905a1cc0cc146b6c4f1ef2c180848585edececada3c0697d8e6L125-R126) [[11]](diffhunk://#diff-a760df550221daee3c32a04994d0fb8713b73be803d42165d9fe514f58716779L160-R161)
* Removed strict validation in artifact resolution that previously required image and video dimensions to be present in metadata. [[1]](diffhunk://#diff-29a4ca02ff3209848f29e7765b15951cdbb77c0df6fb7b25d54f8e4e29c204baL139-L142) [[2]](diffhunk://#diff-29a4ca02ff3209848f29e7765b15951cdbb77c0df6fb7b25d54f8e4e29c204baL154-L157)

**Test and Documentation Updates:**

* Updated all tests and documentation to no longer require artifact storage URLs to start with `https://`, and instead just check for non-None URLs (to allow for other formats like `data:`). [[1]](diffhunk://#diff-3b112c82805b6a95ade56b492dd89dddfc6ea03bfa8f035aa3c36e6939351721L371-R371) [[2]](diffhunk://#diff-246d8241f4bcece093b3bd2230969ad6418410b8ab62613a82b11f3a28e5fb59L312-R312) [[3]](diffhunk://#diff-e41d9291cda69f4585ec0db27b6880987800a25564d1f3b38a0b93036a8fa293L707-R707) [[4]](diffhunk://#diff-e41d9291cda69f4585ec0db27b6880987800a25564d1f3b38a0b93036a8fa293L947-R947) [[5]](diffhunk://#diff-4e9d8ccb7a0dec6f8cfa497b38a9e3addf3883cf036f9443e300660739a9f186L312-R312) [[6]](diffhunk://#diff-dc7956cede0a6c384f2e5dcd68dce3e76f6091026309324420599486b34c5ef8L73) [[7]](diffhunk://#diff-dc7956cede0a6c384f2e5dcd68dce3e76f6091026309324420599486b34c5ef8L110-R109) [[8]](diffhunk://#diff-dc7956cede0a6c384f2e5dcd68dce3e76f6091026309324420599486b34c5ef8L164-R163) [[9]](diffhunk://#diff-902dc5b3b1dd29c009ff80715b46509994c30d2e3aab3d8f394a19fa7849f65bL211-R217) [[10]](diffhunk://#diff-8cdd1b4e9e45ad89dd25d009c1d63ebda65c64e68cc77c297e1b07ab480f98beL148-R153) [[11]](diffhunk://#diff-8cdd1b4e9e45ad89dd25d009c1d63ebda65c64e68cc77c297e1b07ab480f98beL188-R194)
* Adjusted test assertions for artifact dimensions: dimensions are now only checked if present, ensuring that tests pass even if the provider omits them. [[1]](diffhunk://#diff-902dc5b3b1dd29c009ff80715b46509994c30d2e3aab3d8f394a19fa7849f65bL85-R88) [[2]](diffhunk://#diff-902dc5b3b1dd29c009ff80715b46509994c30d2e3aab3d8f394a19fa7849f65bL132-R143) [[3]](diffhunk://#diff-9063e2cea14da8c8601749bd0272367776726668fafe4d25261aad5b4266e681L72-R75) [[4]](diffhunk://#diff-9063e2cea14da8c8601749bd0272367776726668fafe4d25261aad5b4266e681L110-R116) [[5]](diffhunk://#diff-8cdd1b4e9e45ad89dd25d009c1d63ebda65c64e68cc77c297e1b07ab480f98beL75-R78) [[6]](diffhunk://#diff-8cdd1b4e9e45ad89dd25d009c1d63ebda65c64e68cc77c297e1b07ab480f98beL111-R117)

**Provider Implementation Updates:**

* Updated provider implementations (e.g., `fal` image generator) to pass through optional width and height values, rather than defaulting to fixed dimensions.

These changes improve flexibility and compatibility with providers that may not always supply image or video dimensions, and ensure that the backend and tests handle such cases gracefully.