### PR TITLE
Create FAL generator for ByteDance SeedDream edit

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -32,6 +32,9 @@ generators:
   - class: "boards.generators.implementations.fal.video.bytedance_seedance_v1_pro_text_to_video.FalBytedanceSeedanceV1ProTextToVideoGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.bytedance_seedream_v45_edit.FalBytedanceSeedreamV45EditGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.audio.elevenlabs_tts_eleven_v3.FalElevenlabsTtsElevenV3Generator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -1,5 +1,6 @@
 """Fal.ai image generators."""
 
+from .bytedance_seedream_v45_edit import FalBytedanceSeedreamV45EditGenerator
 from .clarity_upscaler import FalClarityUpscalerGenerator
 from .crystal_upscaler import FalCrystalUpscalerGenerator
 from .fal_ideogram_character import FalIdeogramCharacterGenerator
@@ -24,6 +25,7 @@ from .qwen_image import FalQwenImageGenerator
 from .qwen_image_edit import FalQwenImageEditGenerator
 
 __all__ = [
+    "FalBytedanceSeedreamV45EditGenerator",
     "FalClarityUpscalerGenerator",
     "FalCrystalUpscalerGenerator",
     "FalFlux2Generator",

--- a/packages/backend/src/boards/generators/implementations/fal/image/bytedance_seedream_v45_edit.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/bytedance_seedream_v45_edit.py
@@ -1,0 +1,219 @@
+"""
+fal.ai ByteDance Seedream v4.5 Edit image editing generator.
+
+Edit images using fal.ai's ByteDance Seedream v4.5 Edit model.
+A new-generation image creation model that integrates image generation
+and image editing capabilities into a single, unified architecture.
+Supports editing up to 10 input images with a text prompt.
+
+See: https://fal.ai/models/fal-ai/bytedance/seedream/v4.5/edit
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+# Valid image size presets
+ImageSizePreset = Literal[
+    "square_hd",
+    "square",
+    "portrait_4_3",
+    "portrait_16_9",
+    "landscape_4_3",
+    "landscape_16_9",
+    "auto_2K",
+    "auto_4K",
+]
+
+
+class BytedanceSeedreamV45EditInput(BaseModel):
+    """Input schema for ByteDance Seedream v4.5 Edit.
+
+    Artifact fields (like image_sources) are automatically detected via type
+    introspection and resolved from generation IDs to ImageArtifact objects.
+    """
+
+    prompt: str = Field(description="The text prompt used to edit the image")
+    image_sources: list[ImageArtifact] = Field(
+        description="List of input images for editing (up to 10 images)",
+        min_length=1,
+        max_length=10,
+    )
+    num_images: int = Field(
+        default=1,
+        ge=1,
+        le=6,
+        description="Number of images to generate",
+    )
+    image_size: ImageSizePreset | None = Field(
+        default=None,
+        description=(
+            "The size of the generated image. Options: square_hd, square, "
+            "portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9, "
+            "auto_2K, auto_4K. Default is 2048x2048"
+        ),
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Random seed to control the stochasticity of image generation",
+    )
+    sync_mode: bool = Field(
+        default=False,
+        description=(
+            "If True, the media will be returned as a data URI and the output "
+            "data won't be available in the request history"
+        ),
+    )
+    enable_safety_checker: bool = Field(
+        default=True,
+        description="Enables safety filtering on generated images",
+    )
+
+
+class FalBytedanceSeedreamV45EditGenerator(BaseGenerator):
+    """ByteDance Seedream v4.5 Edit image editing generator using fal.ai."""
+
+    name = "fal-bytedance-seedream-v45-edit"
+    artifact_type = "image"
+    description = "Fal: ByteDance Seedream v4.5 Edit - Unified image generation and editing"
+
+    def get_input_schema(self) -> type[BytedanceSeedreamV45EditInput]:
+        return BytedanceSeedreamV45EditInput
+
+    async def generate(
+        self, inputs: BytedanceSeedreamV45EditInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Edit images using fal.ai ByteDance Seedream v4.5 Edit model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalBytedanceSeedreamV45EditGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifacts to Fal's public storage
+        # Fal API requires publicly accessible URLs, but our storage_url might be:
+        # - Localhost URLs (not publicly accessible)
+        # - Private S3 buckets (not publicly accessible)
+        # So we upload to Fal's temporary storage first
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal(inputs.image_sources, context)
+
+        # Prepare arguments for fal.ai API
+        arguments: dict = {
+            "prompt": inputs.prompt,
+            "image_urls": image_urls,
+            "num_images": inputs.num_images,
+            "sync_mode": inputs.sync_mode,
+            "enable_safety_checker": inputs.enable_safety_checker,
+        }
+
+        # Add optional parameters
+        if inputs.image_size is not None:
+            arguments["image_size"] = inputs.image_size
+
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/bytedance/seedream/v4.5/edit",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image URLs from result
+        # fal.ai returns: {
+        #   "images": [{"url": "...", "width": ..., "height": ..., ...}, ...]
+        # }
+        images = result.get("images", [])
+
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url = image_data.get("url")
+            # Extract dimensions if available, otherwise use sensible defaults
+            width = image_data.get("width", 2048)
+            height = image_data.get("height", 2048)
+
+            if not image_url:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Determine format from content_type or default to png
+            content_type = image_data.get("content_type", "image/png")
+            if "jpeg" in content_type or "jpg" in content_type:
+                format_type = "jpeg"
+            elif "webp" in content_type:
+                format_type = "webp"
+            else:
+                format_type = "png"
+
+            # Store with appropriate output_index
+            artifact = await context.store_image_result(
+                storage_url=image_url,
+                format=format_type,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: BytedanceSeedreamV45EditInput) -> float:
+        """Estimate cost for ByteDance Seedream v4.5 Edit generation.
+
+        Pricing not disclosed in documentation, using conservative estimate
+        based on similar high-quality image editing models.
+        """
+        # Conservative estimate per image
+        per_image_cost = 0.05
+        return per_image_cost * inputs.num_images

--- a/packages/backend/tests/generators/implementations/test_bytedance_seedream_v45_edit.py
+++ b/packages/backend/tests/generators/implementations/test_bytedance_seedream_v45_edit.py
@@ -1,0 +1,816 @@
+"""
+Tests for FalBytedanceSeedreamV45EditGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.bytedance_seedream_v45_edit import (
+    BytedanceSeedreamV45EditInput,
+    FalBytedanceSeedreamV45EditGenerator,
+)
+
+
+class TestBytedanceSeedreamV45EditInput:
+    """Tests for BytedanceSeedreamV45EditInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image_artifact_1 = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image1.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+        image_artifact_2 = ImageArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/image2.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedreamV45EditInput(
+            prompt="make the background more vibrant",
+            image_sources=[image_artifact_1, image_artifact_2],
+            num_images=2,
+            image_size="square_hd",
+        )
+
+        assert input_data.prompt == "make the background more vibrant"
+        assert len(input_data.image_sources) == 2
+        assert input_data.num_images == 2
+        assert input_data.image_size == "square_hd"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedreamV45EditInput(
+            prompt="Test prompt",
+            image_sources=[image_artifact],
+        )
+
+        assert input_data.num_images == 1
+        assert input_data.image_size is None
+        assert input_data.sync_mode is False
+        assert input_data.enable_safety_checker is True
+        assert input_data.seed is None
+
+    def test_empty_image_sources(self):
+        """Test validation fails for empty image_sources."""
+        with pytest.raises(ValidationError):
+            BytedanceSeedreamV45EditInput(
+                prompt="Test",
+                image_sources=[],  # Empty list should fail min_length=1
+            )
+
+    def test_too_many_image_sources(self):
+        """Test validation fails for more than 10 images."""
+        image_artifacts = [
+            ImageArtifact(
+                generation_id=f"gen{i}",
+                storage_url=f"https://example.com/image{i}.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+            for i in range(11)  # 11 images
+        ]
+
+        with pytest.raises(ValidationError):
+            BytedanceSeedreamV45EditInput(
+                prompt="Test",
+                image_sources=image_artifacts,  # 11 images should fail max_length=10
+            )
+
+    def test_num_images_validation(self):
+        """Test validation for num_images constraints."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            BytedanceSeedreamV45EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                num_images=0,
+            )
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            BytedanceSeedreamV45EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                num_images=7,  # Max is 6
+            )
+
+    def test_invalid_image_size(self):
+        """Test validation fails for invalid image_size."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            BytedanceSeedreamV45EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                image_size="invalid_size",  # type: ignore[arg-type]
+            )
+
+    def test_image_size_options(self):
+        """Test all valid image size options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_sizes = [
+            "square_hd",
+            "square",
+            "portrait_4_3",
+            "portrait_16_9",
+            "landscape_4_3",
+            "landscape_16_9",
+            "auto_2K",
+            "auto_4K",
+        ]
+
+        for size in valid_sizes:
+            input_data = BytedanceSeedreamV45EditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                image_size=size,  # type: ignore[arg-type]
+            )
+            assert input_data.image_size == size
+
+    def test_max_images_at_boundary(self):
+        """Test 10 images (maximum allowed) is accepted."""
+        image_artifacts = [
+            ImageArtifact(
+                generation_id=f"gen{i}",
+                storage_url=f"https://example.com/image{i}.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+            for i in range(10)  # Exactly 10 images
+        ]
+
+        input_data = BytedanceSeedreamV45EditInput(
+            prompt="Test",
+            image_sources=image_artifacts,
+        )
+        assert len(input_data.image_sources) == 10
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalBytedanceSeedreamV45EditGenerator:
+    """Tests for FalBytedanceSeedreamV45EditGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalBytedanceSeedreamV45EditGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-bytedance-seedream-v45-edit"
+        assert self.generator.artifact_type == "image"
+        assert "Seedream" in self.generator.description
+        assert "ByteDance" in self.generator.description
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == BytedanceSeedreamV45EditInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/image.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+
+            input_data = BytedanceSeedreamV45EditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation with single image output."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedreamV45EditInput(
+            prompt="make the sky more dramatic",
+            image_sources=[input_image],
+            num_images=1,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 2048,
+                            "height": 2048,
+                            "content_type": "image/png",
+                        }
+                    ],
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=2048,
+                height=2048,
+                format="png",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    # Return a fake local file path
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            mock_fal_client.upload_file_async.assert_called_once_with("/tmp/fake_image.png")
+
+            # Verify API calls with uploaded URL
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/bytedance/seedream/v4.5/edit",
+                arguments={
+                    "prompt": "make the sky more dramatic",
+                    "image_urls": [fake_uploaded_url],
+                    "num_images": 1,
+                    "sync_mode": False,
+                    "enable_safety_checker": True,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_multiple_images(self):
+        """Test successful generation with multiple image outputs."""
+        input_image_1 = ImageArtifact(
+            generation_id="gen_input1",
+            storage_url="https://example.com/input1.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+        input_image_2 = ImageArtifact(
+            generation_id="gen_input2",
+            storage_url="https://example.com/input2.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = BytedanceSeedreamV45EditInput(
+            prompt="enhance the colors",
+            image_sources=[input_image_1, input_image_2],
+            num_images=2,
+            image_size="landscape_16_9",
+        )
+
+        fake_output_urls = [
+            "https://storage.googleapis.com/falserverless/output1.png",
+            "https://storage.googleapis.com/falserverless/output2.png",
+        ]
+        fake_uploaded_urls = [
+            "https://fal.media/files/uploaded-input1.png",
+            "https://fal.media/files/uploaded-input2.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_urls[0],
+                            "width": 1920,
+                            "height": 1080,
+                            "content_type": "image/jpeg",
+                        },
+                        {
+                            "url": fake_output_urls[1],
+                            "width": 1920,
+                            "height": 1080,
+                            "content_type": "image/jpeg",
+                        },
+                    ],
+                }
+            )
+
+            # Mock file uploads to return different URLs for each file
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_urls[upload_call_count]
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage results
+            mock_artifacts = [
+                ImageArtifact(
+                    generation_id="test_gen",
+                    storage_url=url,
+                    width=1920,
+                    height=1080,
+                    format="jpeg",
+                )
+                for url in fake_output_urls
+            ]
+
+            artifact_idx = 0
+            resolve_call_count = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    nonlocal resolve_call_count
+                    # Return different fake paths for each artifact
+                    path = f"/tmp/fake_image_{resolve_call_count}.png"
+                    resolve_call_count += 1
+                    return path
+
+                async def store_image_result(self, **kwargs):
+                    nonlocal artifact_idx
+                    result = mock_artifacts[artifact_idx]
+                    artifact_idx += 1
+                    return result
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 2
+
+            # Verify file uploads were called for both images
+            assert mock_fal_client.upload_file_async.call_count == 2
+
+            # Verify API call included image_size and uploaded URLs
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["image_size"] == "landscape_16_9"
+            assert call_args[1]["arguments"]["image_urls"] == fake_uploaded_urls
+
+    @pytest.mark.asyncio
+    async def test_generate_with_seed(self):
+        """Test generation with seed parameter."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedreamV45EditInput(
+            prompt="test prompt",
+            image_sources=[input_image],
+            seed=42,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-seed"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [{"url": fake_output_url, "width": 2048, "height": 2048}],
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=2048,
+                height=2048,
+                format="png",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            await self.generator.generate(input_data, DummyCtx())
+
+            # Verify seed was included in API call
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["seed"] == 42
+
+    @pytest.mark.asyncio
+    async def test_generate_no_images_returned(self):
+        """Test generation fails when API returns no images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedreamV45EditInput(
+            prompt="test",
+            image_sources=[input_image],
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"images": []})
+
+            fake_uploaded_url = "https://fal.media/files/uploaded.png"
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No images returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedreamV45EditInput(
+            prompt="Test prompt",
+            image_sources=[input_image],
+            num_images=1,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.05 * 1)
+        assert cost == 0.05
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_multiple_images(self):
+        """Test cost estimation for multiple images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedreamV45EditInput(
+            prompt="Test prompt",
+            image_sources=[input_image],
+            num_images=5,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.05 * 5)
+        assert cost == 0.25
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = BytedanceSeedreamV45EditInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "image_sources" in schema["properties"]
+        assert "num_images" in schema["properties"]
+        assert "image_size" in schema["properties"]
+        assert "seed" in schema["properties"]
+        assert "sync_mode" in schema["properties"]
+        assert "enable_safety_checker" in schema["properties"]
+
+        # Check that image_sources is an array with min/max constraints
+        image_sources_prop = schema["properties"]["image_sources"]
+        assert image_sources_prop["type"] == "array"
+        assert "minItems" in image_sources_prop
+        assert image_sources_prop["minItems"] == 1
+        assert "maxItems" in image_sources_prop
+        assert image_sources_prop["maxItems"] == 10
+
+        # Check that num_images has constraints
+        num_images_prop = schema["properties"]["num_images"]
+        assert num_images_prop["minimum"] == 1
+        assert num_images_prop["maximum"] == 6
+        assert num_images_prop["default"] == 1
+
+    @pytest.mark.asyncio
+    async def test_content_type_parsing(self):
+        """Test that content_type is correctly parsed for image format."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedreamV45EditInput(
+            prompt="test prompt",
+            image_sources=[input_image],
+            num_images=1,
+        )
+
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-content-type"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": "https://example.com/output.webp",
+                            "width": 2048,
+                            "height": 2048,
+                            "content_type": "image/webp",
+                        }
+                    ],
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            stored_format = None
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    nonlocal stored_format
+                    stored_format = kwargs.get("format")
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url=kwargs.get("storage_url", ""),
+                        width=kwargs.get("width", 2048),
+                        height=kwargs.get("height", 2048),
+                        format=stored_format or "png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            await self.generator.generate(input_data, DummyCtx())
+
+            # Verify webp format was correctly parsed
+            assert stored_format == "webp"

--- a/packages/backend/tests/generators/implementations/test_bytedance_seedream_v45_edit_live.py
+++ b/packages/backend/tests/generators/implementations/test_bytedance_seedream_v45_edit_live.py
@@ -1,0 +1,148 @@
+"""
+Live API tests for FalBytedanceSeedreamV45EditGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_bytedance_seedream_v45_edit_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_bytedance_seedream_v45_edit_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.implementations.fal.image.bytedance_seedream_v45_edit import (
+    BytedanceSeedreamV45EditInput,
+    FalBytedanceSeedreamV45EditGenerator,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestBytedanceSeedreamV45EditGeneratorLive:
+    """Live API tests for FalBytedanceSeedreamV45EditGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalBytedanceSeedreamV45EditGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.fixture
+    def test_image_artifact(self):
+        """Provide a sample image artifact for testing."""
+        return ImageArtifact(
+            generation_id="test_input",
+            storage_url="https://placehold.co/512x512/ff0000/ff0000.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger, test_image_artifact
+    ):
+        """
+        Test basic image editing with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses minimal/cheap settings to reduce cost.
+        """
+        # Create minimal input to reduce cost
+        inputs = BytedanceSeedreamV45EditInput(
+            prompt="Add a blue border around the image",
+            image_sources=[test_image_artifact],
+            num_images=1,  # Minimum images
+            image_size="square",  # Standard size
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) >= 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        # Storage URLs can be HTTPS URLs or other formats (data:, etc.)
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+
+    @pytest.mark.asyncio
+    async def test_generate_with_seed(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger, test_image_artifact
+    ):
+        """
+        Test generation with fixed seed for reproducibility.
+
+        Note: This test verifies seed is accepted, but doesn't verify
+        reproducibility (would require 2 API calls).
+        """
+        inputs = BytedanceSeedreamV45EditInput(
+            prompt="Make the image brighter",
+            image_sources=[test_image_artifact],
+            num_images=1,
+            seed=42,  # Fixed seed
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result (seed doesn't affect output structure, just determinism)
+        assert result.outputs is not None
+        assert len(result.outputs) >= 1
+        assert result.outputs[0].storage_url is not None
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key, test_image_artifact):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Single image
+        inputs_1 = BytedanceSeedreamV45EditInput(
+            prompt="test",
+            image_sources=[test_image_artifact],
+            num_images=1,
+        )
+        cost_1 = await self.generator.estimate_cost(inputs_1)
+
+        # Multiple images
+        inputs_3 = BytedanceSeedreamV45EditInput(
+            prompt="test",
+            image_sources=[test_image_artifact],
+            num_images=3,
+        )
+        cost_3 = await self.generator.estimate_cost(inputs_3)
+
+        # Verify estimate is in reasonable range
+        assert cost_1 > 0.0
+        assert cost_1 < 1.0  # Sanity check
+
+        # Cost should scale linearly with number of images
+        assert cost_3 == cost_1 * 3


### PR DESCRIPTION
Add a new Fal AI generator for fal-ai/bytedance/seedream/v4.5/edit. This model integrates image generation and image editing capabilities into a unified architecture, supporting up to 10 input images with text prompts.

Features:
- Image editing via text prompts
- Multi-image input support (1-10 images)
- Batch generation (1-6 output images)
- Multiple image size presets
- Seed for reproducibility
- Safety checker option

Includes comprehensive unit tests and live API tests.