### PR TITLE
Fix: Create Board first time does not refresh boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,13 @@ docker-up: ## Start Docker services (databases, etc.)
 docker-down: ## Stop Docker services
 	docker-compose down
 
+docker-clean:
+	docker-compose down -v
+	docker-compose rm -f
+	docker-compose pull
+	docker-compose build
+	docker-compose up -d
+
 docker-logs: ## Show Docker logs
 	docker-compose logs -f
 

--- a/packages/frontend/src/hooks/useBoards.ts
+++ b/packages/frontend/src/hooks/useBoards.ts
@@ -75,9 +75,11 @@ export function useBoards(options: UseBoardsOptions = {}): BoardsHook {
       if (!result.data?.createBoard) {
         throw new Error("Failed to create board");
       }
+      // Refetch boards to update the UI with the new board
+      reexecuteQuery({ requestPolicy: "network-only" });
       return result.data.createBoard;
     },
-    [createBoardMutation]
+    [createBoardMutation, reexecuteQuery]
   );
 
   const deleteBoard = useCallback(


### PR DESCRIPTION
This pull request introduces a new Docker maintenance command and improves the UI update process after creating a board. The most important changes are grouped below:

**Docker workflow improvements:**

* Added a new `docker-clean` target to the `Makefile` that stops and removes containers/volumes, pulls the latest images, rebuilds, and starts Docker services fresh. This helps ensure a clean and up-to-date development environment.

**Frontend board management:**

* Updated the `useBoards` hook so that after creating a new board, the board list is refetched from the server. This ensures the UI immediately reflects the addition of the new board.