### PR TITLE
Create FAL generator for nano-banana-pro edit

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -104,6 +104,9 @@ generators:
   - class: "boards.generators.implementations.fal.image.nano_banana_pro.FalNanoBananaProGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.nano_banana_pro_edit.FalNanoBananaProEditGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.video.fal_pixverse_lipsync.FalPixverseLipsyncGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -15,6 +15,7 @@ from .imagen4_preview_fast import FalImagen4PreviewFastGenerator
 from .nano_banana import FalNanoBananaGenerator
 from .nano_banana_edit import FalNanoBananaEditGenerator
 from .nano_banana_pro import FalNanoBananaProGenerator
+from .nano_banana_pro_edit import FalNanoBananaProEditGenerator
 from .qwen_image import FalQwenImageGenerator
 from .qwen_image_edit import FalQwenImageEditGenerator
 
@@ -34,6 +35,7 @@ __all__ = [
     "FalNanoBananaGenerator",
     "FalNanoBananaEditGenerator",
     "FalNanoBananaProGenerator",
+    "FalNanoBananaProEditGenerator",
     "FalQwenImageEditGenerator",
     "FalQwenImageGenerator",
 ]

--- a/packages/backend/src/boards/generators/implementations/fal/image/nano_banana_pro_edit.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/nano_banana_pro_edit.py
@@ -1,0 +1,226 @@
+"""
+fal.ai nano-banana-pro image editing generator.
+
+Edit images using fal.ai's nano-banana-pro/edit model (powered by Google's latest
+image generation and editing model). Specializes in realism and typography.
+
+See: https://fal.ai/models/fal-ai/nano-banana-pro/edit
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class NanoBananaProEditInput(BaseModel):
+    """Input schema for nano-banana-pro image editing.
+
+    Artifact fields (like image_sources) are automatically detected via type
+    introspection and resolved from generation IDs to ImageArtifact objects.
+    """
+
+    prompt: str = Field(
+        min_length=3,
+        max_length=50000,
+        description="The prompt for image editing",
+    )
+    image_sources: list[ImageArtifact] = Field(
+        description="List of input images for editing (from previous generations)",
+        min_length=1,
+    )
+    num_images: int = Field(
+        default=1,
+        ge=1,
+        le=4,
+        description="Number of images to generate",
+    )
+    aspect_ratio: Literal[
+        "auto",
+        "21:9",
+        "16:9",
+        "3:2",
+        "4:3",
+        "5:4",
+        "1:1",
+        "4:5",
+        "3:4",
+        "2:3",
+        "9:16",
+    ] = Field(
+        default="auto",
+        description=(
+            "Aspect ratio for generated images. Default is 'auto', which takes one "
+            "of the input images' aspect ratio"
+        ),
+    )
+    resolution: Literal["1K", "2K", "4K"] = Field(
+        default="1K",
+        description="Image resolution (1K, 2K, or 4K)",
+    )
+    output_format: Literal["jpeg", "png", "webp"] = Field(
+        default="png",
+        description="Output image format",
+    )
+    sync_mode: bool = Field(
+        default=False,
+        description=(
+            "If True, the media will be returned as a data URI and the output "
+            "data won't be available in the request history"
+        ),
+    )
+    enable_web_search: bool = Field(
+        default=False,
+        description="Enable web search for generating images with current information",
+    )
+    limit_generations: bool = Field(
+        default=False,
+        description=(
+            "Experimental parameter to limit the number of generations from each "
+            "round of prompting to 1. Set to True to disregard any instructions in "
+            "the prompt regarding the number of images to generate"
+        ),
+    )
+
+
+class FalNanoBananaProEditGenerator(BaseGenerator):
+    """nano-banana-pro image editing generator using fal.ai.
+
+    Google's state-of-the-art image generation and editing model, specializing
+    in realism and typography applications.
+    """
+
+    name = "fal-nano-banana-pro-edit"
+    artifact_type = "image"
+    description = (
+        "Fal: nano-banana-pro edit - Google's state-of-the-art image editing "
+        "with excellent realism and typography"
+    )
+
+    def get_input_schema(self) -> type[NanoBananaProEditInput]:
+        return NanoBananaProEditInput
+
+    async def generate(
+        self, inputs: NanoBananaProEditInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Edit images using fal.ai nano-banana-pro/edit model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalNanoBananaProEditGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifacts to Fal's public storage
+        # Fal API requires publicly accessible URLs, but our storage_url might be:
+        # - Localhost URLs (not publicly accessible)
+        # - Private S3 buckets (not publicly accessible)
+        # So we upload to Fal's temporary storage first
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal(inputs.image_sources, context)
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "prompt": inputs.prompt,
+            "image_urls": image_urls,
+            "num_images": inputs.num_images,
+            "aspect_ratio": inputs.aspect_ratio,
+            "resolution": inputs.resolution,
+            "output_format": inputs.output_format,
+            "sync_mode": inputs.sync_mode,
+            "enable_web_search": inputs.enable_web_search,
+            "limit_generations": inputs.limit_generations,
+        }
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/nano-banana-pro/edit",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image URLs and description from result
+        # fal.ai returns: {
+        #   "images": [{"url": "...", "width": ..., "height": ...}, ...],
+        #   "description": "Text description from the model"
+        # }
+        images = result.get("images", [])
+
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url = image_data.get("url")
+            # Extract dimensions if available, otherwise use sensible defaults
+            width = image_data.get("width", 1024)
+            height = image_data.get("height", 1024)
+
+            if not image_url:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Store with appropriate output_index
+            artifact = await context.store_image_result(
+                storage_url=image_url,
+                format=inputs.output_format,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: NanoBananaProEditInput) -> float:
+        """Estimate cost for nano-banana-pro edit generation.
+
+        nano-banana-pro/edit uses Google's latest image editing model.
+        Using the same pricing as nano-banana-pro text-to-image.
+        """
+        # $0.039 per image
+        return 0.039 * inputs.num_images

--- a/packages/backend/tests/generators/implementations/test_nano_banana_pro_edit.py
+++ b/packages/backend/tests/generators/implementations/test_nano_banana_pro_edit.py
@@ -1,0 +1,692 @@
+"""
+Tests for FalNanoBananaProEditGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.nano_banana_pro_edit import (
+    FalNanoBananaProEditGenerator,
+    NanoBananaProEditInput,
+)
+
+
+class TestNanoBananaProEditInput:
+    """Tests for NanoBananaProEditInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image_artifact_1 = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image1.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+        image_artifact_2 = ImageArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/image2.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = NanoBananaProEditInput(
+            prompt="make a photo of the man driving the car",
+            image_sources=[image_artifact_1, image_artifact_2],
+            num_images=2,
+            output_format="jpeg",
+        )
+
+        assert input_data.prompt == "make a photo of the man driving the car"
+        assert len(input_data.image_sources) == 2
+        assert input_data.num_images == 2
+        assert input_data.output_format == "jpeg"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = NanoBananaProEditInput(
+            prompt="Test prompt",
+            image_sources=[image_artifact],
+        )
+
+        assert input_data.num_images == 1
+        assert input_data.output_format == "png"
+        assert input_data.sync_mode is False
+        assert input_data.limit_generations is False
+        assert input_data.aspect_ratio == "auto"
+        assert input_data.resolution == "1K"
+        assert input_data.enable_web_search is False
+
+    def test_prompt_too_short(self):
+        """Test validation fails for prompt that is too short."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            NanoBananaProEditInput(
+                prompt="ab",  # Too short, min_length=3
+                image_sources=[image_artifact],
+            )
+
+    def test_invalid_output_format(self):
+        """Test validation fails for invalid output format."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            NanoBananaProEditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+                output_format="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_aspect_ratio(self):
+        """Test validation fails for invalid aspect ratio."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            NanoBananaProEditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+                aspect_ratio="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_resolution(self):
+        """Test validation fails for invalid resolution."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            NanoBananaProEditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+                resolution="8K",  # type: ignore[arg-type]
+            )
+
+    def test_empty_image_sources(self):
+        """Test validation fails for empty image_sources."""
+        with pytest.raises(ValidationError):
+            NanoBananaProEditInput(
+                prompt="Test prompt",
+                image_sources=[],  # Empty list should fail min_length=1
+            )
+
+    def test_num_images_validation(self):
+        """Test validation for num_images constraints."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            NanoBananaProEditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+                num_images=0,
+            )
+
+        # Test above maximum (max is 4 for nano-banana-pro)
+        with pytest.raises(ValidationError):
+            NanoBananaProEditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+                num_images=5,
+            )
+
+    def test_aspect_ratio_options(self):
+        """Test all valid aspect ratio options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_ratios = [
+            "auto",
+            "21:9",
+            "16:9",
+            "3:2",
+            "4:3",
+            "5:4",
+            "1:1",
+            "4:5",
+            "3:4",
+            "2:3",
+            "9:16",
+        ]
+
+        for ratio in valid_ratios:
+            input_data = NanoBananaProEditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+                aspect_ratio=ratio,  # type: ignore[arg-type]
+            )
+            assert input_data.aspect_ratio == ratio
+
+    def test_resolution_options(self):
+        """Test all valid resolution options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_resolutions = ["1K", "2K", "4K"]
+
+        for resolution in valid_resolutions:
+            input_data = NanoBananaProEditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+                resolution=resolution,  # type: ignore[arg-type]
+            )
+            assert input_data.resolution == resolution
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalNanoBananaProEditGenerator:
+    """Tests for FalNanoBananaProEditGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalNanoBananaProEditGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-nano-banana-pro-edit"
+        assert self.generator.artifact_type == "image"
+        assert "edit" in self.generator.description.lower()
+        assert "nano-banana-pro" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == NanoBananaProEditInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/image.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+
+            input_data = NanoBananaProEditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation with single image output."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = NanoBananaProEditInput(
+            prompt="make the sky more dramatic",
+            image_sources=[input_image],
+            num_images=1,
+            output_format="jpeg",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_description = "Here is a photo with a more dramatic sky."
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 1024,
+                            "height": 768,
+                        }
+                    ],
+                    "description": fake_description,
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=768,
+                format="jpeg",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    # Return a fake local file path
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            mock_fal_client.upload_file_async.assert_called_once_with("/tmp/fake_image.png")
+
+            # Verify API calls with uploaded URL
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/nano-banana-pro/edit",
+                arguments={
+                    "prompt": "make the sky more dramatic",
+                    "image_urls": [fake_uploaded_url],
+                    "num_images": 1,
+                    "aspect_ratio": "auto",
+                    "resolution": "1K",
+                    "output_format": "jpeg",
+                    "sync_mode": False,
+                    "enable_web_search": False,
+                    "limit_generations": False,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_multiple_images(self):
+        """Test successful generation with multiple image outputs."""
+        input_image_1 = ImageArtifact(
+            generation_id="gen_input1",
+            storage_url="https://example.com/input1.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+        input_image_2 = ImageArtifact(
+            generation_id="gen_input2",
+            storage_url="https://example.com/input2.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = NanoBananaProEditInput(
+            prompt="enhance the colors",
+            image_sources=[input_image_1, input_image_2],
+            num_images=2,
+            output_format="png",
+            aspect_ratio="16:9",
+            resolution="2K",
+        )
+
+        fake_output_urls = [
+            "https://storage.googleapis.com/falserverless/output1.png",
+            "https://storage.googleapis.com/falserverless/output2.png",
+        ]
+        fake_uploaded_urls = [
+            "https://fal.media/files/uploaded-input1.png",
+            "https://fal.media/files/uploaded-input2.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {"url": fake_output_urls[0], "width": 1920, "height": 1080},
+                        {"url": fake_output_urls[1], "width": 1920, "height": 1080},
+                    ],
+                    "description": "Enhanced colors applied.",
+                }
+            )
+
+            # Mock file uploads to return different URLs for each file
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_urls[upload_call_count]
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage results
+            mock_artifacts = [
+                ImageArtifact(
+                    generation_id="test_gen",
+                    storage_url=url,
+                    width=1920,
+                    height=1080,
+                    format="png",
+                )
+                for url in fake_output_urls
+            ]
+
+            artifact_idx = 0
+            resolve_call_count = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    nonlocal resolve_call_count
+                    # Return different fake paths for each artifact
+                    path = f"/tmp/fake_image_{resolve_call_count}.png"
+                    resolve_call_count += 1
+                    return path
+
+                async def store_image_result(self, **kwargs):
+                    nonlocal artifact_idx
+                    result = mock_artifacts[artifact_idx]
+                    artifact_idx += 1
+                    return result
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 2
+
+            # Verify file uploads were called for both images
+            assert mock_fal_client.upload_file_async.call_count == 2
+
+            # Verify API call included aspect_ratio, resolution, and uploaded URLs
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["aspect_ratio"] == "16:9"
+            assert call_args[1]["arguments"]["resolution"] == "2K"
+            assert call_args[1]["arguments"]["image_urls"] == fake_uploaded_urls
+
+    @pytest.mark.asyncio
+    async def test_generate_no_images_returned(self):
+        """Test generation fails when API returns no images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = NanoBananaProEditInput(
+            prompt="test prompt",
+            image_sources=[input_image],
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"images": [], "description": ""})
+
+            fake_uploaded_url = "https://fal.media/files/uploaded.png"
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No images returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = NanoBananaProEditInput(
+            prompt="Test prompt",
+            image_sources=[input_image],
+            num_images=1,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.039 * 1)
+        assert cost == 0.039
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_multiple_images(self):
+        """Test cost estimation for multiple images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = NanoBananaProEditInput(
+            prompt="Test prompt",
+            image_sources=[input_image],
+            num_images=4,  # Max for nano-banana-pro
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.039 * 4)
+        assert cost == pytest.approx(0.156)
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = NanoBananaProEditInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "image_sources" in schema["properties"]
+        assert "num_images" in schema["properties"]
+        assert "output_format" in schema["properties"]
+        assert "aspect_ratio" in schema["properties"]
+        assert "resolution" in schema["properties"]
+        assert "enable_web_search" in schema["properties"]
+
+        # Check that image_sources is an array
+        image_sources_prop = schema["properties"]["image_sources"]
+        assert image_sources_prop["type"] == "array"
+        assert "minItems" in image_sources_prop
+
+        # Check that num_images has constraints
+        num_images_prop = schema["properties"]["num_images"]
+        assert num_images_prop["minimum"] == 1
+        assert num_images_prop["maximum"] == 4
+        assert num_images_prop["default"] == 1
+
+        # Check that prompt has length constraints
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop["minLength"] == 3
+        assert prompt_prop["maxLength"] == 50000

--- a/packages/backend/tests/generators/implementations/test_nano_banana_pro_edit_live.py
+++ b/packages/backend/tests/generators/implementations/test_nano_banana_pro_edit_live.py
@@ -1,0 +1,269 @@
+"""
+Live API tests for FalNanoBananaProEditGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_nano_banana_pro_edit_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_nano_banana_pro_edit_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.implementations.fal.image.nano_banana_pro_edit import (
+    FalNanoBananaProEditGenerator,
+    NanoBananaProEditInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestNanoBananaProEditGeneratorLive:
+    """Live API tests for FalNanoBananaProEditGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalNanoBananaProEditGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test basic image editing with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses a small publicly accessible test image to minimize cost.
+        """
+        # Use a small publicly accessible test image (512x512 solid color)
+        test_image_url = "https://placehold.co/512x512/ff0000/ff0000.png"
+
+        # Create test image artifact
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url=test_image_url,
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create minimal input to reduce cost
+        inputs = NanoBananaProEditInput(
+            prompt="Add text 'HELLO' in the center",
+            image_sources=[test_artifact],
+            num_images=1,  # Single image
+            resolution="1K",  # Lowest resolution
+            output_format="jpeg",  # JPEG output
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+        assert artifact.format == "jpeg"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_aspect_ratio(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with specific aspect ratio.
+
+        Verifies that aspect_ratio parameter is correctly processed.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/512x512/00ff00/00ff00.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input2",
+            storage_url=test_image_url,
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create input with landscape aspect ratio
+        inputs = NanoBananaProEditInput(
+            prompt="Change the color to blue",
+            image_sources=[test_artifact],
+            aspect_ratio="16:9",  # Landscape aspect ratio
+            num_images=1,
+            resolution="1K",
+            output_format="jpeg",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url.startswith("https://")
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+
+    @pytest.mark.asyncio
+    async def test_generate_with_multiple_inputs(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with multiple input images.
+
+        Verifies that the generator can process multiple source images.
+        """
+        # Use small test images (different colors)
+        test_artifact_1 = ImageArtifact(
+            generation_id="test_input3a",
+            storage_url="https://placehold.co/256x256/ff0000/ff0000.png",
+            format="png",
+            width=256,
+            height=256,
+        )
+        test_artifact_2 = ImageArtifact(
+            generation_id="test_input3b",
+            storage_url="https://placehold.co/256x256/0000ff/0000ff.png",
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input with multiple source images
+        inputs = NanoBananaProEditInput(
+            prompt="Blend these colors together",
+            image_sources=[test_artifact_1, test_artifact_2],
+            num_images=1,
+            resolution="1K",
+            output_format="jpeg",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url.startswith("https://")
+
+    @pytest.mark.asyncio
+    async def test_generate_batch(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test batch image generation.
+
+        Verifies that multiple images can be generated in a single request.
+        """
+        # Use small test image
+        test_artifact = ImageArtifact(
+            generation_id="test_input4",
+            storage_url="https://placehold.co/512x512/ffff00/ffff00.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create input with small batch (2 images to minimize cost)
+        inputs = NanoBananaProEditInput(
+            prompt="Add geometric shapes",
+            image_sources=[test_artifact],
+            num_images=2,  # Test batch functionality
+            resolution="1K",
+            output_format="jpeg",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify we got 2 images
+        assert result.outputs is not None
+        assert len(result.outputs) == 2
+
+        # Verify both artifacts are valid
+        for artifact in result.outputs:
+            assert isinstance(artifact, ImageArtifact)
+            assert artifact.storage_url is not None
+            assert artifact.storage_url.startswith("https://")
+            if artifact.width is not None:
+                assert artifact.width > 0
+            if artifact.height is not None:
+                assert artifact.height > 0
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_batch_size(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation scales with batch size.
+
+        This doesn't make an API call, just verifies the cost logic.
+        """
+        # Create dummy input (artifact won't be used for estimation)
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url="https://example.com/test.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Single image
+        inputs_1 = NanoBananaProEditInput(
+            prompt="test prompt", image_sources=[test_artifact], num_images=1
+        )
+        cost_1 = await self.generator.estimate_cost(inputs_1)
+
+        # Four images (max for nano-banana-pro)
+        inputs_4 = NanoBananaProEditInput(
+            prompt="test prompt", image_sources=[test_artifact], num_images=4
+        )
+        cost_4 = await self.generator.estimate_cost(inputs_4)
+
+        # Cost should scale linearly with number of images
+        assert cost_4 == cost_1 * 4
+
+        # Sanity check on absolute costs
+        assert cost_1 > 0.0
+        assert cost_1 < 0.1  # Should be well under $0.10 per image


### PR DESCRIPTION
Add FalNanoBananaProEditGenerator for Google's state-of-the-art image editing model accessed via Fal.ai's fal-ai/nano-banana-pro/edit endpoint.

Features:
- Image editing with text prompts
- Multiple input images support
- Resolution options (1K, 2K, 4K)
- Aspect ratio control (auto and preset ratios)
- Web search integration option
- Batch generation (1-4 images)

Includes:
- Generator implementation with artifact upload
- Comprehensive unit tests (19 tests)
- Live API tests for manual verification
- Module exports and configuration