### PR TITLE
Create FAL Flux 2 Pro edit generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -47,6 +47,9 @@ generators:
   - class: "boards.generators.implementations.fal.image.flux_2_pro.FalFlux2ProGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.flux_2_pro_edit.FalFlux2ProEditGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.image.flux_pro_kontext.FalFluxProKontextGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -6,6 +6,7 @@ from .fal_ideogram_character import FalIdeogramCharacterGenerator
 from .flux_2 import FalFlux2Generator
 from .flux_2_edit import FalFlux2EditGenerator
 from .flux_2_pro import FalFlux2ProGenerator
+from .flux_2_pro_edit import FalFlux2ProEditGenerator
 from .flux_pro_kontext import FalFluxProKontextGenerator
 from .flux_pro_ultra import FalFluxProUltraGenerator
 from .gemini_25_flash_image import FalGemini25FlashImageGenerator
@@ -28,6 +29,7 @@ __all__ = [
     "FalFlux2Generator",
     "FalFlux2EditGenerator",
     "FalFlux2ProGenerator",
+    "FalFlux2ProEditGenerator",
     "FalFluxProKontextGenerator",
     "FalFluxProUltraGenerator",
     "FalGemini25FlashImageGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/image/flux_2_pro_edit.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/flux_2_pro_edit.py
@@ -1,0 +1,221 @@
+"""
+fal.ai FLUX 2 Pro Edit generator.
+
+Production-grade multi-reference image editing that combines up to 9 reference
+images through a streamlined pipeline for professional image manipulation.
+Supports natural language precision, explicit image indexing with @ symbol,
+and zero-configuration workflow.
+
+Based on Fal AI's fal-ai/flux-2-pro/edit model.
+See: https://fal.ai/models/fal-ai/flux-2-pro/edit
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+# Image size presets supported by the API
+ImageSizePreset = Literal[
+    "auto",
+    "square_hd",
+    "square",
+    "portrait_4_3",
+    "portrait_16_9",
+    "landscape_4_3",
+    "landscape_16_9",
+]
+
+
+class Flux2ProEditInput(BaseModel):
+    """Input schema for FLUX 2 Pro Edit.
+
+    Artifact fields (like image_sources) are automatically detected via type
+    introspection and resolved from generation IDs to ImageArtifact objects.
+    """
+
+    prompt: str = Field(
+        description="The prompt to edit the images. Use @ symbol to reference "
+        "specific input images by index (e.g., '@1' for first image)."
+    )
+    image_sources: list[ImageArtifact] = Field(
+        description="List of input images for editing (up to 9 images, 9 MP total)",
+        min_length=1,
+        max_length=9,
+    )
+    image_size: ImageSizePreset | None = Field(
+        default="auto",
+        description="The size of the generated image. If 'auto', the size will be "
+        "determined by the model based on input images.",
+    )
+    output_format: Literal["jpeg", "png"] = Field(
+        default="jpeg",
+        description="The format of the generated image.",
+    )
+    sync_mode: bool = Field(
+        default=False,
+        description=(
+            "If True, the media will be returned as a data URI and the output "
+            "data won't be available in the request history."
+        ),
+    )
+    safety_tolerance: Literal[1, 2, 3, 4, 5] = Field(
+        default=2,
+        description=(
+            "The safety tolerance level for the generated image. "
+            "1 is most strict, 5 is most permissive."
+        ),
+    )
+    enable_safety_checker: bool = Field(
+        default=True,
+        description="Whether to enable the safety checker.",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="The seed to use for the generation. Leave empty for random.",
+    )
+
+
+class FalFlux2ProEditGenerator(BaseGenerator):
+    """FLUX 2 Pro Edit image generator using fal.ai.
+
+    Production-grade multi-reference editing that combines up to 9 reference
+    images through a streamlined pipeline. Supports natural language precision
+    for describing complex edits without masks.
+    """
+
+    name = "fal-flux-2-pro-edit"
+    artifact_type = "image"
+    description = "Fal: FLUX 2 Pro Edit - Production-grade multi-reference image editing"
+
+    def get_input_schema(self) -> type[Flux2ProEditInput]:
+        return Flux2ProEditInput
+
+    async def generate(
+        self, inputs: Flux2ProEditInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Edit images using fal.ai FLUX 2 Pro Edit model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalFlux2ProEditGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifacts to Fal's public storage
+        # Fal API requires publicly accessible URLs, but our storage_url might be:
+        # - Localhost URLs (not publicly accessible)
+        # - Private S3 buckets (not publicly accessible)
+        # So we upload to Fal's temporary storage first
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal(inputs.image_sources, context)
+
+        # Prepare arguments for fal.ai API
+        arguments: dict = {
+            "prompt": inputs.prompt,
+            "image_urls": image_urls,
+            "output_format": inputs.output_format,
+            "sync_mode": inputs.sync_mode,
+            "safety_tolerance": inputs.safety_tolerance,
+            "enable_safety_checker": inputs.enable_safety_checker,
+        }
+
+        # Add optional parameters
+        if inputs.image_size is not None:
+            arguments["image_size"] = inputs.image_size
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/flux-2-pro/edit",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image URLs from result
+        # fal.ai returns: {
+        #   "images": [{"url": "...", "width": ..., "height": ..., ...}, ...],
+        #   "seed": ...
+        # }
+        images = result.get("images", [])
+
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url = image_data.get("url")
+            # Extract dimensions if available, otherwise use sensible defaults
+            width = image_data.get("width", 1024)
+            height = image_data.get("height", 1024)
+
+            if not image_url:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Store with appropriate output_index
+            artifact = await context.store_image_result(
+                storage_url=image_url,
+                format=inputs.output_format,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: Flux2ProEditInput) -> float:
+        """Estimate cost for FLUX 2 Pro Edit generation.
+
+        Pricing: $0.03 for first megapixel, $0.015 for additional megapixels.
+        Using base cost of $0.03 as default (1 MP output).
+        """
+        # Base cost per generation (1 megapixel default)
+        base_cost = 0.03
+        return base_cost

--- a/packages/backend/tests/generators/implementations/test_flux_2_pro_edit.py
+++ b/packages/backend/tests/generators/implementations/test_flux_2_pro_edit.py
@@ -1,0 +1,697 @@
+"""
+Tests for FalFlux2ProEditGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.flux_2_pro_edit import (
+    FalFlux2ProEditGenerator,
+    Flux2ProEditInput,
+)
+
+
+class TestFlux2ProEditInput:
+    """Tests for Flux2ProEditInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image_artifact_1 = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image1.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+        image_artifact_2 = ImageArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/image2.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2ProEditInput(
+            prompt="Combine @1 and @2 into a single scene",
+            image_sources=[image_artifact_1, image_artifact_2],
+            image_size="square_hd",
+            output_format="png",
+        )
+
+        assert input_data.prompt == "Combine @1 and @2 into a single scene"
+        assert len(input_data.image_sources) == 2
+        assert input_data.image_size == "square_hd"
+        assert input_data.output_format == "png"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2ProEditInput(
+            prompt="Test prompt",
+            image_sources=[image_artifact],
+        )
+
+        assert input_data.image_size == "auto"
+        assert input_data.output_format == "jpeg"
+        assert input_data.sync_mode is False
+        assert input_data.safety_tolerance == 2
+        assert input_data.enable_safety_checker is True
+        assert input_data.seed is None
+
+    def test_invalid_output_format(self):
+        """Test validation fails for invalid output format."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            Flux2ProEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                output_format="webp",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_image_size(self):
+        """Test validation fails for invalid image size."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            Flux2ProEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                image_size="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_safety_tolerance(self):
+        """Test validation fails for invalid safety tolerance."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            Flux2ProEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                safety_tolerance=0,  # type: ignore[arg-type]
+            )
+
+        with pytest.raises(ValidationError):
+            Flux2ProEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                safety_tolerance=6,  # type: ignore[arg-type]
+            )
+
+    def test_empty_image_sources(self):
+        """Test validation fails for empty image_sources."""
+        with pytest.raises(ValidationError):
+            Flux2ProEditInput(
+                prompt="Test",
+                image_sources=[],  # Empty list should fail min_length=1
+            )
+
+    def test_too_many_image_sources(self):
+        """Test validation fails for more than 9 images."""
+        image_artifacts = [
+            ImageArtifact(
+                generation_id=f"gen{i}",
+                storage_url=f"https://example.com/image{i}.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+            for i in range(10)  # 10 images should fail
+        ]
+
+        with pytest.raises(ValidationError):
+            Flux2ProEditInput(
+                prompt="Test",
+                image_sources=image_artifacts,
+            )
+
+    def test_image_size_options(self):
+        """Test all valid image size options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_sizes = [
+            "auto",
+            "square_hd",
+            "square",
+            "portrait_4_3",
+            "portrait_16_9",
+            "landscape_4_3",
+            "landscape_16_9",
+        ]
+
+        for size in valid_sizes:
+            input_data = Flux2ProEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                image_size=size,  # type: ignore[arg-type]
+            )
+            assert input_data.image_size == size
+
+    def test_safety_tolerance_options(self):
+        """Test all valid safety tolerance options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        for tolerance in [1, 2, 3, 4, 5]:
+            input_data = Flux2ProEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                safety_tolerance=tolerance,  # type: ignore[arg-type]
+            )
+            assert input_data.safety_tolerance == tolerance
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalFlux2ProEditGenerator:
+    """Tests for FalFlux2ProEditGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalFlux2ProEditGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-flux-2-pro-edit"
+        assert self.generator.artifact_type == "image"
+        assert "FLUX 2 Pro Edit" in self.generator.description
+        assert "multi-reference" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == Flux2ProEditInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/image.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+
+            input_data = Flux2ProEditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation with single image output."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2ProEditInput(
+            prompt="enhance the colors in @1",
+            image_sources=[input_image],
+            output_format="jpeg",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 1024,
+                            "height": 768,
+                        }
+                    ],
+                    "seed": 12345,
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=768,
+                format="jpeg",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    # Return a fake local file path
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            mock_fal_client.upload_file_async.assert_called_once_with("/tmp/fake_image.png")
+
+            # Verify API calls with uploaded URL
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/flux-2-pro/edit",
+                arguments={
+                    "prompt": "enhance the colors in @1",
+                    "image_urls": [fake_uploaded_url],  # Should use uploaded URL, not original
+                    "output_format": "jpeg",
+                    "sync_mode": False,
+                    "safety_tolerance": 2,
+                    "enable_safety_checker": True,
+                    "image_size": "auto",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_multiple_images(self):
+        """Test successful generation with multiple input images."""
+        input_image_1 = ImageArtifact(
+            generation_id="gen_input1",
+            storage_url="https://example.com/input1.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+        input_image_2 = ImageArtifact(
+            generation_id="gen_input2",
+            storage_url="https://example.com/input2.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = Flux2ProEditInput(
+            prompt="combine @1 and @2 into a composite",
+            image_sources=[input_image_1, input_image_2],
+            image_size="landscape_16_9",
+            output_format="png",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_urls = [
+            "https://fal.media/files/uploaded-input1.png",
+            "https://fal.media/files/uploaded-input2.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {"url": fake_output_url, "width": 1920, "height": 1080},
+                    ],
+                    "seed": 67890,
+                }
+            )
+
+            # Mock file uploads to return different URLs for each file
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_urls[upload_call_count]
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1920,
+                height=1080,
+                format="png",
+            )
+
+            resolve_call_count = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    nonlocal resolve_call_count
+                    # Return different fake paths for each artifact
+                    path = f"/tmp/fake_image_{resolve_call_count}.png"
+                    resolve_call_count += 1
+                    return path
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify file uploads were called for both images
+            assert mock_fal_client.upload_file_async.call_count == 2
+
+            # Verify API call included image_size and uploaded URLs
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["image_size"] == "landscape_16_9"
+            assert call_args[1]["arguments"]["image_urls"] == fake_uploaded_urls
+
+    @pytest.mark.asyncio
+    async def test_generate_with_seed(self):
+        """Test generation with specified seed."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2ProEditInput(
+            prompt="test prompt",
+            image_sources=[input_image],
+            seed=42,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-seed"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [{"url": fake_output_url, "width": 1024, "height": 768}],
+                    "seed": 42,
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=768,
+                format="jpeg",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            await self.generator.generate(input_data, DummyCtx())
+
+            # Verify seed was included in API call
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["seed"] == 42
+
+    @pytest.mark.asyncio
+    async def test_generate_no_images_returned(self):
+        """Test generation fails when API returns no images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2ProEditInput(
+            prompt="test",
+            image_sources=[input_image],
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"images": [], "seed": 0})
+
+            fake_uploaded_url = "https://fal.media/files/uploaded.png"
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No images returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Flux2ProEditInput(
+            prompt="Test prompt",
+            image_sources=[input_image],
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Base cost for 1 megapixel is $0.03
+        assert cost == 0.03
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = Flux2ProEditInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "image_sources" in schema["properties"]
+        assert "image_size" in schema["properties"]
+        assert "output_format" in schema["properties"]
+        assert "safety_tolerance" in schema["properties"]
+        assert "seed" in schema["properties"]
+
+        # Check that image_sources is an array with constraints
+        image_sources_prop = schema["properties"]["image_sources"]
+        assert image_sources_prop["type"] == "array"
+        assert "minItems" in image_sources_prop
+        assert image_sources_prop["minItems"] == 1
+        assert "maxItems" in image_sources_prop
+        assert image_sources_prop["maxItems"] == 9

--- a/packages/backend/tests/generators/implementations/test_flux_2_pro_edit_live.py
+++ b/packages/backend/tests/generators/implementations/test_flux_2_pro_edit_live.py
@@ -1,0 +1,247 @@
+"""
+Live API tests for FalFlux2ProEditGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_flux_2_pro_edit_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_flux_2_pro_edit_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.implementations.fal.image.flux_2_pro_edit import (
+    FalFlux2ProEditGenerator,
+    Flux2ProEditInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestFlux2ProEditGeneratorLive:
+    """Live API tests for FalFlux2ProEditGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalFlux2ProEditGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test basic image editing with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses a small publicly accessible test image to minimize cost.
+        """
+        # Use a small publicly accessible test image (256x256 solid color)
+        test_image_url = "https://placehold.co/256x256/ff0000/ff0000.png"
+
+        # Create test image artifact
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create minimal input to reduce cost
+        inputs = Flux2ProEditInput(
+            prompt="Add a small white circle in the center",
+            image_sources=[test_artifact],
+            output_format="jpeg",  # JPEG is cheaper than PNG
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+        assert artifact.format == "jpeg"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_multiple_images(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with multiple input images.
+
+        Verifies that multi-reference editing works with @ symbol references.
+        """
+        # Use small test images
+        test_image_1 = ImageArtifact(
+            generation_id="test_input1",
+            storage_url="https://placehold.co/256x256/ff0000/ff0000.png",
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        test_image_2 = ImageArtifact(
+            generation_id="test_input2",
+            storage_url="https://placehold.co/256x256/0000ff/0000ff.png",
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input with multiple images and explicit references
+        inputs = Flux2ProEditInput(
+            prompt="Blend @1 and @2 together",
+            image_sources=[test_image_1, test_image_2],
+            output_format="jpeg",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+
+    @pytest.mark.asyncio
+    async def test_generate_with_image_size(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with specific image size preset.
+
+        Verifies that image_size parameter is correctly processed.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/256x256/00ff00/00ff00.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input with specific image size
+        inputs = Flux2ProEditInput(
+            prompt="Make it more vibrant",
+            image_sources=[test_artifact],
+            image_size="square",
+            output_format="jpeg",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Create dummy input (artifact won't be used for estimation)
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url="https://example.com/test.png",
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        inputs = Flux2ProEditInput(
+            prompt="test",
+            image_sources=[test_artifact],
+        )
+        cost = await self.generator.estimate_cost(inputs)
+
+        # Sanity check on absolute costs
+        # Base cost is $0.03 per megapixel
+        assert cost > 0.0
+        assert cost == 0.03  # Base cost for 1 MP
+
+    @pytest.mark.asyncio
+    async def test_generate_with_seed(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with fixed seed for reproducibility.
+
+        Note: This test verifies seed is accepted, but doesn't verify
+        reproducibility (would require 2 API calls).
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/256x256/ffff00/ffff00.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input with specific seed
+        inputs = Flux2ProEditInput(
+            prompt="Add subtle texture",
+            image_sources=[test_artifact],
+            seed=42,  # Fixed seed
+            output_format="jpeg",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result (seed doesn't affect output structure, just determinism)
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+        assert result.outputs[0].storage_url is not None


### PR DESCRIPTION
Add fal-ai/flux-2-pro/edit generator for production-grade multi-reference image editing. Supports up to 9 input images with @ symbol references, natural language precision editing, and zero-configuration workflow.

- Generator implementation with Fal AI integration
- Unit tests with comprehensive input validation coverage
- Live API tests for real API verification
- Module exports and configuration updates