### PR TITLE
Create Gemini 2.5 Flash image edit generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -62,6 +62,9 @@ generators:
   - class: "boards.generators.implementations.fal.image.gemini_25_flash_image.FalGemini25FlashImageGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.gemini_25_flash_image_edit.FalGemini25FlashImageEditGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.image.gpt_image_1_edit_image.FalGptImage1EditImageGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -11,6 +11,7 @@ from .flux_2_pro_edit import FalFlux2ProEditGenerator
 from .flux_pro_kontext import FalFluxProKontextGenerator
 from .flux_pro_ultra import FalFluxProUltraGenerator
 from .gemini_25_flash_image import FalGemini25FlashImageGenerator
+from .gemini_25_flash_image_edit import FalGemini25FlashImageEditGenerator
 from .gpt_image_1_edit_image import FalGptImage1EditImageGenerator
 from .gpt_image_1_mini import FalGptImage1MiniGenerator
 from .ideogram_character_edit import FalIdeogramCharacterEditGenerator
@@ -35,6 +36,7 @@ __all__ = [
     "FalFlux2ProEditGenerator",
     "FalFluxProKontextGenerator",
     "FalFluxProUltraGenerator",
+    "FalGemini25FlashImageEditGenerator",
     "FalGemini25FlashImageGenerator",
     "FalGptImage1EditImageGenerator",
     "FalGptImage1MiniGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/image/gemini_25_flash_image_edit.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/gemini_25_flash_image_edit.py
@@ -1,0 +1,208 @@
+"""
+Google Gemini 2.5 Flash Image edit image-to-image generator.
+
+Google's state-of-the-art image generation and editing model available through fal.ai.
+Performs image-to-image transformations and edits based on text prompts.
+Supports multiple aspect ratios and output formats with batch generation up to 4 images.
+
+Based on Fal AI's fal-ai/gemini-25-flash-image/edit model.
+See: https://fal.ai/models/fal-ai/gemini-25-flash-image/edit
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class Gemini25FlashImageEditInput(BaseModel):
+    """Input schema for Gemini 2.5 Flash Image edit generation.
+
+    Artifact fields (like image_sources) are automatically detected via type
+    introspection and resolved from generation IDs to ImageArtifact objects.
+    """
+
+    prompt: str = Field(
+        description="The editing instruction for image transformation",
+        min_length=3,
+        max_length=5000,
+    )
+    image_sources: list[ImageArtifact] = Field(
+        description="List of input images for editing (from previous generations)",
+        min_length=1,
+    )
+    num_images: int = Field(
+        default=1,
+        ge=1,
+        le=4,
+        description="Number of images to generate (max 4)",
+    )
+    aspect_ratio: (
+        Literal[
+            "auto",
+            "21:9",
+            "16:9",
+            "3:2",
+            "4:3",
+            "5:4",
+            "1:1",
+            "4:5",
+            "3:4",
+            "2:3",
+            "9:16",
+        ]
+        | None
+    ) = Field(
+        default="auto",
+        description="Image aspect ratio. Default 'auto' uses input image's aspect ratio.",
+    )
+    output_format: Literal["jpeg", "png", "webp"] = Field(
+        default="png",
+        description="Output image format",
+    )
+    sync_mode: bool = Field(
+        default=False,
+        description="Return media as data URI without request history storage",
+    )
+    limit_generations: bool = Field(
+        default=False,
+        description="Restrict to single generation per round (experimental)",
+    )
+
+
+class FalGemini25FlashImageEditGenerator(BaseGenerator):
+    """Google Gemini 2.5 Flash Image edit generator using fal.ai."""
+
+    name = "fal-gemini-25-flash-image-edit"
+    artifact_type = "image"
+    description = "Fal: Gemini 2.5 Flash Image Edit - AI-powered image editing with Gemini"
+
+    def get_input_schema(self) -> type[Gemini25FlashImageEditInput]:
+        return Gemini25FlashImageEditInput
+
+    async def generate(
+        self, inputs: Gemini25FlashImageEditInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Edit images using Google Gemini 2.5 Flash Image via fal.ai."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalGemini25FlashImageEditGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifacts to Fal's public storage
+        # Fal API requires publicly accessible URLs, but our storage_url might be:
+        # - Localhost URLs (not publicly accessible)
+        # - Private S3 buckets (not publicly accessible)
+        # So we upload to Fal's temporary storage first
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal(inputs.image_sources, context)
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "prompt": inputs.prompt,
+            "image_urls": image_urls,
+            "num_images": inputs.num_images,
+            "output_format": inputs.output_format,
+            "sync_mode": inputs.sync_mode,
+            "limit_generations": inputs.limit_generations,
+        }
+
+        # Add aspect_ratio if provided
+        if inputs.aspect_ratio is not None:
+            arguments["aspect_ratio"] = inputs.aspect_ratio
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/gemini-25-flash-image/edit",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image URLs and description from result
+        # fal.ai returns: {
+        #   "images": [{"url": "...", "width": ..., "height": ..., ...}, ...],
+        #   "description": "Text description from Gemini"
+        # }
+        images = result.get("images", [])
+
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url = image_data.get("url")
+            # Use 'or' to handle explicit None values from API
+            width = image_data.get("width") or 1024
+            height = image_data.get("height") or 1024
+
+            if not image_url:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Store with appropriate output_index
+            artifact = await context.store_image_result(
+                storage_url=image_url,
+                format=inputs.output_format,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: Gemini25FlashImageEditInput) -> float:
+        """Estimate cost for Gemini 2.5 Flash Image edit generation.
+
+        Note: Pricing information not available in fal.ai documentation.
+        Using placeholder estimate similar to other Gemini-based models.
+        """
+        # Placeholder cost estimate per image (similar to nano-banana which also uses Gemini)
+        per_image_cost = 0.039
+        return per_image_cost * inputs.num_images

--- a/packages/backend/tests/generators/implementations/test_gemini_25_flash_image_edit.py
+++ b/packages/backend/tests/generators/implementations/test_gemini_25_flash_image_edit.py
@@ -1,0 +1,643 @@
+"""
+Tests for FalGemini25FlashImageEditGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.gemini_25_flash_image_edit import (
+    FalGemini25FlashImageEditGenerator,
+    Gemini25FlashImageEditInput,
+)
+
+
+class TestGemini25FlashImageEditInput:
+    """Tests for Gemini25FlashImageEditInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image_artifact_1 = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image1.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+        image_artifact_2 = ImageArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/image2.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Gemini25FlashImageEditInput(
+            prompt="make a photo of the man driving the car",
+            image_sources=[image_artifact_1, image_artifact_2],
+            num_images=2,
+            output_format="jpeg",
+        )
+
+        assert input_data.prompt == "make a photo of the man driving the car"
+        assert len(input_data.image_sources) == 2
+        assert input_data.num_images == 2
+        assert input_data.output_format == "jpeg"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Gemini25FlashImageEditInput(
+            prompt="Test prompt",
+            image_sources=[image_artifact],
+        )
+
+        assert input_data.num_images == 1
+        assert input_data.output_format == "png"
+        assert input_data.sync_mode is False
+        assert input_data.limit_generations is False
+        assert input_data.aspect_ratio == "auto"
+
+    def test_invalid_output_format(self):
+        """Test validation fails for invalid output format."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            Gemini25FlashImageEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                output_format="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_aspect_ratio(self):
+        """Test validation fails for invalid aspect ratio."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            Gemini25FlashImageEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                aspect_ratio="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_empty_image_sources(self):
+        """Test validation fails for empty image_sources."""
+        with pytest.raises(ValidationError):
+            Gemini25FlashImageEditInput(
+                prompt="Test",
+                image_sources=[],  # Empty list should fail min_length=1
+            )
+
+    def test_num_images_validation(self):
+        """Test validation for num_images constraints."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            Gemini25FlashImageEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                num_images=0,
+            )
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            Gemini25FlashImageEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                num_images=5,
+            )
+
+    def test_prompt_validation(self):
+        """Test validation for prompt constraints."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Test below minimum (3 characters)
+        with pytest.raises(ValidationError):
+            Gemini25FlashImageEditInput(
+                prompt="ab",  # Only 2 characters
+                image_sources=[image_artifact],
+            )
+
+    def test_aspect_ratio_options(self):
+        """Test all valid aspect ratio options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_ratios = [
+            "auto",
+            "21:9",
+            "16:9",
+            "3:2",
+            "4:3",
+            "5:4",
+            "1:1",
+            "4:5",
+            "3:4",
+            "2:3",
+            "9:16",
+        ]
+
+        for ratio in valid_ratios:
+            input_data = Gemini25FlashImageEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                aspect_ratio=ratio,  # type: ignore[arg-type]
+            )
+            assert input_data.aspect_ratio == ratio
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalGemini25FlashImageEditGenerator:
+    """Tests for FalGemini25FlashImageEditGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalGemini25FlashImageEditGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-gemini-25-flash-image-edit"
+        assert self.generator.artifact_type == "image"
+        assert "edit" in self.generator.description.lower()
+        assert "Gemini" in self.generator.description
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == Gemini25FlashImageEditInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/image.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+
+            input_data = Gemini25FlashImageEditInput(
+                prompt="Test prompt",
+                image_sources=[image_artifact],
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation with single image output."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Gemini25FlashImageEditInput(
+            prompt="make the sky more dramatic",
+            image_sources=[input_image],
+            num_images=1,
+            output_format="jpeg",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_description = "Here is a photo with a more dramatic sky."
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 1024,
+                            "height": 768,
+                        }
+                    ],
+                    "description": fake_description,
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=768,
+                format="jpeg",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    # Return a fake local file path
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            mock_fal_client.upload_file_async.assert_called_once_with("/tmp/fake_image.png")
+
+            # Verify API calls with uploaded URL
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/gemini-25-flash-image/edit",
+                arguments={
+                    "prompt": "make the sky more dramatic",
+                    "image_urls": [fake_uploaded_url],  # Should use uploaded URL, not original
+                    "num_images": 1,
+                    "output_format": "jpeg",
+                    "sync_mode": False,
+                    "limit_generations": False,
+                    "aspect_ratio": "auto",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_multiple_images(self):
+        """Test successful generation with multiple image outputs."""
+        input_image_1 = ImageArtifact(
+            generation_id="gen_input1",
+            storage_url="https://example.com/input1.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+        input_image_2 = ImageArtifact(
+            generation_id="gen_input2",
+            storage_url="https://example.com/input2.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = Gemini25FlashImageEditInput(
+            prompt="enhance the colors",
+            image_sources=[input_image_1, input_image_2],
+            num_images=2,
+            output_format="png",
+            aspect_ratio="16:9",
+        )
+
+        fake_output_urls = [
+            "https://storage.googleapis.com/falserverless/output1.png",
+            "https://storage.googleapis.com/falserverless/output2.png",
+        ]
+        fake_uploaded_urls = [
+            "https://fal.media/files/uploaded-input1.png",
+            "https://fal.media/files/uploaded-input2.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {"url": fake_output_urls[0], "width": 1920, "height": 1080},
+                        {"url": fake_output_urls[1], "width": 1920, "height": 1080},
+                    ],
+                    "description": "Enhanced colors applied.",
+                }
+            )
+
+            # Mock file uploads to return different URLs for each file
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_urls[upload_call_count]
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage results
+            mock_artifacts = [
+                ImageArtifact(
+                    generation_id="test_gen",
+                    storage_url=url,
+                    width=1920,
+                    height=1080,
+                    format="png",
+                )
+                for url in fake_output_urls
+            ]
+
+            artifact_idx = 0
+            resolve_call_count = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    nonlocal resolve_call_count
+                    # Return different fake paths for each artifact
+                    path = f"/tmp/fake_image_{resolve_call_count}.png"
+                    resolve_call_count += 1
+                    return path
+
+                async def store_image_result(self, **kwargs):
+                    nonlocal artifact_idx
+                    result = mock_artifacts[artifact_idx]
+                    artifact_idx += 1
+                    return result
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 2
+
+            # Verify file uploads were called for both images
+            assert mock_fal_client.upload_file_async.call_count == 2
+
+            # Verify API call included aspect_ratio and uploaded URLs
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["aspect_ratio"] == "16:9"
+            assert call_args[1]["arguments"]["image_urls"] == fake_uploaded_urls
+
+    @pytest.mark.asyncio
+    async def test_generate_no_images_returned(self):
+        """Test generation fails when API returns no images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Gemini25FlashImageEditInput(
+            prompt="test",
+            image_sources=[input_image],
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"images": [], "description": ""})
+
+            fake_uploaded_url = "https://fal.media/files/uploaded.png"
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No images returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Gemini25FlashImageEditInput(
+            prompt="Test prompt",
+            image_sources=[input_image],
+            num_images=1,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.039 * 1)
+        assert cost == 0.039
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_multiple_images(self):
+        """Test cost estimation for multiple images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Gemini25FlashImageEditInput(
+            prompt="Test prompt",
+            image_sources=[input_image],
+            num_images=4,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.039 * 4)
+        assert cost == 0.156
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = Gemini25FlashImageEditInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "image_sources" in schema["properties"]
+        assert "num_images" in schema["properties"]
+        assert "output_format" in schema["properties"]
+        assert "aspect_ratio" in schema["properties"]
+
+        # Check that image_sources is an array
+        image_sources_prop = schema["properties"]["image_sources"]
+        assert image_sources_prop["type"] == "array"
+        assert "minItems" in image_sources_prop
+
+        # Check that num_images has constraints
+        num_images_prop = schema["properties"]["num_images"]
+        assert num_images_prop["minimum"] == 1
+        assert num_images_prop["maximum"] == 4
+        assert num_images_prop["default"] == 1

--- a/packages/backend/tests/generators/implementations/test_gemini_25_flash_image_edit_live.py
+++ b/packages/backend/tests/generators/implementations/test_gemini_25_flash_image_edit_live.py
@@ -1,0 +1,226 @@
+"""
+Live API tests for FalGemini25FlashImageEditGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_gemini_25_flash_image_edit_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_gemini_25_flash_image_edit_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.implementations.fal.image.gemini_25_flash_image_edit import (
+    FalGemini25FlashImageEditGenerator,
+    Gemini25FlashImageEditInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestGemini25FlashImageEditGeneratorLive:
+    """Live API tests for FalGemini25FlashImageEditGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalGemini25FlashImageEditGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test basic image editing with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses a small publicly accessible test image to minimize cost.
+        """
+        # Use a small publicly accessible test image (512x512 solid color)
+        # This is a simple red square image that's small and cheap to process
+        test_image_url = "https://placehold.co/512x512/ff0000/ff0000.png"
+
+        # Create test image artifact
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url=test_image_url,
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create minimal input to reduce cost
+        inputs = Gemini25FlashImageEditInput(
+            prompt="Add text 'HELLO' to the image",
+            image_sources=[test_artifact],
+            num_images=1,  # Single image
+            output_format="jpeg",  # JPEG is cheaper than PNG
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+        assert artifact.format == "jpeg"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_aspect_ratio(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with custom aspect ratio.
+
+        Verifies that aspect_ratio parameter is correctly processed.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/512x512/00ff00/00ff00.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input2",
+            storage_url=test_image_url,
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create input with custom aspect ratio
+        inputs = Gemini25FlashImageEditInput(
+            prompt="Change this to blue",
+            image_sources=[test_artifact],
+            aspect_ratio="1:1",
+            num_images=1,
+            output_format="jpeg",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url.startswith("https://")
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+
+    @pytest.mark.asyncio
+    async def test_generate_with_multiple_outputs(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with multiple image outputs.
+
+        Verifies that num_images parameter works correctly.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/512x512/ffff00/ffff00.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input3",
+            storage_url=test_image_url,
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create input requesting 2 images
+        inputs = Gemini25FlashImageEditInput(
+            prompt="Add text 'TEST'",
+            image_sources=[test_artifact],
+            num_images=2,  # Multiple outputs
+            output_format="jpeg",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result has multiple outputs (API may return more than requested)
+        assert result.outputs is not None
+        assert len(result.outputs) >= 2
+
+        # Verify both artifacts
+        for artifact in result.outputs:
+            assert isinstance(artifact, ImageArtifact)
+            assert artifact.storage_url.startswith("https://")
+            if artifact.width is not None:
+                assert artifact.width > 0
+            if artifact.height is not None:
+                assert artifact.height > 0
+            assert artifact.format == "jpeg"
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Create dummy input (artifact won't be used for estimation)
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url="https://example.com/test.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Single image
+        inputs_1 = Gemini25FlashImageEditInput(
+            prompt="test edit",
+            image_sources=[test_artifact],
+            num_images=1,
+        )
+        cost_1 = await self.generator.estimate_cost(inputs_1)
+
+        # Multiple images
+        inputs_4 = Gemini25FlashImageEditInput(
+            prompt="test edit",
+            image_sources=[test_artifact],
+            num_images=4,
+        )
+        cost_4 = await self.generator.estimate_cost(inputs_4)
+
+        # Cost should scale linearly with number of images
+        assert cost_4 == cost_1 * 4
+
+        # Sanity check on absolute costs
+        assert cost_1 > 0.0
+        assert cost_1 < 0.2  # Should be under $0.20 per image


### PR DESCRIPTION
Add fal-ai/gemini-25-flash-image/edit generator for AI-powered image editing using Google's Gemini model through Fal.ai. This is an image-to-image generator that accepts input images and text prompts to perform edits.

Features:
- Accepts multiple input images for editing
- Supports batch generation (up to 4 images)
- Multiple aspect ratio options including auto-detect
- Output formats: JPEG, PNG, WebP

Includes comprehensive unit tests and live API tests.