### PR TITLE
Update getting started documentation section

### DIFF
--- a/apps/docs/docs/baseboards/overview.md
+++ b/apps/docs/docs/baseboards/overview.md
@@ -1,0 +1,324 @@
+---
+sidebar_position: 1
+---
+
+# Baseboards Overview
+
+**Baseboards** is a production-ready reference implementation of the Boards toolkit, deployable with a single command via the `@weirdfingers/baseboards` CLI.
+
+## What is Baseboards?
+
+Baseboards serves two purposes:
+
+1. **Turnkey Solution** - Deploy a fully-functional Boards instance immediately for personal or production use
+2. **Reference Implementation** - Demonstrates best practices for building applications with the Boards toolkit
+
+Unlike cloning the repository for development, Baseboards provides a pre-configured, containerized deployment that "just works" out of the box.
+
+## Quick Start
+
+```bash
+# Install and start Baseboards
+npx @weirdfingers/baseboards up my-boards-app
+
+# Access at http://localhost:3300
+```
+
+See the [Installation Guide](../installation/installing-baseboards) for detailed setup instructions.
+
+## Architecture
+
+Baseboards uses Docker Compose to orchestrate several services:
+
+```
+my-boards-app/
+├── web/                      # Next.js frontend (from apps/baseboards)
+├── api/                      # FastAPI backend (from packages/backend)
+├── data/storage/             # Generated media (local storage)
+├── docker/                   # Docker Compose configuration
+├── compose.yaml              # Production configuration
+├── compose.dev.yaml          # Development overrides
+└── README.md
+```
+
+### Services
+
+- **web** - Next.js frontend application
+  - Port: 3300 (default)
+  - Built from `apps/baseboards` in the monorepo
+  - Responsive UI with Tailwind CSS and Radix UI components
+
+- **api** - FastAPI backend with GraphQL
+  - Port: 8088 (default)
+  - Built from `packages/backend` in the monorepo
+  - Handles job processing, storage, and database operations
+
+- **db** - PostgreSQL 15 database
+  - Port: 5432 (internal)
+  - Persistent storage for boards, artifacts, and user data
+
+- **redis** - Redis 7 cache and job queue
+  - Port: 6379 (internal)
+  - Job queue management and caching
+
+- **worker** - Background job processor
+  - Executes AI generation jobs
+  - Processes uploads and storage operations
+
+## Configuration
+
+### Environment Variables
+
+API keys and configuration are stored in `api/.env`:
+
+```bash
+# Generator API keys (JSON format)
+BOARDS_GENERATOR_API_KEYS={"REPLICATE_API_KEY":"r8_...","OPENAI_API_KEY":"sk-..."}
+
+# Database
+DATABASE_URL=postgresql://boards:boards@db:5432/boards
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+
+# Storage (default: local)
+STORAGE_PROVIDER=local
+```
+
+During initial setup, the CLI prompts for API keys. You can also edit `api/.env` directly.
+
+### Generator Configuration
+
+Edit `api/config/generators.yaml` to customize available generators:
+
+```yaml
+generators:
+  - name: flux-schnell
+    provider: replicate
+    type: text-to-image
+    model: black-forest-labs/flux-schnell
+
+  - name: gpt-4o
+    provider: openai
+    type: text-to-text
+    model: gpt-4o
+```
+
+See the [Generators documentation](../generators/overview) for more details.
+
+### Storage Configuration
+
+Edit `api/config/storage_config.yaml` to configure storage backends:
+
+```yaml
+# Local storage (default)
+type: local
+local:
+  base_path: /app/data/storage
+
+# Or use cloud storage
+# type: s3
+# s3:
+#   bucket: my-boards-bucket
+#   region: us-east-1
+```
+
+Supported storage backends:
+- **Local** - File system storage
+- **S3** - Amazon S3
+- **GCS** - Google Cloud Storage
+- **Supabase** - Supabase Storage
+
+See the [Storage documentation](../backend/storage) for configuration details.
+
+## CLI Commands
+
+### `baseboards up [directory]`
+
+Start Baseboards. Creates project from templates if directory doesn't exist.
+
+```bash
+baseboards up                    # Current directory (detached)
+baseboards up my-app             # New directory (detached)
+baseboards up --prod             # Production mode
+baseboards up --attach           # Attach to logs (foreground)
+baseboards up --ports web=3300   # Custom ports
+```
+
+### `baseboards down [directory]`
+
+Stop Baseboards.
+
+```bash
+baseboards down              # Stop services
+baseboards down --volumes    # Also remove volumes (deletes data)
+```
+
+### `baseboards logs [directory] [services...]`
+
+View service logs.
+
+```bash
+baseboards logs              # All services
+baseboards logs api web      # Specific services
+baseboards logs -f           # Follow logs
+baseboards logs --since 1h   # Last hour
+```
+
+### `baseboards status [directory]`
+
+Show service status.
+
+```bash
+baseboards status
+```
+
+### `baseboards update [directory]`
+
+Update to the latest version (preserves configuration).
+
+```bash
+baseboards update
+```
+
+### `baseboards clean [directory]`
+
+Clean up Docker resources.
+
+```bash
+baseboards clean             # Remove containers and volumes
+baseboards clean --hard      # Also remove images
+```
+
+### `baseboards doctor [directory]`
+
+Run diagnostics and show system information.
+
+```bash
+baseboards doctor
+```
+
+## Getting API Keys
+
+Baseboards requires API keys from AI providers to generate content:
+
+- **Replicate**: https://replicate.com/account/api-tokens
+- **OpenAI**: https://platform.openai.com/api-keys
+- **FAL**: https://fal.ai/dashboard/keys
+- **Google AI**: https://makersuite.google.com/app/apikey
+
+Keys are stored in `api/.env` as a JSON object:
+
+```bash
+BOARDS_GENERATOR_API_KEYS={"REPLICATE_API_KEY":"r8_...","OPENAI_API_KEY":"sk-..."}
+```
+
+## Production Deployment
+
+### Using Docker Compose
+
+```bash
+# Production mode
+baseboards up --prod
+
+# Custom ports
+baseboards up --prod --ports web=80,api=8080
+```
+
+### Environment Setup
+
+For production deployments:
+
+1. **Use strong database credentials** - Edit `docker/compose.yaml`
+2. **Configure external storage** - Use S3/GCS instead of local storage
+3. **Set up authentication** - See [Auth documentation](../auth/overview)
+4. **Enable HTTPS** - Use a reverse proxy (nginx, Caddy)
+5. **Configure monitoring** - See [Monitoring documentation](../deployment/monitoring)
+
+### Scaling
+
+To run multiple workers for higher throughput:
+
+```bash
+# Edit docker/compose.yaml
+docker compose up --scale worker=3
+```
+
+## Customization
+
+Baseboards is designed to be customized:
+
+1. **Clone the generated directory** to version control
+2. **Modify configuration files** (`generators.yaml`, `storage_config.yaml`, etc.)
+3. **Update environment variables** in `api/.env` and `web/.env`
+4. **Edit Docker Compose** files for custom networking, volumes, or services
+5. **Extend the codebase** by forking the Boards repository
+
+For deeper customization, consider:
+- [Building a custom application](../installation/custom-application) using the toolkit packages
+- [Contributing to Boards](../guides/contributing) to add features upstream
+
+## Differences from Repository Clone
+
+| Aspect | Baseboards CLI | Repository Clone |
+|--------|---------------|------------------|
+| **Purpose** | Deploy and use Boards | Develop and contribute |
+| **Setup time** | ~5 minutes | ~10-15 minutes |
+| **Prerequisites** | Docker, Node.js 20+ | Docker, Node.js 18+, Python 3.12+, pnpm |
+| **Updates** | `baseboards update` | `git pull` + rebuild |
+| **Customization** | Configuration files | Full source code access |
+| **Use case** | Production deployment | Development environment |
+
+## Troubleshooting
+
+### Port Conflicts
+
+If default ports are in use:
+
+```bash
+# Use custom ports
+baseboards up --ports web=3301,api=8089
+```
+
+### Service Won't Start
+
+```bash
+# Check logs
+baseboards logs
+
+# Check status
+baseboards status
+
+# Run diagnostics
+baseboards doctor
+```
+
+### Database Connection Issues
+
+```bash
+# Restart services
+baseboards down
+baseboards up
+```
+
+### Worker Not Processing Jobs
+
+```bash
+# Check worker logs
+baseboards logs worker
+
+# Verify Redis connection
+baseboards logs redis
+
+# Restart worker
+docker compose restart worker
+```
+
+## Next Steps
+
+- 📖 **[Installation Guide](../installation/installing-baseboards)** - Complete setup instructions
+- 🎨 **[Generators](../generators/overview)** - Configure AI generators
+- 🔐 **[Authentication](../auth/overview)** - Set up user authentication
+- 🚀 **[Deployment](../deployment/overview)** - Production deployment guide
+- 🏗️ **[Backend SDK](../backend/getting-started)** - Extend the backend
+- ⚛️ **[Frontend Hooks](../frontend/getting-started)** - Customize the frontend

--- a/apps/docs/docs/installation.md
+++ b/apps/docs/docs/installation.md
@@ -4,235 +4,65 @@ sidebar_position: 2
 
 # Installation
 
-Complete installation guide for setting up Boards in your development environment.
+Choose the installation method that best fits your needs.
 
-## Prerequisites
+## Installation Options
 
-Before installing Boards, ensure you have the following installed:
+There are three ways to get started with Boards:
 
-### Required Software
+### ⚡ Quickest Start: Install Baseboards
 
-- **Node.js 18+** - JavaScript runtime
-- **Python 3.12+** - Backend programming language
-- **pnpm** - Fast, disk space efficient package manager
-- **Docker & Docker Compose** - For local database services
-- **Git** - Version control
+**Best for:** Using Boards immediately without development setup
 
-### Package Managers
-
-#### Install pnpm
+Deploy a production-ready Boards instance with one command:
 
 ```bash
-# Via npm
-npm install -g pnpm
-
-# Via Homebrew (macOS)
-brew install pnpm
-
-# Via script
-curl -fsSL https://get.pnpm.io/install.sh | sh -
+npx @weirdfingers/baseboards up my-boards-app
 ```
 
-#### Install uv (Python)
+- **Time to start:** ~5 minutes
+- **Prerequisites:** Docker, Node.js 20+
+- **Learn more:** [Baseboards Installation Guide](./installation/installing-baseboards)
 
-```bash
-# Via pip
-pip install uv
+### 🛠️ Contribute to Boards
 
-# Via Homebrew (macOS)
-brew install uv
+**Best for:** Contributing to the project or deep customization
 
-# Via script
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-## Installation Steps
-
-### 1. Clone Repository
+Clone the repository to access the full source code:
 
 ```bash
 git clone https://github.com/weirdfingers/boards.git
 cd boards
-```
-
-### 2. Install Dependencies
-
-The Makefile provides convenient commands for setup:
-
-```bash
-# Install all dependencies (Python and Node.js)
 make install
 ```
 
-This will:
+- **Time to start:** ~10 minutes
+- **Prerequisites:** Docker, Node.js 18+, Python 3.12+, pnpm
+- **Learn more:** [Repository Cloning Guide](./installation/cloning-repository)
 
-- Install Python dependencies with `uv`
-- Install Node.js dependencies with `pnpm`
-- Set up workspace linking
+### 🚧 Build a Custom Application
 
-### 3. Start Services
+**Best for:** Building your own application with Boards packages
 
-Start the required database and cache services:
+Create a custom app using the Boards backend and frontend packages.
 
-```bash
-# Start PostgreSQL and Redis via Docker
-make docker-up
-```
+- **Status:** Under construction
+- **Prerequisites:** Docker, Node.js 18+, Python 3.12+
+- **Learn more:** [Custom Application Guide](./installation/custom-application)
 
-This creates:
+## Comparison
 
-- **PostgreSQL 15** on port 5433
-  - Database: `boards_dev`
-  - User: `boards`
-  - Password: `boards_dev`
-- **Redis 7** on port 6380
-
-### 4. Database Setup
-
-Initialize the database schema:
-
-```bash
-cd packages/backend
-
-# Create virtual environment and install dependencies
-# Note: uv sync automatically installs dev dependencies (includes all providers/storage for typecheck)
-uv sync
-
-# Apply database migrations
-uv run alembic upgrade head
-```
-
-### 5. Set Up Pre-commit Hooks (Optional but Recommended)
-
-Pre-commit hooks automatically run linters and type checks before each commit:
-
-```bash
-# Install pre-commit hooks
-cd packages/backend
-uv run pre-commit install                      # Install commit hooks
-uv run pre-commit install --hook-type pre-push  # Install push hooks
-
-# Manually run all hooks (optional - they'll run automatically)
-uv run pre-commit run --all-files              # Run commit hooks
-uv run pre-commit run --hook-stage push --all-files  # Run push hooks (includes tests)
-```
-
-**On every commit**, the hooks automatically:
-
-- Lint Python code with `ruff`
-- Format Python code with `ruff format`
-- Type check backend with `pyright`
-- Lint frontend packages
-- Type check frontend packages
-- Check for common issues (trailing whitespace, large files, etc.)
-
-**Before every push**, the hooks automatically:
-
-- Run all backend tests (pytest)
-- Run all frontend tests (vitest)
-
-### 6. Start Development Servers
-
-```bash
-# Start all development servers
-make dev
-
-# Or start individually:
-# Backend only:
-cd packages/backend && uvicorn boards.api.app:app --reload --port 8088
-```
-
-## Verify Installation
-
-### Backend API
-
-Check the backend is running:
-
-```bash
-curl http://localhost:8088/health
-# Should return: {"status": "healthy"}
-```
-
-### GraphQL Playground
-
-Open http://localhost:8088/graphql in your browser to access the GraphQL playground.
-
-### Frontend Example
-
-Open http://localhost:3033 in your browser to see the example Next.js application.
-
-## Troubleshooting
-
-### Common Issues
-
-**Docker services won't start:**
-
-```bash
-# Check if ports are in use
-lsof -i :5433  # PostgreSQL
-lsof -i :6380  # Redis
-
-# Reset Docker containers
-make docker-down
-make docker-up
-```
-
-**Python dependency issues:**
-
-```bash
-# Clean and reinstall
-cd packages/backend
-rm -rf .venv
-uv sync  # Automatically includes dev dependencies
-```
-
-**Node.js dependency issues:**
-
-```bash
-# Clean and reinstall
-pnpm clean
-pnpm install
-```
-
-**Database connection errors:**
-
-```bash
-# Verify PostgreSQL is running
-docker ps | grep postgres
-
-# Test connection manually
-psql -h localhost -U boards -d boards_dev
-```
-
-### Getting Help
-
-- **GitHub Issues**: [Report bugs](https://github.com/weirdfingers/boards/issues)
-- **Discussions**: [Ask questions](https://github.com/weirdfingers/boards/discussions)
-- **Documentation**: [Browse docs](https://weirdfingers.github.io/boards/)
-
-## Development Tools
-
-### Recommended IDE Setup
-
-- **VS Code** with extensions:
-  - Python
-  - Pylance
-  - ES7+ React/Redux/React-Native snippets
-  - GraphQL
-
-### Code Quality Tools
-
-All tools are configured and can be run via Make:
-
-```bash
-make lint      # Run all linters
-make typecheck # TypeScript type checking
-make test      # Run all tests
-make build     # Build all packages
-```
+| Method | Setup Time | Prerequisites | Customization | Updates |
+|--------|------------|---------------|---------------|---------|
+| **Baseboards** | ~5 min | Docker, Node.js 20+ | Configuration files | `baseboards update` |
+| **Clone Repo** | ~10 min | Docker, Node.js 18+, Python 3.12+, pnpm | Full source access | `git pull` + rebuild |
+| **Custom App** | Coming soon | Docker, Node.js 18+, Python 3.12+ | Maximum flexibility | Package updates |
 
 ## Next Steps
 
-- 📚 **[Backend Development](./backend/getting-started)** - Start building with the Python SDK
-- ⚛️ **[Frontend Integration](./frontend/getting-started)** - Use React hooks
-- 🚀 **[Deployment Guide](./deployment/overview)** - Deploy to production
+Choose your path above to get started, or:
+
+- 📘 **[Introduction](./intro)** - Learn more about Boards
+- 📖 **[Baseboards Overview](./baseboards/overview)** - Understand the reference implementation
+- 🏗️ **[Backend SDK](./backend/getting-started)** - Backend development
+- ⚛️ **[Frontend Hooks](./frontend/getting-started)** - React integration

--- a/apps/docs/docs/installation/cloning-repository.md
+++ b/apps/docs/docs/installation/cloning-repository.md
@@ -1,0 +1,443 @@
+---
+sidebar_position: 2
+---
+
+# Cloning the Repository
+
+Complete installation guide for setting up the Boards development environment from source.
+
+## When to Use This Approach
+
+Clone the repository when you want to:
+
+- **Contribute** to the Boards project
+- **Customize** the core toolkit deeply
+- **Develop** new features or fixes
+- **Learn** from the complete source code
+
+If you just want to **use** Boards, consider [Installing Baseboards](./installing-baseboards) instead.
+
+## Prerequisites
+
+Before installing Boards, ensure you have the following installed:
+
+### Required Software
+
+- **Node.js 18+** - JavaScript runtime
+  - [Download Node.js](https://nodejs.org/)
+  - Verify: `node --version`
+
+- **Python 3.12+** - Backend programming language
+  - [Download Python](https://www.python.org/downloads/)
+  - Verify: `python --version` or `python3 --version`
+
+- **pnpm** - Fast, disk space efficient package manager
+  - Install: `npm install -g pnpm`
+  - Or via Homebrew: `brew install pnpm`
+  - Or via script: `curl -fsSL https://get.pnpm.io/install.sh | sh -`
+  - Verify: `pnpm --version`
+
+- **Docker & Docker Compose** - For local database services
+  - [Download Docker Desktop](https://www.docker.com/products/docker-desktop/)
+  - Verify: `docker --version` and `docker compose version`
+
+- **Git** - Version control
+  - [Download Git](https://git-scm.com/downloads)
+  - Verify: `git --version`
+
+### Package Managers
+
+#### Install pnpm
+
+```bash
+# Via npm
+npm install -g pnpm
+
+# Via Homebrew (macOS)
+brew install pnpm
+
+# Via script
+curl -fsSL https://get.pnpm.io/install.sh | sh -
+```
+
+#### Install uv (Python)
+
+```bash
+# Via pip
+pip install uv
+
+# Via Homebrew (macOS)
+brew install uv
+
+# Via script
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Verify installation:
+
+```bash
+uv --version
+```
+
+## Installation Steps
+
+### 1. Clone Repository
+
+```bash
+git clone https://github.com/weirdfingers/boards.git
+cd boards
+```
+
+### 2. Install Dependencies
+
+The Makefile provides convenient commands for setup:
+
+```bash
+# Install all dependencies (Python and Node.js)
+make install
+```
+
+This will:
+
+- Install Python dependencies with `uv`
+- Install Node.js dependencies with `pnpm`
+- Set up workspace linking
+
+**What happens under the hood:**
+- Python packages in `packages/backend/` are installed in editable mode
+- Node packages are linked via pnpm workspaces
+- All dependencies are installed according to lock files
+
+### 3. Start Services
+
+Start the required database and cache services:
+
+```bash
+# Start PostgreSQL and Redis via Docker
+make docker-up
+```
+
+This creates:
+
+- **PostgreSQL 15** on port 5433
+  - Database: `boards_dev`
+  - User: `boards`
+  - Password: `boards_dev`
+- **Redis 7** on port 6380
+
+**Verify services are running:**
+
+```bash
+docker ps | grep boards
+```
+
+You should see `boards-postgres` and `boards-redis` containers running.
+
+### 4. Database Setup
+
+Initialize the database schema:
+
+```bash
+cd packages/backend
+
+# Create virtual environment and install dependencies
+# Note: uv sync automatically installs dev dependencies (includes all providers/storage for typecheck)
+uv sync
+
+# Apply database migrations
+uv run alembic upgrade head
+```
+
+**What this does:**
+- Creates all database tables (boards, artifacts, jobs, etc.)
+- Sets up indexes and constraints
+- Prepares the database for development
+
+**Verify migration:**
+
+```bash
+# Connect to database
+psql -h localhost -p 5433 -U boards -d boards_dev
+
+# List tables
+\dt
+
+# Exit
+\q
+```
+
+### 5. Set Up Pre-commit Hooks (Optional but Recommended)
+
+Pre-commit hooks automatically run linters and type checks before each commit:
+
+```bash
+# Install pre-commit hooks
+cd packages/backend
+uv run pre-commit install                      # Install commit hooks
+uv run pre-commit install --hook-type pre-push  # Install push hooks
+
+# Manually run all hooks (optional - they'll run automatically)
+uv run pre-commit run --all-files              # Run commit hooks
+uv run pre-commit run --hook-stage push --all-files  # Run push hooks (includes tests)
+```
+
+**On every commit**, the hooks automatically:
+
+- Lint Python code with `ruff`
+- Format Python code with `ruff format`
+- Type check backend with `pyright`
+- Lint frontend packages
+- Type check frontend packages
+- Check for common issues (trailing whitespace, large files, etc.)
+
+**Before every push**, the hooks automatically:
+
+- Run all backend tests (pytest)
+- Run all frontend tests (vitest)
+
+**Why use pre-commit hooks?**
+- Catch issues before they reach CI
+- Maintain consistent code quality
+- Save time in code review
+
+### 6. Start Development Servers
+
+```bash
+# Return to project root
+cd ../..
+
+# Start all development servers
+make dev
+```
+
+This starts:
+- **Backend API** at http://localhost:8088
+- **Frontend example** at http://localhost:3033
+- **Documentation** at http://localhost:4500
+- **GraphQL playground** at http://localhost:8088/graphql
+
+**Or start individually:**
+
+```bash
+# Backend only
+make dev-backend
+# Or: cd packages/backend && uvicorn boards.api.app:app --reload --port 8088
+
+# Frontend only
+make dev-frontend
+# Or: cd apps/baseboards && pnpm dev
+
+# Worker (for job processing)
+make dev-worker
+# Or: cd packages/backend && uv run python -m boards.workers.worker
+
+# Documentation
+make dev-docs
+# Or: cd apps/docs && pnpm start
+```
+
+## Verify Installation
+
+### Backend API
+
+Check the backend is running:
+
+```bash
+curl http://localhost:8088/health
+# Should return: {"status": "healthy"}
+```
+
+### GraphQL Playground
+
+Open http://localhost:8088/graphql in your browser to access the GraphQL playground.
+
+Try a test query:
+
+```graphql
+query {
+  generators {
+    name
+    type
+    provider
+  }
+}
+```
+
+### Frontend Example
+
+Open http://localhost:3033 in your browser to see the example Next.js application (Baseboards reference implementation).
+
+### Documentation
+
+Open http://localhost:4500 in your browser to browse the documentation locally.
+
+## Troubleshooting
+
+### Common Issues
+
+#### Docker services won't start
+
+```bash
+# Check if ports are in use
+lsof -i :5433  # PostgreSQL
+lsof -i :6380  # Redis
+
+# Reset Docker containers
+make docker-down
+make docker-up
+
+# View logs
+make docker-logs
+```
+
+#### Python dependency issues
+
+```bash
+# Clean and reinstall
+cd packages/backend
+rm -rf .venv
+uv sync  # Automatically includes dev dependencies
+
+# Verify installation
+uv pip list
+```
+
+#### Node.js dependency issues
+
+```bash
+# Clean and reinstall
+pnpm clean
+pnpm install
+
+# If issues persist, clear cache
+pnpm store prune
+pnpm install
+```
+
+#### Database connection errors
+
+```bash
+# Verify PostgreSQL is running
+docker ps | grep postgres
+
+# Test connection manually
+psql -h localhost -p 5433 -U boards -d boards_dev
+
+# Check backend environment variables
+cat packages/backend/.env
+
+# Should include:
+# DATABASE_URL=postgresql://boards:boards_dev@localhost:5433/boards_dev
+```
+
+#### TypeScript errors in frontend
+
+```bash
+# Regenerate types
+make typecheck
+
+# Or manually
+cd packages/frontend
+pnpm typecheck
+```
+
+#### Migration errors
+
+```bash
+# Check migration status
+cd packages/backend
+uv run alembic current
+
+# Rollback if needed
+uv run alembic downgrade -1
+
+# Reapply
+uv run alembic upgrade head
+```
+
+### Getting Help
+
+- **GitHub Issues**: [Report bugs](https://github.com/weirdfingers/boards/issues)
+- **Discussions**: [Ask questions](https://github.com/weirdfingers/boards/discussions)
+- **Documentation**: [Browse docs](https://weirdfingers.github.io/boards/)
+- **Discord**: [Join community](https://discord.gg/rvVuHyuPEx)
+
+## Development Tools
+
+### Recommended IDE Setup
+
+- **VS Code** with extensions:
+  - Python
+  - Pylance
+  - ES7+ React/Redux/React-Native snippets
+  - GraphQL: Language Feature Support
+  - Prettier - Code formatter
+  - ESLint
+
+### Code Quality Tools
+
+All tools are configured and can be run via Make:
+
+```bash
+# Run all linters
+make lint
+
+# Lint backend only
+make lint-backend
+
+# Lint frontend only
+make lint-frontend
+
+# Type checking
+make typecheck
+
+# Run all tests
+make test
+
+# Test backend only
+make test-backend
+
+# Test frontend only
+make test-frontend
+
+# Build all packages
+make build
+```
+
+### Understanding the Monorepo
+
+The repository uses:
+
+- **pnpm workspaces** for Node.js packages
+- **uv** for Python package management
+- **Turborepo** for build orchestration
+- **Make** for convenient commands
+
+**Package structure:**
+
+```
+boards/
+├── packages/
+│   ├── backend/          # Python backend (published to PyPI)
+│   ├── frontend/         # React hooks (published to npm as @weirdfingers/boards)
+│   └── cli-launcher/     # Baseboards CLI (published to npm)
+├── apps/
+│   ├── baseboards/       # Reference Next.js app
+│   └── docs/            # Documentation website
+├── docker/              # Docker Compose configs
+├── Makefile            # Convenient commands
+└── turbo.json          # Turborepo configuration
+```
+
+See [CLAUDE.md](https://github.com/weirdfingers/boards/blob/main/CLAUDE.md) for detailed architecture and contribution guidelines.
+
+## Next Steps
+
+Now that you have the development environment set up:
+
+- 📚 **[Backend Development](../backend/getting-started)** - Start building with the Python SDK
+- ⚛️ **[Frontend Integration](../frontend/getting-started)** - Use React hooks
+- 🎨 **[Creating Generators](../generators/creating-generators)** - Add new AI providers
+- 🧪 **[Testing Guide](../backend/testing)** - Write and run tests
+- 🤝 **[Contributing Guide](../guides/contributing)** - Contribute to the project
+- 🚀 **[Deployment Guide](../deployment/overview)** - Deploy to production

--- a/apps/docs/docs/installation/custom-application.md
+++ b/apps/docs/docs/installation/custom-application.md
@@ -1,0 +1,232 @@
+---
+sidebar_position: 3
+---
+
+# Building a Custom Application
+
+🚧 **This guide is under construction** 🚧
+
+Learn how to build a custom application using the Boards backend and frontend packages.
+
+## Overview
+
+Instead of using Baseboards or cloning the full repository, you can build your own custom application by installing the Boards packages directly:
+
+- **`@weirdfingers/boards`** (npm) - React hooks and frontend utilities
+- **`boards`** (PyPI, coming soon) - Python backend SDK
+
+This approach gives you:
+
+- ✅ **Full customization** - Build your own UI and UX
+- ✅ **Minimal dependencies** - Only include what you need
+- ✅ **Framework flexibility** - Use with Remix, Vite, or any React setup
+- ✅ **Production packages** - Stable, versioned releases
+
+## What's Coming
+
+This guide will cover:
+
+1. **Backend Setup**
+   - Installing the `boards` Python package
+   - Configuring database and storage
+   - Setting up GraphQL API
+   - Running workers for job processing
+
+2. **Frontend Setup**
+   - Installing `@weirdfingers/boards` npm package
+   - Configuring the GraphQL client
+   - Using React hooks for boards, artifacts, and generators
+   - Building custom UI components
+
+3. **Authentication**
+   - Integrating auth providers (Supabase, Clerk, Auth0)
+   - Configuring multi-tenancy
+   - Setting up authorization rules
+
+4. **Deployment**
+   - Containerizing your custom app
+   - Deploying to cloud providers
+   - Configuring production settings
+
+## Current Status
+
+**Backend Package (PyPI):** 🚧 In development
+- The backend will be published as a pip-installable package
+- Currently, you need to clone the repository to use the backend
+
+**Frontend Package (npm):** ✅ Available
+- `@weirdfingers/boards` is published and ready to use
+- Documentation for standalone usage is being finalized
+
+## Alternatives While This Guide is in Development
+
+### Option 1: Install Baseboards
+
+For the quickest start, use Baseboards:
+
+```bash
+npx @weirdfingers/baseboards up my-app
+```
+
+Then customize the generated code. See the [Baseboards Installation Guide](./installing-baseboards).
+
+### Option 2: Clone the Repository
+
+For full access to the source code:
+
+```bash
+git clone https://github.com/weirdfingers/boards.git
+cd boards
+make install
+```
+
+See the [Repository Cloning Guide](./cloning-repository).
+
+### Option 3: Use Frontend Package Only (Experimental)
+
+You can install the frontend package now and connect it to a Baseboards backend:
+
+```bash
+# Install the frontend package
+npm install @weirdfingers/boards
+
+# Or with pnpm
+pnpm add @weirdfingers/boards
+```
+
+**Example usage:**
+
+```tsx
+import { BoardsProvider, useBoards, useBoard } from '@weirdfingers/boards';
+
+function App() {
+  return (
+    <BoardsProvider graphqlUrl="http://localhost:8088/graphql">
+      <BoardsList />
+    </BoardsProvider>
+  );
+}
+
+function BoardsList() {
+  const { boards, loading, error } = useBoards();
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+
+  return (
+    <div>
+      {boards.map(board => (
+        <div key={board.id}>{board.title}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+**Note:** You still need a backend running (via Baseboards or cloned repository) to provide the GraphQL API.
+
+## Prerequisites (When Available)
+
+When this guide is complete, you'll need:
+
+- **Docker and Docker Compose** - For database and Redis
+- **Node.js 18+** - For frontend development
+- **Python 3.12+** - For backend development
+- **PostgreSQL** - Database (via Docker or external)
+- **Redis** - Job queue (via Docker or external)
+
+## Stay Updated
+
+This guide is actively being developed. Follow progress:
+
+- **GitHub**: [Boards Repository](https://github.com/weirdfingers/boards)
+- **Discord**: [Join the Community](https://discord.gg/rvVuHyuPEx)
+- **Documentation**: Check back regularly for updates
+
+## Contributing
+
+Want to help write this guide? Contributions are welcome!
+
+1. Check the [Contributing Guide](../guides/contributing)
+2. Join the discussion on [Discord](https://discord.gg/rvVuHyuPEx)
+3. Open an issue or PR on [GitHub](https://github.com/weirdfingers/boards)
+
+## Resources
+
+While this guide is being written, these resources may help:
+
+- 📘 **[Baseboards Overview](../baseboards/overview)** - See how Baseboards uses the packages
+- 🏗️ **[Backend SDK](../backend/getting-started)** - Backend development guide
+- ⚛️ **[Frontend Hooks](../frontend/getting-started)** - React hooks documentation
+- 🎨 **[Generators](../generators/overview)** - Working with AI generators
+- 🔐 **[Authentication](../auth/overview)** - Auth setup and configuration
+
+## Example: Minimal Custom Setup (Preview)
+
+Here's a preview of what the setup might look like when this guide is complete:
+
+### Backend
+
+```bash
+# Install backend package (coming soon)
+pip install boards
+
+# Create main.py
+cat > main.py << 'EOF'
+from boards import create_app
+from boards.config import Config
+
+config = Config(
+    database_url="postgresql://user:pass@localhost/boards",
+    redis_url="redis://localhost:6379",
+    storage_provider="local",
+)
+
+app = create_app(config)
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8088)
+EOF
+
+# Run
+python main.py
+```
+
+### Frontend
+
+```bash
+# Install frontend package
+npm install @weirdfingers/boards urql graphql
+
+# Create App.tsx
+cat > App.tsx << 'EOF'
+import { BoardsProvider, useBoards } from '@weirdfingers/boards';
+
+export default function App() {
+  return (
+    <BoardsProvider graphqlUrl="http://localhost:8088/graphql">
+      <MyBoardsApp />
+    </BoardsProvider>
+  );
+}
+
+function MyBoardsApp() {
+  const { boards } = useBoards();
+  return (
+    <div>
+      <h1>My Custom Boards App</h1>
+      {boards.map(board => (
+        <div key={board.id}>{board.title}</div>
+      ))}
+    </div>
+  );
+}
+EOF
+```
+
+**Note:** This is a simplified preview. The actual implementation will include proper configuration, error handling, and more features.
+
+---
+
+Check back soon for the complete guide! 🚀

--- a/apps/docs/docs/installation/installing-baseboards.md
+++ b/apps/docs/docs/installation/installing-baseboards.md
@@ -1,0 +1,397 @@
+---
+sidebar_position: 1
+---
+
+# Installing Baseboards
+
+Complete guide to installing and configuring Baseboards, the one-command Boards deployment.
+
+## What You'll Get
+
+Baseboards provides a complete, containerized Boards instance including:
+
+- **Web UI** - Next.js frontend at http://localhost:3300
+- **GraphQL API** - Backend server at http://localhost:8088
+- **PostgreSQL** - Database for persistent storage
+- **Redis** - Job queue and caching
+- **Worker** - Background job processor for AI generation
+
+## Prerequisites
+
+### Required Software
+
+- **Docker Desktop** (macOS/Windows) or **Docker Engine** (Linux)
+  - [Download Docker Desktop](https://www.docker.com/products/docker-desktop/)
+  - Verify: `docker --version` and `docker compose version`
+
+- **Node.js 20+**
+  - [Download Node.js](https://nodejs.org/)
+  - Verify: `node --version`
+
+### System Requirements
+
+- **Memory**: 4GB RAM minimum, 8GB recommended
+- **Disk Space**: 2GB for Docker images + storage for generated content
+- **Ports**: 3300 (web), 8088 (api) must be available
+
+## Installation
+
+### Step 1: Run the CLI
+
+```bash
+npx @weirdfingers/baseboards up my-boards-app
+```
+
+This command will:
+
+1. ✅ Check system prerequisites (Docker, Node.js)
+2. 📁 Create project directory with templates
+3. 🔑 Prompt for API keys (optional - can add later)
+4. 🐳 Pull Docker images
+5. 🚀 Start all services in detached mode
+
+### Step 2: Enter API Keys
+
+The CLI will prompt you to enter API keys for AI providers:
+
+```
+? Enter Replicate API key (optional): r8_xxxxx
+? Enter OpenAI API key (optional): sk-xxxxx
+? Enter FAL API key (optional): xxxxx
+? Enter Google AI API key (optional): xxxxx
+```
+
+**Tip:** You can skip this and add keys later by editing `api/.env`.
+
+### Step 3: Wait for Services
+
+The CLI will start all services. This may take a few minutes on first run while Docker images are downloaded.
+
+```
+✓ Services started successfully
+✓ Web UI: http://localhost:3300
+✓ GraphQL API: http://localhost:8088/graphql
+```
+
+### Step 4: Access Baseboards
+
+Open http://localhost:3300 in your browser. You should see the Boards interface!
+
+## Getting API Keys
+
+To use AI generators, you'll need API keys from providers:
+
+### Replicate (Recommended)
+
+1. Sign up at https://replicate.com
+2. Go to https://replicate.com/account/api-tokens
+3. Create a new token
+4. Copy the token (starts with `r8_`)
+
+**Supported models:**
+- FLUX Schnell (fast image generation)
+- Stable Diffusion XL
+- Many other models
+
+### OpenAI
+
+1. Sign up at https://platform.openai.com
+2. Go to https://platform.openai.com/api-keys
+3. Create a new API key
+4. Copy the key (starts with `sk-`)
+
+**Supported models:**
+- GPT-4o (text generation)
+- DALL-E 3 (image generation)
+
+### FAL.ai
+
+1. Sign up at https://fal.ai
+2. Go to https://fal.ai/dashboard/keys
+3. Create a new API key
+4. Copy the key
+
+**Supported models:**
+- Fast Flux models
+- Real-time image generation
+
+### Google AI
+
+1. Sign up at https://ai.google.dev
+2. Go to https://makersuite.google.com/app/apikey
+3. Create a new API key
+4. Copy the key
+
+**Supported models:**
+- Gemini models
+
+## Configuration
+
+### Adding or Updating API Keys
+
+Edit `api/.env` in your installation directory:
+
+```bash
+cd my-boards-app
+nano api/.env  # or use your preferred editor
+```
+
+Update the `BOARDS_GENERATOR_API_KEYS` variable:
+
+```bash
+BOARDS_GENERATOR_API_KEYS={"REPLICATE_API_KEY":"r8_...","OPENAI_API_KEY":"sk-...","FAL_API_KEY":"...","GOOGLE_API_KEY":"..."}
+```
+
+After editing, restart the services:
+
+```bash
+baseboards down
+baseboards up
+```
+
+### Configuring Generators
+
+Edit `api/config/generators.yaml` to enable/disable generators or add new ones:
+
+```yaml
+generators:
+  # Enable Replicate FLUX Schnell (fast image generation)
+  - name: flux-schnell
+    provider: replicate
+    type: text-to-image
+    model: black-forest-labs/flux-schnell
+    enabled: true
+
+  # Enable OpenAI GPT-4o
+  - name: gpt-4o
+    provider: openai
+    type: text-to-text
+    model: gpt-4o
+    enabled: true
+```
+
+See the [Generators documentation](../generators/configuration) for more details.
+
+### Configuring Storage
+
+By default, Baseboards uses local file storage. To use cloud storage, edit `api/config/storage_config.yaml`:
+
+```yaml
+# Local storage (default)
+type: local
+local:
+  base_path: /app/data/storage
+
+# Amazon S3
+# type: s3
+# s3:
+#   bucket: my-boards-bucket
+#   region: us-east-1
+#   access_key_id: AWS_ACCESS_KEY_ID  # Or set AWS_ACCESS_KEY_ID env var
+#   secret_access_key: AWS_SECRET_ACCESS_KEY  # Or set AWS_SECRET_ACCESS_KEY env var
+
+# Google Cloud Storage
+# type: gcs
+# gcs:
+#   bucket: my-boards-bucket
+#   project_id: my-project
+#   credentials_path: /path/to/service-account.json
+
+# Supabase Storage
+# type: supabase
+# supabase:
+#   url: https://xxx.supabase.co
+#   key: your-anon-key
+#   bucket: boards-storage
+```
+
+See the [Storage documentation](../backend/storage) for configuration details.
+
+### Custom Ports
+
+If the default ports are in use:
+
+```bash
+baseboards up --ports web=3301,api=8089
+```
+
+Or edit `docker/compose.yaml` to change ports permanently.
+
+## Using Baseboards
+
+### Managing Services
+
+```bash
+# Stop services
+baseboards down
+
+# Start services
+baseboards up
+
+# Restart services
+baseboards down && baseboards up
+
+# View logs
+baseboards logs
+
+# Follow logs in real-time
+baseboards logs -f
+
+# View specific service logs
+baseboards logs api
+baseboards logs worker
+
+# Check service status
+baseboards status
+```
+
+### Updating Baseboards
+
+```bash
+# Update to latest version (preserves your data and configuration)
+baseboards update
+```
+
+### Cleaning Up
+
+```bash
+# Stop and remove containers (keeps data)
+baseboards down
+
+# Stop and remove containers + data
+baseboards down --volumes
+
+# Full cleanup including Docker images
+baseboards clean --hard
+```
+
+## Troubleshooting
+
+### Docker Not Running
+
+**Error:** `Cannot connect to the Docker daemon`
+
+**Solution:** Start Docker Desktop or Docker Engine
+
+```bash
+# macOS/Windows: Open Docker Desktop application
+
+# Linux: Start Docker service
+sudo systemctl start docker
+```
+
+### Port Already in Use
+
+**Error:** `Bind for 0.0.0.0:3300 failed: port is already allocated`
+
+**Solution:** Use custom ports or stop the conflicting service
+
+```bash
+# Use custom ports
+baseboards up --ports web=3301,api=8089
+
+# Or find and stop the conflicting process
+lsof -i :3300  # macOS/Linux
+netstat -ano | findstr :3300  # Windows
+```
+
+### Services Won't Start
+
+**Solution:** Check logs and run diagnostics
+
+```bash
+# View all logs
+baseboards logs
+
+# Run diagnostics
+baseboards doctor
+
+# Try restarting
+baseboards down
+baseboards up
+```
+
+### API Keys Not Working
+
+**Symptoms:** Generators fail with authentication errors
+
+**Solution:**
+
+1. Verify keys are correct in `api/.env`
+2. Check the JSON format is valid (use a JSON validator)
+3. Restart services after editing `.env`
+
+```bash
+# Example correct format
+BOARDS_GENERATOR_API_KEYS={"REPLICATE_API_KEY":"r8_xxxxx"}
+
+# Example incorrect format (missing quotes)
+BOARDS_GENERATOR_API_KEYS={REPLICATE_API_KEY:r8_xxxxx}  # ❌ Wrong
+```
+
+### Worker Not Processing Jobs
+
+**Symptoms:** Jobs stuck in "pending" status
+
+**Solution:** Check worker logs and restart
+
+```bash
+# Check worker logs
+baseboards logs worker
+
+# Restart worker
+docker compose restart worker
+
+# Full restart
+baseboards down
+baseboards up
+```
+
+### Database Connection Errors
+
+**Solution:** Reset database
+
+```bash
+# Stop services and remove volumes
+baseboards down --volumes
+
+# Start fresh
+baseboards up
+```
+
+**Warning:** This will delete all data (boards, artifacts, etc.)
+
+### Disk Space Issues
+
+**Solution:** Clean up old images and containers
+
+```bash
+# Remove stopped containers
+docker container prune
+
+# Remove unused images
+docker image prune -a
+
+# Remove unused volumes
+docker volume prune
+
+# Or use baseboards clean
+baseboards clean --hard
+```
+
+## Production Deployment
+
+For production use, see the [Deployment Guide](../deployment/overview) for:
+
+- Setting up HTTPS with reverse proxy
+- Configuring authentication
+- Using external databases
+- Setting up monitoring and logging
+- Scaling workers for higher throughput
+
+## Next Steps
+
+- 📘 **[Baseboards Overview](../baseboards/overview)** - Learn more about Baseboards
+- 🎨 **[Generators Guide](../generators/getting-started)** - Configure AI generators
+- 🔐 **[Authentication Setup](../auth/overview)** - Add user authentication
+- 🚀 **[Deployment Guide](../deployment/overview)** - Deploy to production

--- a/apps/docs/docs/intro.md
+++ b/apps/docs/docs/intro.md
@@ -28,42 +28,70 @@ Boards is built as a **monorepo** with both Python and TypeScript components:
 
 ## Getting Started
 
-### Prerequisites
+Choose your path based on what you want to do with Boards:
 
-- **Node.js** 18+ 
-- **Python** 3.12+
-- **Docker** and **Docker Compose** (for local development)
-- **pnpm** package manager
+| Path | Best For | Time to Start | Prerequisites |
+|------|----------|---------------|---------------|
+| **[Install Baseboards](#-quickest-start-install-baseboards)** ⚡ | Using Boards immediately | ~5 minutes | Docker, Node.js 20+ |
+| **[Clone Repository](#-contribute-to-boards)** | Contributing to Boards | ~10 minutes | Docker, Node.js 18+, Python 3.12+, pnpm |
+| **[Custom Application](#-build-a-custom-app)** | Building your own app | Coming soon | Docker, Node.js 18+, Python 3.12+ |
 
-### Quick Setup
+### ⚡ Quickest Start: Install Baseboards
+
+Baseboards is a production-ready Boards instance you can deploy with one command:
 
 ```bash
-# Clone the repository
+# Create and start Baseboards
+npx @weirdfingers/baseboards up my-boards-app
+
+# Access at http://localhost:3300
+```
+
+**Requirements:**
+- Docker Desktop (macOS/Windows) or Docker Engine (Linux)
+- Node.js 20+
+
+**Next steps:**
+- 📖 **[Baseboards Installation Guide](./installation/installing-baseboards)** - Complete setup and configuration
+- 📘 **[Baseboards Documentation](./baseboards/overview)** - Learn more about Baseboards
+
+### 🛠️ Contribute to Boards
+
+Clone the repository to contribute or customize the toolkit:
+
+```bash
 git clone https://github.com/weirdfingers/boards.git
 cd boards
-
-# Install all dependencies
 make install
-
-# Start database and Redis services  
 make docker-up
-
-# Start development servers
 make dev
 ```
 
-This will start:
-- Backend API server at `http://localhost:8088`
-- Frontend example at `http://localhost:3033`
-- Documentation at `http://localhost:4500`
-- GraphQL playground at `http://localhost:8088/graphql`
+**Requirements:**
+- Docker and Docker Compose
+- Node.js 18+
+- Python 3.12+
+- pnpm package manager
 
-## Next Steps
+**Next steps:**
+- 📖 **[Repository Setup Guide](./installation/cloning-repository)** - Detailed installation
+- 🤝 **[Contributing Guide](./guides/contributing)** - How to contribute
 
-- 📖 **[Installation Guide](./installation)** - Detailed setup instructions
+### 🚧 Build a Custom App
+
+Create your own application using the Boards backend and frontend packages.
+
+**Status:** 🚧 Under construction
+
+**Requirements:**
+- Docker and Docker Compose
+- Node.js 18+
+- Python 3.12+
+
+**Next steps:**
+- 📖 **[Custom Application Guide](./installation/custom-application)** - Coming soon
 - 🏗️ **[Backend SDK](./backend/getting-started)** - Python backend development
 - ⚛️ **[Frontend Hooks](./frontend/getting-started)** - React integration
-- 🎨 **[Auth Providers](./auth/overview)** - Authentication system
 
 ## Community & Social
 

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -18,6 +18,24 @@ const sidebars: SidebarsConfig = {
     "installation",
     {
       type: "category",
+      label: "Installation Guides",
+      collapsed: false,
+      items: [
+        "installation/installing-baseboards",
+        "installation/cloning-repository",
+        "installation/custom-application",
+      ],
+    },
+    {
+      type: "category",
+      label: "Baseboards",
+      collapsed: false,
+      items: [
+        "baseboards/overview",
+      ],
+    },
+    {
+      type: "category",
       label: "Backend Development",
       collapsed: false,
       items: [


### PR DESCRIPTION
Restructure the documentation to present users with three clear paths:
1. Installing Baseboards (quickest, ~5 minutes)
2. Cloning the repository (for contributors)
3. Building a custom app (under construction)

Changes:
- Update intro.md with comparison table and detailed path sections
- Create comprehensive Baseboards overview documentation
- Split installation into three detailed guides:
  - installing-baseboards.md: Complete Baseboards setup guide
  - cloning-repository.md: Repository clone guide for contributors
  - custom-application.md: Placeholder for custom app guide
- Convert installation.md to landing page with comparison
- Update sidebars.ts to organize new documentation structure

This provides clearer guidance for users based on their goals while maintaining backward compatibility for existing documentation links.