### PR TITLE
Create FAL Flux 2 Edit generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -38,6 +38,9 @@ generators:
   - class: "boards.generators.implementations.fal.audio.fal_elevenlabs_tts_turbo_v2_5.FalElevenlabsTtsTurboV25Generator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.flux_2_edit.FalFlux2EditGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.image.flux_pro_kontext.FalFluxProKontextGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -3,6 +3,7 @@
 from .clarity_upscaler import FalClarityUpscalerGenerator
 from .crystal_upscaler import FalCrystalUpscalerGenerator
 from .fal_ideogram_character import FalIdeogramCharacterGenerator
+from .flux_2_edit import FalFlux2EditGenerator
 from .flux_pro_kontext import FalFluxProKontextGenerator
 from .flux_pro_ultra import FalFluxProUltraGenerator
 from .gemini_25_flash_image import FalGemini25FlashImageGenerator
@@ -22,6 +23,7 @@ from .qwen_image_edit import FalQwenImageEditGenerator
 __all__ = [
     "FalClarityUpscalerGenerator",
     "FalCrystalUpscalerGenerator",
+    "FalFlux2EditGenerator",
     "FalFluxProKontextGenerator",
     "FalFluxProUltraGenerator",
     "FalGemini25FlashImageGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/image/flux_2_edit.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/flux_2_edit.py
@@ -1,0 +1,230 @@
+"""
+fal.ai FLUX.2 [dev] Edit image-to-image editing generator.
+
+Edit images using fal.ai's flux-2/edit model, enabling precise modifications
+using natural language descriptions and hex color control.
+Based on Black Forest Labs' FLUX.2 [dev] model.
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class Flux2EditImageSize(BaseModel):
+    """Custom image size configuration."""
+
+    width: int = Field(ge=512, le=2048, description="Image width (512-2048)")
+    height: int = Field(ge=512, le=2048, description="Image height (512-2048)")
+
+
+class Flux2EditInput(BaseModel):
+    """Input schema for FLUX.2 [dev] Edit image editing.
+
+    Artifact fields (like image_sources) are automatically detected via type
+    introspection and resolved from generation IDs to ImageArtifact objects.
+    """
+
+    prompt: str = Field(
+        description="Editing instruction (e.g., 'Change his clothes to casual suit and tie')"
+    )
+    image_sources: list[ImageArtifact] = Field(
+        description="List of input images for editing (max 3 images)",
+        min_length=1,
+        max_length=3,
+    )
+    num_images: int = Field(
+        default=1,
+        ge=1,
+        le=4,
+        description="Number of output images to generate (1-4)",
+    )
+    image_size: (
+        Literal["square_hd", "portrait_4_3", "landscape_16_9"] | Flux2EditImageSize | None
+    ) = Field(
+        default=None,
+        description=(
+            "Output image size - predefined (square_hd, portrait_4_3, landscape_16_9) "
+            "or custom dimensions"
+        ),
+    )
+    acceleration: Literal["none", "regular", "high"] = Field(
+        default="regular",
+        description="Acceleration mode for generation speed/quality tradeoff",
+    )
+    num_inference_steps: int = Field(
+        default=28,
+        ge=4,
+        le=50,
+        description="Number of inference steps (4-50, higher = better quality but slower)",
+    )
+    output_format: Literal["jpeg", "png", "webp"] = Field(
+        default="png",
+        description="Output image format",
+    )
+    guidance_scale: float = Field(
+        default=2.5,
+        ge=0.0,
+        le=20.0,
+        description="Guidance scale for generation (0-20)",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Random seed for reproducible outputs",
+    )
+    enable_prompt_expansion: bool = Field(
+        default=False,
+        description="Enable automatic prompt expansion for better results",
+    )
+    enable_safety_checker: bool = Field(
+        default=True,
+        description="Enable safety checker to filter NSFW content",
+    )
+    sync_mode: bool = Field(
+        default=False,
+        description="If True, return data URI instead of URL (output won't be in request history)",
+    )
+
+
+class FalFlux2EditGenerator(BaseGenerator):
+    """FLUX.2 [dev] Edit image-to-image generator using fal.ai."""
+
+    name = "fal-flux-2-edit"
+    artifact_type = "image"
+    description = "Fal: FLUX.2 [dev] Edit - Precise image editing with natural language"
+
+    def get_input_schema(self) -> type[Flux2EditInput]:
+        return Flux2EditInput
+
+    async def generate(
+        self, inputs: Flux2EditInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Edit images using fal.ai flux-2/edit model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalFlux2EditGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifacts to Fal's public storage
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal(inputs.image_sources, context)
+
+        # Prepare arguments for fal.ai API
+        arguments: dict[str, object] = {
+            "prompt": inputs.prompt,
+            "image_urls": image_urls,
+            "num_images": inputs.num_images,
+            "acceleration": inputs.acceleration,
+            "num_inference_steps": inputs.num_inference_steps,
+            "output_format": inputs.output_format,
+            "guidance_scale": inputs.guidance_scale,
+            "enable_prompt_expansion": inputs.enable_prompt_expansion,
+            "enable_safety_checker": inputs.enable_safety_checker,
+            "sync_mode": inputs.sync_mode,
+        }
+
+        # Add optional fields if provided
+        if inputs.image_size is not None:
+            if isinstance(inputs.image_size, str):
+                arguments["image_size"] = inputs.image_size
+            else:
+                # Custom size object
+                arguments["image_size"] = {
+                    "width": inputs.image_size.width,
+                    "height": inputs.image_size.height,
+                }
+
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/flux-2/edit",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image URLs from result
+        # fal.ai returns: {"images": [{"url": "...", "width": ..., "height": ...}, ...]}
+        images = result.get("images", [])
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url_result = image_data.get("url")
+            width = image_data.get("width", 1024)
+            height = image_data.get("height", 1024)
+
+            if not image_url_result:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Store with appropriate output_index
+            artifact = await context.store_image_result(
+                storage_url=image_url_result,
+                format=inputs.output_format,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: Flux2EditInput) -> float:
+        """Estimate cost for FLUX.2 Edit generation.
+
+        FLUX.2 [dev] Edit is a premium image editing model. Estimated cost
+        is approximately $0.06 per image based on similar Flux models.
+        """
+        # Cost per image * number of images
+        cost_per_image = 0.06
+        return cost_per_image * inputs.num_images

--- a/packages/backend/tests/generators/implementations/test_flux_2_edit.py
+++ b/packages/backend/tests/generators/implementations/test_flux_2_edit.py
@@ -1,0 +1,857 @@
+"""
+Tests for FalFlux2EditGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.flux_2_edit import (
+    FalFlux2EditGenerator,
+    Flux2EditImageSize,
+    Flux2EditInput,
+)
+
+
+class TestFlux2EditInput:
+    """Tests for Flux2EditInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image_artifact_1 = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image1.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+        image_artifact_2 = ImageArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/image2.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2EditInput(
+            prompt="Change the background to a sunset",
+            image_sources=[image_artifact_1, image_artifact_2],
+            num_images=2,
+            output_format="jpeg",
+        )
+
+        assert input_data.prompt == "Change the background to a sunset"
+        assert len(input_data.image_sources) == 2
+        assert input_data.num_images == 2
+        assert input_data.output_format == "jpeg"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2EditInput(
+            prompt="Test prompt",
+            image_sources=[image_artifact],
+        )
+
+        assert input_data.num_images == 1
+        assert input_data.output_format == "png"
+        assert input_data.acceleration == "regular"
+        assert input_data.num_inference_steps == 28
+        assert input_data.guidance_scale == 2.5
+        assert input_data.enable_prompt_expansion is False
+        assert input_data.enable_safety_checker is True
+        assert input_data.sync_mode is False
+        assert input_data.image_size is None
+        assert input_data.seed is None
+
+    def test_invalid_output_format(self):
+        """Test validation fails for invalid output format."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            Flux2EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                output_format="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_acceleration(self):
+        """Test validation fails for invalid acceleration mode."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            Flux2EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                acceleration="turbo",  # type: ignore[arg-type]
+            )
+
+    def test_empty_image_sources(self):
+        """Test validation fails for empty image_sources."""
+        with pytest.raises(ValidationError):
+            Flux2EditInput(
+                prompt="Test",
+                image_sources=[],  # Empty list should fail min_length=1
+            )
+
+    def test_too_many_image_sources(self):
+        """Test validation fails for more than 3 image sources."""
+        artifacts = [
+            ImageArtifact(
+                generation_id=f"gen{i}",
+                storage_url=f"https://example.com/image{i}.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+            for i in range(4)  # 4 images - exceeds max_length=3
+        ]
+
+        with pytest.raises(ValidationError):
+            Flux2EditInput(
+                prompt="Test",
+                image_sources=artifacts,
+            )
+
+    def test_num_images_validation(self):
+        """Test validation for num_images constraints."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            Flux2EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                num_images=0,
+            )
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            Flux2EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                num_images=5,
+            )
+
+    def test_num_inference_steps_validation(self):
+        """Test validation for num_inference_steps constraints."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            Flux2EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                num_inference_steps=3,
+            )
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            Flux2EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                num_inference_steps=51,
+            )
+
+    def test_guidance_scale_validation(self):
+        """Test validation for guidance_scale constraints."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            Flux2EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                guidance_scale=-1.0,
+            )
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            Flux2EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                guidance_scale=21.0,
+            )
+
+    def test_image_size_predefined(self):
+        """Test predefined image size options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_sizes = ["square_hd", "portrait_4_3", "landscape_16_9"]
+
+        for size in valid_sizes:
+            input_data = Flux2EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                image_size=size,  # type: ignore[arg-type]
+            )
+            assert input_data.image_size == size
+
+    def test_image_size_custom(self):
+        """Test custom image size configuration."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        custom_size = Flux2EditImageSize(width=1024, height=768)
+        input_data = Flux2EditInput(
+            prompt="Test",
+            image_sources=[image_artifact],
+            image_size=custom_size,
+        )
+        assert isinstance(input_data.image_size, Flux2EditImageSize)
+        assert input_data.image_size.width == 1024
+        assert input_data.image_size.height == 768
+
+    def test_custom_image_size_validation(self):
+        """Test custom image size validation constraints."""
+        # Test width below minimum
+        with pytest.raises(ValidationError):
+            Flux2EditImageSize(width=256, height=1024)
+
+        # Test width above maximum
+        with pytest.raises(ValidationError):
+            Flux2EditImageSize(width=4096, height=1024)
+
+        # Test height below minimum
+        with pytest.raises(ValidationError):
+            Flux2EditImageSize(width=1024, height=256)
+
+        # Test height above maximum
+        with pytest.raises(ValidationError):
+            Flux2EditImageSize(width=1024, height=4096)
+
+    def test_acceleration_options(self):
+        """Test all valid acceleration options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_options = ["none", "regular", "high"]
+
+        for option in valid_options:
+            input_data = Flux2EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                acceleration=option,  # type: ignore[arg-type]
+            )
+            assert input_data.acceleration == option
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalFlux2EditGenerator:
+    """Tests for FalFlux2EditGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalFlux2EditGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-flux-2-edit"
+        assert self.generator.artifact_type == "image"
+        assert "FLUX" in self.generator.description
+        assert "Edit" in self.generator.description
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == Flux2EditInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/image.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+
+            input_data = Flux2EditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation with single image output."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2EditInput(
+            prompt="Change his clothes to casual suit and tie",
+            image_sources=[input_image],
+            num_images=1,
+            output_format="jpeg",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 1024,
+                            "height": 768,
+                        }
+                    ],
+                    "seed": 12345,
+                    "has_nsfw_concepts": [False],
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=768,
+                format="jpeg",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    # Return a fake local file path
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            mock_fal_client.upload_file_async.assert_called_once_with("/tmp/fake_image.png")
+
+            # Verify API calls with uploaded URL
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/flux-2/edit",
+                arguments={
+                    "prompt": "Change his clothes to casual suit and tie",
+                    "image_urls": [fake_uploaded_url],
+                    "num_images": 1,
+                    "acceleration": "regular",
+                    "num_inference_steps": 28,
+                    "output_format": "jpeg",
+                    "guidance_scale": 2.5,
+                    "enable_prompt_expansion": False,
+                    "enable_safety_checker": True,
+                    "sync_mode": False,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_multiple_images(self):
+        """Test successful generation with multiple image outputs."""
+        input_image_1 = ImageArtifact(
+            generation_id="gen_input1",
+            storage_url="https://example.com/input1.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+        input_image_2 = ImageArtifact(
+            generation_id="gen_input2",
+            storage_url="https://example.com/input2.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = Flux2EditInput(
+            prompt="Add a dramatic sky",
+            image_sources=[input_image_1, input_image_2],
+            num_images=2,
+            output_format="png",
+            image_size="landscape_16_9",
+        )
+
+        fake_output_urls = [
+            "https://storage.googleapis.com/falserverless/output1.png",
+            "https://storage.googleapis.com/falserverless/output2.png",
+        ]
+        fake_uploaded_urls = [
+            "https://fal.media/files/uploaded-input1.png",
+            "https://fal.media/files/uploaded-input2.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {"url": fake_output_urls[0], "width": 1920, "height": 1080},
+                        {"url": fake_output_urls[1], "width": 1920, "height": 1080},
+                    ],
+                    "seed": 54321,
+                    "has_nsfw_concepts": [False, False],
+                }
+            )
+
+            # Mock file uploads to return different URLs for each file
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_urls[upload_call_count]
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage results
+            mock_artifacts = [
+                ImageArtifact(
+                    generation_id="test_gen",
+                    storage_url=url,
+                    width=1920,
+                    height=1080,
+                    format="png",
+                )
+                for url in fake_output_urls
+            ]
+
+            artifact_idx = 0
+            resolve_call_count = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    nonlocal resolve_call_count
+                    # Return different fake paths for each artifact
+                    path = f"/tmp/fake_image_{resolve_call_count}.png"
+                    resolve_call_count += 1
+                    return path
+
+                async def store_image_result(self, **kwargs):
+                    nonlocal artifact_idx
+                    result = mock_artifacts[artifact_idx]
+                    artifact_idx += 1
+                    return result
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 2
+
+            # Verify file uploads were called for both images
+            assert mock_fal_client.upload_file_async.call_count == 2
+
+            # Verify API call included image_size and uploaded URLs
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["image_size"] == "landscape_16_9"
+            assert call_args[1]["arguments"]["image_urls"] == fake_uploaded_urls
+
+    @pytest.mark.asyncio
+    async def test_generate_with_custom_image_size(self):
+        """Test generation with custom image size dimensions."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        custom_size = Flux2EditImageSize(width=1024, height=768)
+        input_data = Flux2EditInput(
+            prompt="Enhance details",
+            image_sources=[input_image],
+            num_images=1,
+            output_format="png",
+            image_size=custom_size,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [{"url": fake_output_url, "width": 1024, "height": 768}],
+                    "seed": 99999,
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=768,
+                format="png",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify API call included custom image_size as object
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["image_size"] == {"width": 1024, "height": 768}
+
+    @pytest.mark.asyncio
+    async def test_generate_no_images_returned(self):
+        """Test generation fails when API returns no images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2EditInput(
+            prompt="test",
+            image_sources=[input_image],
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-999"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"images": []})
+
+            fake_uploaded_url = "https://fal.media/files/uploaded.png"
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No images returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2EditInput(
+            prompt="Test prompt",
+            image_sources=[input_image],
+            num_images=1,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.06 * 1)
+        assert cost == 0.06
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_multiple_images(self):
+        """Test cost estimation for multiple images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2EditInput(
+            prompt="Test prompt",
+            image_sources=[input_image],
+            num_images=4,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.06 * 4)
+        assert cost == 0.24
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = Flux2EditInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "image_sources" in schema["properties"]
+        assert "num_images" in schema["properties"]
+        assert "output_format" in schema["properties"]
+        assert "acceleration" in schema["properties"]
+        assert "num_inference_steps" in schema["properties"]
+        assert "guidance_scale" in schema["properties"]
+        assert "image_size" in schema["properties"]
+
+        # Check that image_sources is an array with constraints
+        image_sources_prop = schema["properties"]["image_sources"]
+        assert image_sources_prop["type"] == "array"
+        assert "minItems" in image_sources_prop
+        assert "maxItems" in image_sources_prop
+        assert image_sources_prop["minItems"] == 1
+        assert image_sources_prop["maxItems"] == 3
+
+        # Check that num_images has constraints
+        num_images_prop = schema["properties"]["num_images"]
+        assert num_images_prop["minimum"] == 1
+        assert num_images_prop["maximum"] == 4
+        assert num_images_prop["default"] == 1
+
+        # Check that num_inference_steps has constraints
+        inference_steps_prop = schema["properties"]["num_inference_steps"]
+        assert inference_steps_prop["minimum"] == 4
+        assert inference_steps_prop["maximum"] == 50
+        assert inference_steps_prop["default"] == 28
+
+        # Check that guidance_scale has constraints
+        guidance_prop = schema["properties"]["guidance_scale"]
+        assert guidance_prop["minimum"] == 0.0
+        assert guidance_prop["maximum"] == 20.0
+        assert guidance_prop["default"] == 2.5

--- a/packages/backend/tests/generators/implementations/test_flux_2_edit_live.py
+++ b/packages/backend/tests/generators/implementations/test_flux_2_edit_live.py
@@ -1,0 +1,210 @@
+"""
+Live API tests for FalFlux2EditGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_flux_2_edit_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_flux_2_edit_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.implementations.fal.image.flux_2_edit import (
+    FalFlux2EditGenerator,
+    Flux2EditInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestFlux2EditGeneratorLive:
+    """Live API tests for FalFlux2EditGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalFlux2EditGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test basic image editing with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses a small publicly accessible test image to minimize cost.
+        """
+        # Use a small publicly accessible test image (256x256 solid color)
+        test_image_url = "https://placehold.co/256x256/ff0000/ff0000.png"
+
+        # Create test image artifact
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create minimal input to reduce cost
+        inputs = Flux2EditInput(
+            prompt="Add a small white circle in the center",
+            image_sources=[test_artifact],
+            num_images=1,  # Single image
+            output_format="jpeg",  # JPEG is cheaper than PNG
+            acceleration="high",  # Faster and potentially cheaper
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+        assert artifact.format == "jpeg"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_custom_parameters(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with custom parameters.
+
+        Verifies that acceleration and guidance_scale parameters are correctly processed.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/256x256/00ff00/00ff00.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input2",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input with specific parameters
+        inputs = Flux2EditInput(
+            prompt="Make it blue",
+            image_sources=[test_artifact],
+            num_images=1,
+            output_format="jpeg",
+            acceleration="regular",
+            guidance_scale=5.0,
+            num_inference_steps=20,  # Fewer steps for faster/cheaper generation
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Create dummy input (artifact won't be used for estimation)
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url="https://example.com/test.png",
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Single image
+        inputs_1 = Flux2EditInput(prompt="test", image_sources=[test_artifact], num_images=1)
+        cost_1 = await self.generator.estimate_cost(inputs_1)
+
+        # Multiple images
+        inputs_4 = Flux2EditInput(prompt="test", image_sources=[test_artifact], num_images=4)
+        cost_4 = await self.generator.estimate_cost(inputs_4)
+
+        # Cost should scale linearly with number of images
+        assert cost_4 == cost_1 * 4
+
+        # Sanity check on absolute costs
+        assert cost_1 > 0.0
+        assert cost_1 < 0.2  # Should be under $0.20 per image (estimated at ~$0.06)
+
+    @pytest.mark.asyncio
+    async def test_generate_with_seed(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with fixed seed for reproducibility.
+
+        Note: This test verifies seed is accepted, but doesn't verify
+        reproducibility (would require 2 API calls).
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/256x256/0000ff/0000ff.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input3",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input with specific seed
+        inputs = Flux2EditInput(
+            prompt="Add yellow stars",
+            image_sources=[test_artifact],
+            seed=42,  # Fixed seed
+            num_images=1,
+            output_format="jpeg",
+            acceleration="high",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result (seed doesn't affect output structure, just determinism)
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+        assert result.outputs[0].storage_url is not None


### PR DESCRIPTION
Create new Fal AI generator for fal-ai/flux-2/edit model, enabling precise image modifications using natural language descriptions.

Features:
- Support for 1-3 input images with automatic artifact resolution
- Configurable output size (predefined or custom dimensions 512-2048)
- Multiple acceleration modes (none/regular/high)
- Customizable inference steps, guidance scale, and seed
- Safety checker and prompt expansion options
- Cost estimation at $0.06 per output image

Includes comprehensive unit tests (23 tests) and live API tests.