### PR TITLE
Default for cli-launcher up is detached

### DIFF
--- a/packages/cli-launcher/README.md
+++ b/packages/cli-launcher/README.md
@@ -19,13 +19,13 @@ open http://localhost:3300
 
 ### `up [directory]`
 
-Scaffold and start Baseboards. If the directory doesn't exist, creates a new project from templates.
+Scaffold and start Baseboards. If the directory doesn't exist, creates a new project from templates. Runs in detached mode (background) by default.
 
 ```bash
-baseboards up                    # Current directory
-baseboards up my-app             # New directory
+baseboards up                    # Current directory (detached)
+baseboards up my-app             # New directory (detached)
 baseboards up --prod             # Production mode
-baseboards up --detached         # Background mode
+baseboards up --attach           # Attach to logs (foreground)
 baseboards up --ports web=3300   # Custom ports
 ```
 

--- a/packages/cli-launcher/src/commands/up.ts
+++ b/packages/cli-launcher/src/commands/up.ts
@@ -131,10 +131,10 @@ export async function up(directory: string, options: UpOptions): Promise<void> {
   await runMigrations(ctx);
 
   // Step 10: Print success message
-  printSuccessMessage(ctx, options.detached || false, missingKeys.length > 0);
+  printSuccessMessage(ctx, !options.attach, missingKeys.length > 0);
 
-  // Step 11: Attach to logs if not detached
-  if (!options.detached) {
+  // Step 11: Attach to logs if --attach flag is provided
+  if (options.attach) {
     try {
       await attachToLogs(ctx);
     } catch (error: any) {

--- a/packages/cli-launcher/src/index.ts
+++ b/packages/cli-launcher/src/index.ts
@@ -46,7 +46,7 @@ program
   .argument("[directory]", "Project directory", ".")
   .option("--dev", "Development mode with hot reload (default)", true)
   .option("--prod", "Production mode with prebuilt images")
-  .option("--detached", "Run in detached mode (background)")
+  .option("--attach", "Attach to logs (runs in foreground)")
   .option("--ports <ports>", "Custom ports (e.g., web=3300 api=8800)")
   .action(up);
 

--- a/packages/cli-launcher/src/types.ts
+++ b/packages/cli-launcher/src/types.ts
@@ -30,7 +30,7 @@ export interface ProjectContext {
 export interface UpOptions {
   dev?: boolean;
   prod?: boolean;
-  detached?: boolean;
+  attach?: boolean;
   ports?: string;
 }
 


### PR DESCRIPTION
This pull request updates the behavior and documentation of the `up` command in the CLI launcher to make detached (background) mode the default, and introduces a new `--attach` flag to run in the foreground and attach to logs. The changes ensure consistency in flag naming, default behavior, and user guidance.

**CLI behavior and options:**

* Changed the default mode of `baseboards up` to run in detached (background) mode, and replaced the `--detached` flag with a new `--attach` flag that attaches to logs and runs in the foreground (`packages/cli-launcher/src/index.ts`, `packages/cli-launcher/src/types.ts`). [[1]](diffhunk://#diff-f9431ccf07c47b6e16a192030662aad3f8331d106c93cc6ff3057ba24663b864L49-R49) [[2]](diffhunk://#diff-c849d6051898d1fba548c165628a555f192b060983cd195dadbbcec4221ee1b3L33-R33)
* Updated logic in the `up` command to use the `--attach` flag, printing the appropriate success message and attaching to logs only if `--attach` is provided (`packages/cli-launcher/src/commands/up.ts`).

**Documentation:**

* Updated the `README.md` to reflect the new default behavior (detached mode), clarified usage examples, and documented the new `--attach` flag (`packages/cli-launcher/README.md`).