### PR TITLE
Fix baseboards worker to rewrite internal urls

### DIFF
--- a/packages/backend/src/boards/config.py
+++ b/packages/backend/src/boards/config.py
@@ -56,6 +56,10 @@ class Settings(BaseSettings):
     # Frontend Integration
     frontend_base_url: str | None = None
 
+    # Internal API URL (for Docker environments where worker needs to reach API)
+    # This allows workers to reach the API using Docker internal networking
+    internal_api_url: str | None = None
+
     # Job Queue Settings
     job_queue_name: str = "boards-jobs"
     job_timeout: int = 3600  # 1 hour default timeout
@@ -92,6 +96,17 @@ class Settings(BaseSettings):
 
 # Global settings instance
 settings = Settings()
+
+# Debug: Log settings initialization (only in debug mode)
+if settings.debug:
+    from .logging import get_logger
+
+    _logger = get_logger(__name__)
+    _logger.debug(
+        "Settings initialized",
+        internal_api_url=settings.internal_api_url,
+        environment=settings.environment,
+    )
 
 
 def initialize_generator_api_keys() -> None:

--- a/packages/backend/tests/auth/test_factory.py
+++ b/packages/backend/tests/auth/test_factory.py
@@ -74,12 +74,15 @@ class TestAuthFactory:
             "SUPABASE_SERVICE_ROLE_KEY": "test-key",
         },
     )
-    def test_supabase_adapter(self):
+    @patch("boards.auth.adapters.supabase.create_client")
+    def test_supabase_adapter(self, mock_create_client):
         """Test creating Supabase adapter."""
         from boards.auth.adapters.supabase import SupabaseAuthAdapter
 
         adapter = get_auth_adapter()
         assert isinstance(adapter, SupabaseAuthAdapter)
+        # Verify create_client was called with correct args
+        mock_create_client.assert_called_once_with("https://test.supabase.co", "test-key")
 
     @patch.dict(os.environ, {"BOARDS_AUTH_PROVIDER": "supabase"})
     def test_supabase_adapter_missing_config(self):

--- a/packages/cli-launcher/template-sources/compose.dev.yaml
+++ b/packages/cli-launcher/template-sources/compose.dev.yaml
@@ -5,7 +5,6 @@ services:
   api:
     volumes:
       - ./api:/app
-      - ./data/storage:/app/data/storage
     environment:
       - PYTHONUNBUFFERED=1
     command:
@@ -24,9 +23,9 @@ services:
   worker:
     volumes:
       - ./api:/app
-      - ./data/storage:/app/data/storage
     environment:
       - PYTHONUNBUFFERED=1
+      - BOARDS_INTERNAL_API_URL=http://api:8800
 
   web:
     command: sh -c "pnpm install && pnpm dev"

--- a/packages/cli-launcher/template-sources/compose.yaml
+++ b/packages/cli-launcher/template-sources/compose.yaml
@@ -34,6 +34,8 @@ services:
     env_file:
       - docker/.env
       - api/.env
+    volumes:
+      - ./data/storage:/app/data/storage
     depends_on:
       db:
         condition: service_healthy
@@ -67,6 +69,10 @@ services:
     env_file:
       - docker/.env
       - api/.env
+    volumes:
+      - ./data/storage:/app/data/storage
+    environment:
+      - BOARDS_INTERNAL_API_URL=http://api:8800
     depends_on:
       db:
         condition: service_healthy

--- a/packages/frontend/src/graphql/operations.ts
+++ b/packages/frontend/src/graphql/operations.ts
@@ -79,7 +79,7 @@ export const GET_BOARD = gql`
   ${BOARD_FRAGMENT}
   ${USER_FRAGMENT}
   ${GENERATION_FRAGMENT}
-  query GetBoard($id: UUID!) {
+  query GetBoard($id: UUID!, $limit: Int, $offset: Int) {
     board(id: $id) {
       ...BoardFragment
       owner {
@@ -99,7 +99,7 @@ export const GET_BOARD = gql`
           ...UserFragment
         }
       }
-      generations(limit: 10) {
+      generations(limit: $limit, offset: $offset) {
         ...GenerationFragment
       }
     }

--- a/packages/frontend/src/hooks/useBoard.ts
+++ b/packages/frontend/src/hooks/useBoard.ts
@@ -118,13 +118,20 @@ interface BoardHook {
   revokeShareLink: (linkId: string) => Promise<void>;
 }
 
-export function useBoard(boardId: string): BoardHook {
+export function useBoard(
+  boardId: string,
+  options?: { limit?: number; offset?: number }
+): BoardHook {
   const { user } = useAuth();
 
   // Query for board data
   const [{ data, fetching, error }, reexecuteQuery] = useQuery({
     query: GET_BOARD,
-    variables: { id: boardId },
+    variables: {
+      id: boardId,
+      limit: options?.limit ?? 100, // Default to 100 generations
+      offset: options?.offset ?? 0,
+    },
     pause: !boardId,
     requestPolicy: "cache-and-network", // Always fetch fresh data while showing cached data
   });

--- a/sql/basic.sql
+++ b/sql/basic.sql
@@ -26,3 +26,12 @@ set storage_url = replace(
     )
 where storage_url is not null
     and storage_url like 'http://localhost:8000/storage/%';
+---
+select b.title,
+    b.is_public,
+    g.generator_name,
+    g.artifact_type,
+    g.storage_url,
+    g.input_params
+from generations g
+    left join boards b on g.board_id = b.id;


### PR DESCRIPTION
This pull request introduces improved support for Docker-based deployments, particularly for internal API networking, and enhances artifact URL resolution in container environments. It also adds pagination support for board generations in the frontend and backend, improves test reliability, and makes minor adjustments to Docker Compose templates and SQL queries.

**Docker internal networking and artifact URL resolution:**

* Added `internal_api_url` to the `Settings` class in `config.py` to allow workers to access the API using Docker internal networking. This is configurable via the `BOARDS_INTERNAL_API_URL` environment variable. [[1]](diffhunk://#diff-dec586a81f136fcf403a69cc05160d50d224dbe7f9b3eb6a6cd0186867fd7739R59-R62) [[2]](diffhunk://#diff-d9439ab71d6239eee4381e0bf4f3adb2fa5707247d1affed5b44302ff5f97badL27-R28) [[3]](diffhunk://#diff-ced1045cd088a687de847906c275cfd850158d481fe139cc327315006892e245R72-R75)
* Implemented `_rewrite_storage_url` in `resolution.py` to rewrite public artifact URLs to internal Docker network URLs, ensuring workers can download artifacts regardless of networking setup. This is now used in artifact download logic. [[1]](diffhunk://#diff-78ec1f8a10e05612a6cce2d97d7b3f6df744ef9ae9d07805f5d71fd159ae2a50R27-R75) [[2]](diffhunk://#diff-78ec1f8a10e05612a6cce2d97d7b3f6df744ef9ae9d07805f5d71fd159ae2a50R149-R159)
* Added debug logging for settings initialization and URL rewriting to aid troubleshooting in containerized environments. [[1]](diffhunk://#diff-dec586a81f136fcf403a69cc05160d50d224dbe7f9b3eb6a6cd0186867fd7739R100-R110) [[2]](diffhunk://#diff-78ec1f8a10e05612a6cce2d97d7b3f6df744ef9ae9d07805f5d71fd159ae2a50R27-R75) [[3]](diffhunk://#diff-78ec1f8a10e05612a6cce2d97d7b3f6df744ef9ae9d07805f5d71fd159ae2a50R149-R159)

**Frontend and backend pagination for generations:**

* Updated the `GET_BOARD` GraphQL query and `useBoard` hook to support `limit` and `offset` parameters, enabling pagination of board generations in the frontend. [[1]](diffhunk://#diff-d673edccf51004e2361c7479044bc430dbd3d9cf7374872b5109eff9ed6011e8L82-R82) [[2]](diffhunk://#diff-d673edccf51004e2361c7479044bc430dbd3d9cf7374872b5109eff9ed6011e8L102-R102) [[3]](diffhunk://#diff-a069ff8913d2c80a039b4e1112b84b4cddb68e5a58a1bda5eee3a08491e505f2L121-R134)

**Testing improvements:**

* Updated Supabase adapter tests to patch the `create_client` method, improving test reliability and isolation.

**Docker Compose and SQL changes:**

* Adjusted Docker Compose templates to mount storage volumes only where needed and to set the `BOARDS_INTERNAL_API_URL` environment variable for the worker and api services. [[1]](diffhunk://#diff-d9439ab71d6239eee4381e0bf4f3adb2fa5707247d1affed5b44302ff5f97badL8) [[2]](diffhunk://#diff-ced1045cd088a687de847906c275cfd850158d481fe139cc327315006892e245R37-R38) [[3]](diffhunk://#diff-d9439ab71d6239eee4381e0bf4f3adb2fa5707247d1affed5b44302ff5f97badL27-R28) [[4]](diffhunk://#diff-ced1045cd088a687de847906c275cfd850158d481fe139cc327315006892e245R72-R75)
* Added a SQL query to join boards and generations for easier data inspection.