### PR TITLE
Mark Supabase setup guide as untested

### DIFF
--- a/apps/docs/docs/auth/providers/supabase.md
+++ b/apps/docs/docs/auth/providers/supabase.md
@@ -1,5 +1,13 @@
 # Supabase Authentication
 
+:::caution Under Construction
+
+This documentation has not yet been fully tested with an actual Supabase project. Some steps may be incomplete or require adjustments. We welcome community contributions to validate and improve this guide.
+
+**[Help us test this guide →](https://github.com/weirdfingers/boards/issues/152)**
+
+:::
+
 Use Supabase Auth for managed authentication with social providers, email/password, and more.
 
 ## Backend Setup

--- a/apps/docs/docs/guides/supabase-setup.md
+++ b/apps/docs/docs/guides/supabase-setup.md
@@ -4,6 +4,14 @@ sidebar_position: 2
 
 # Supabase Setup Guide
 
+:::caution Under Construction
+
+This documentation has not yet been fully tested with an actual Supabase project. Some steps may be incomplete or require adjustments. We welcome community contributions to validate and improve this guide.
+
+**[Help us test this guide →](https://github.com/weirdfingers/boards/issues/152)**
+
+:::
+
 Learn how to configure Boards to use Supabase as your database, storage, and authentication provider instead of the default local PostgreSQL setup.
 
 ## Why Use Supabase?


### PR DESCRIPTION
Add caution admonitions to Supabase setup and authentication documentation indicating they have not been fully tested with an actual Supabase project. Links to issue #152 for community help with validation.