### PR TITLE
Ensure docker builds

### DIFF
--- a/packages/cli-launcher/src/commands/up.ts
+++ b/packages/cli-launcher/src/commands/up.ts
@@ -369,6 +369,7 @@ async function startDockerCompose(
     ...composeFiles.flatMap((f) => ["-f", f]),
     "up",
     "-d",
+    "--build",
     "--remove-orphans",
   ];
 


### PR DESCRIPTION
This pull request introduces a minor improvement to the Docker Compose startup process in the CLI launcher. The change ensures that services are always rebuilt when starting up, which helps prevent issues caused by outdated images.

* Added the `--build` flag to the Docker Compose command in `packages/cli-launcher/src/commands/up.ts`, ensuring services are rebuilt on startup.