### PR TITLE
Generate release notes on publish

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           tag_name: "v${{ steps.bump.outputs.version }}"
           name: "v${{ steps.bump.outputs.version }}"
+          generate_release_notes: true
           draft: false
           prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request makes a small update to the release workflow to automatically generate release notes when creating a new release. release notes on publish