### PR TITLE
fix: cli-launcher : remove broken paths in tsconfig

### DIFF
--- a/packages/cli-launcher/scripts/prepare-templates.js
+++ b/packages/cli-launcher/scripts/prepare-templates.js
@@ -193,7 +193,9 @@ if (fs.existsSync(tsconfigPath)) {
     }
 
     fs.writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2) + "\n");
-    console.log("   ✅ Removed monorepo-specific path mappings from tsconfig.json");
+    console.log(
+      "   ✅ Removed monorepo-specific path mappings from tsconfig.json"
+    );
   }
 }
 


### PR DESCRIPTION
This pull request updates the template preparation workflow in `prepare-templates.js` to improve project portability and simplify TypeScript configuration. The most important changes include reordering the steps to ensure configuration updates happen before copying backend files, and introducing logic to clean up monorepo-specific path mappings in `tsconfig.json` for the web template.

**Configuration updates:**

* Added logic to remove monorepo-specific path mappings for `@weirdfingers/boards` from `tsconfig.json` in the web template, ensuring TypeScript resolves dependencies from npm instead of local paths. The script also removes the entire `paths` property if it becomes empty.
* Updated the workflow order so that the `next.config.js` and `tsconfig.json` updates occur before copying backend files, improving the clarity and correctness of the template preparation steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tsconfig cleanup for web template and reorders preparation so config updates run before backend copy.
> 
> - **CLI Template Prep (`packages/cli-launcher/scripts/prepare-templates.js`)**:
>   - **TypeScript config**: Remove monorepo-specific `@weirdfingers/boards` path mappings from `web/tsconfig.json`; delete `compilerOptions.paths` if it becomes empty.
>   - **Workflow order**: Move configuration updates (e.g., `next.config.js`, `tsconfig.json`) ahead of backend copying; update flow comments accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dda1d45dd44f27496e8e8628933217a94882ce52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->