### PR TITLE
Create FAL text-to-image generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -134,6 +134,9 @@ generators:
   - class: "boards.generators.implementations.fal.image.qwen_image.FalQwenImageGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.reve_text_to_image.FalReveTextToImageGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.image.seedream_v45_text_to_image.FalSeedreamV45TextToImageGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -24,6 +24,7 @@ from .nano_banana_pro import FalNanoBananaProGenerator
 from .nano_banana_pro_edit import FalNanoBananaProEditGenerator
 from .qwen_image import FalQwenImageGenerator
 from .qwen_image_edit import FalQwenImageEditGenerator
+from .reve_text_to_image import FalReveTextToImageGenerator
 from .seedream_v45_text_to_image import FalSeedreamV45TextToImageGenerator
 
 __all__ = [
@@ -51,5 +52,6 @@ __all__ = [
     "FalNanoBananaProEditGenerator",
     "FalQwenImageEditGenerator",
     "FalQwenImageGenerator",
+    "FalReveTextToImageGenerator",
     "FalSeedreamV45TextToImageGenerator",
 ]

--- a/packages/backend/src/boards/generators/implementations/fal/image/reve_text_to_image.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/reve_text_to_image.py
@@ -1,0 +1,155 @@
+"""
+fal.ai Reve text-to-image generator.
+
+Reve's text-to-image model generates detailed visual output that closely follows
+your instructions, with strong aesthetic quality and accurate text rendering.
+
+Based on Fal AI's fal-ai/reve/text-to-image model.
+See: https://fal.ai/models/fal-ai/reve/text-to-image
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class ReveTextToImageInput(BaseModel):
+    """Input schema for Reve text-to-image generation."""
+
+    prompt: str = Field(
+        description="Text description of desired image",
+        min_length=1,
+        max_length=2560,
+    )
+    num_images: int = Field(
+        default=1,
+        ge=1,
+        le=4,
+        description="Number of images to generate",
+    )
+    aspect_ratio: Literal["16:9", "9:16", "3:2", "2:3", "4:3", "3:4", "1:1"] = Field(
+        default="3:2",
+        description="Desired image aspect ratio",
+    )
+    output_format: Literal["png", "jpeg", "webp"] = Field(
+        default="png",
+        description="Output image format",
+    )
+
+
+class FalReveTextToImageGenerator(BaseGenerator):
+    """Reve text-to-image generator using fal.ai."""
+
+    name = "fal-reve-text-to-image"
+    artifact_type = "image"
+    description = (
+        "Fal: Reve - detailed text-to-image with strong aesthetic quality "
+        "and accurate text rendering"
+    )
+
+    def get_input_schema(self) -> type[ReveTextToImageInput]:
+        return ReveTextToImageInput
+
+    async def generate(
+        self, inputs: ReveTextToImageInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate images using fal.ai Reve text-to-image model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalReveTextToImageGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "prompt": inputs.prompt,
+            "num_images": inputs.num_images,
+            "aspect_ratio": inputs.aspect_ratio,
+            "output_format": inputs.output_format,
+        }
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/reve/text-to-image",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image URLs from result
+        # fal.ai returns: {"images": [{"url": "...", "width": ..., "height": ...}, ...]}
+        images = result.get("images", [])
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url = image_data.get("url")
+            width = image_data.get("width")
+            height = image_data.get("height")
+
+            if not image_url:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Store with appropriate output_index
+            artifact = await context.store_image_result(
+                storage_url=image_url,
+                format=inputs.output_format,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: ReveTextToImageInput) -> float:
+        """Estimate cost for Reve text-to-image generation.
+
+        Reve typically costs around $0.03 per image.
+        """
+        return 0.03 * inputs.num_images

--- a/packages/backend/tests/generators/implementations/test_reve_text_to_image.py
+++ b/packages/backend/tests/generators/implementations/test_reve_text_to_image.py
@@ -1,0 +1,524 @@
+"""
+Tests for FalReveTextToImageGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.reve_text_to_image import (
+    FalReveTextToImageGenerator,
+    ReveTextToImageInput,
+)
+
+
+class TestReveTextToImageInput:
+    """Tests for ReveTextToImageInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        input_data = ReveTextToImageInput(
+            prompt="A serene mountain landscape at sunset with snow-capped peaks",
+            num_images=2,
+            aspect_ratio="16:9",
+            output_format="jpeg",
+        )
+
+        assert input_data.prompt == "A serene mountain landscape at sunset with snow-capped peaks"
+        assert input_data.num_images == 2
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.output_format == "jpeg"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = ReveTextToImageInput(prompt="Test prompt")
+
+        assert input_data.num_images == 1
+        assert input_data.aspect_ratio == "3:2"
+        assert input_data.output_format == "png"
+
+    def test_invalid_output_format(self):
+        """Test validation fails for invalid output format."""
+        with pytest.raises(ValidationError):
+            ReveTextToImageInput(
+                prompt="Test",
+                output_format="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_aspect_ratio(self):
+        """Test validation fails for invalid aspect ratio."""
+        with pytest.raises(ValidationError):
+            ReveTextToImageInput(
+                prompt="Test",
+                aspect_ratio="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_empty_prompt(self):
+        """Test validation fails for empty prompt."""
+        with pytest.raises(ValidationError):
+            ReveTextToImageInput(prompt="")
+
+    def test_prompt_too_long(self):
+        """Test validation fails for prompt exceeding max length."""
+        long_prompt = "a" * 2561  # Exceeds max_length of 2560
+        with pytest.raises(ValidationError):
+            ReveTextToImageInput(prompt=long_prompt)
+
+    def test_num_images_validation(self):
+        """Test validation for num_images constraints."""
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            ReveTextToImageInput(
+                prompt="Test",
+                num_images=0,
+            )
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            ReveTextToImageInput(
+                prompt="Test",
+                num_images=5,
+            )
+
+    def test_aspect_ratio_options(self):
+        """Test all valid aspect ratio options."""
+        valid_ratios = ["16:9", "9:16", "3:2", "2:3", "4:3", "3:4", "1:1"]
+
+        for ratio in valid_ratios:
+            input_data = ReveTextToImageInput(
+                prompt="Test",
+                aspect_ratio=ratio,  # type: ignore[arg-type]
+            )
+            assert input_data.aspect_ratio == ratio
+
+    def test_output_format_options(self):
+        """Test all valid output format options."""
+        valid_formats = ["png", "jpeg", "webp"]
+
+        for fmt in valid_formats:
+            input_data = ReveTextToImageInput(
+                prompt="Test",
+                output_format=fmt,  # type: ignore[arg-type]
+            )
+            assert input_data.output_format == fmt
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalReveTextToImageGenerator:
+    """Tests for FalReveTextToImageGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalReveTextToImageGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-reve-text-to-image"
+        assert self.generator.artifact_type == "image"
+        assert "Reve" in self.generator.description
+        assert "text-to-image" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == ReveTextToImageInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = ReveTextToImageInput(prompt="Test prompt")
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation with single image output."""
+        input_data = ReveTextToImageInput(
+            prompt="A serene mountain landscape",
+            num_images=1,
+            aspect_ratio="16:9",
+            output_format="png",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 1920,
+                            "height": 1080,
+                        }
+                    ],
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1920,
+                height=1080,
+                format="png",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify API calls
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/reve/text-to-image",
+                arguments={
+                    "prompt": "A serene mountain landscape",
+                    "num_images": 1,
+                    "aspect_ratio": "16:9",
+                    "output_format": "png",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_multiple_images(self):
+        """Test successful generation with multiple image outputs."""
+        input_data = ReveTextToImageInput(
+            prompt="Abstract colorful art",
+            num_images=3,
+            aspect_ratio="1:1",
+            output_format="jpeg",
+        )
+
+        fake_output_urls = [
+            "https://storage.googleapis.com/falserverless/output1.png",
+            "https://storage.googleapis.com/falserverless/output2.png",
+            "https://storage.googleapis.com/falserverless/output3.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {"url": fake_output_urls[0], "width": 1024, "height": 1024},
+                        {"url": fake_output_urls[1], "width": 1024, "height": 1024},
+                        {"url": fake_output_urls[2], "width": 1024, "height": 1024},
+                    ],
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage results
+            mock_artifacts = [
+                ImageArtifact(
+                    generation_id="test_gen",
+                    storage_url=url,
+                    width=1024,
+                    height=1024,
+                    format="jpeg",
+                )
+                for url in fake_output_urls
+            ]
+
+            artifact_idx = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    nonlocal artifact_idx
+                    result = mock_artifacts[artifact_idx]
+                    artifact_idx += 1
+                    return result
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 3
+
+            # Verify API call
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["num_images"] == 3
+            assert call_args[1]["arguments"]["aspect_ratio"] == "1:1"
+
+    @pytest.mark.asyncio
+    async def test_generate_no_images_returned(self):
+        """Test generation fails when API returns no images."""
+        input_data = ReveTextToImageInput(prompt="test")
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"images": []})
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No images returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_url_in_response(self):
+        """Test generation fails when API returns image without URL."""
+        input_data = ReveTextToImageInput(prompt="test")
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-999"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {"width": 1024, "height": 1024}  # Missing URL
+                    ]
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="missing URL"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_data = ReveTextToImageInput(
+            prompt="Test prompt",
+            num_images=1,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.03 * 1)
+        assert cost == 0.03
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_multiple_images(self):
+        """Test cost estimation for multiple images."""
+        input_data = ReveTextToImageInput(
+            prompt="Test prompt",
+            num_images=4,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.03 * 4)
+        assert cost == 0.12
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = ReveTextToImageInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "num_images" in schema["properties"]
+        assert "aspect_ratio" in schema["properties"]
+        assert "output_format" in schema["properties"]
+
+        # Check that prompt has constraints
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop["minLength"] == 1
+        assert prompt_prop["maxLength"] == 2560
+
+        # Check that num_images has constraints
+        num_images_prop = schema["properties"]["num_images"]
+        assert num_images_prop["minimum"] == 1
+        assert num_images_prop["maximum"] == 4
+        assert num_images_prop["default"] == 1
+
+        # Check that aspect_ratio has enum options
+        # Note: Pydantic schema for Literal may use $defs, so we check for presence
+        assert "aspect_ratio" in schema["properties"]
+
+        # Check that output_format has default
+        assert "output_format" in schema["properties"]

--- a/packages/backend/tests/generators/implementations/test_reve_text_to_image_live.py
+++ b/packages/backend/tests/generators/implementations/test_reve_text_to_image_live.py
@@ -1,0 +1,141 @@
+"""
+Live API tests for FalReveTextToImageGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_reve_text_to_image_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_reve_text_to_image_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.implementations.fal.image.reve_text_to_image import (
+    FalReveTextToImageGenerator,
+    ReveTextToImageInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestReveTextToImageGeneratorLive:
+    """Live API tests for FalReveTextToImageGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalReveTextToImageGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, dummy_context, cost_logger):
+        """
+        Test basic image generation with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses minimal/cheap settings to reduce cost.
+        """
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(ReveTextToImageInput(prompt="test"))
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Create minimal input to reduce cost
+        inputs = ReveTextToImageInput(
+            prompt="A simple red circle on white background",
+            num_images=1,  # Single image
+            aspect_ratio="1:1",  # Square for simplicity
+            output_format="jpeg",  # Smaller file size
+        )
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        from boards.generators.artifacts import ImageArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+        assert artifact.format in ["jpeg", "png", "webp"]
+
+    @pytest.mark.asyncio
+    async def test_generate_with_different_aspect_ratio(
+        self, skip_if_no_fal_key, dummy_context, cost_logger
+    ):
+        """
+        Test generation with different aspect ratio.
+
+        Verifies that aspect_ratio parameter is correctly processed.
+        """
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(
+            ReveTextToImageInput(prompt="test", aspect_ratio="16:9")
+        )
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Create input with landscape aspect ratio
+        inputs = ReveTextToImageInput(
+            prompt="Minimalist landscape scene",
+            aspect_ratio="16:9",
+            num_images=1,
+            output_format="jpeg",
+        )
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        from boards.generators.artifacts import ImageArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Single image
+        inputs_1 = ReveTextToImageInput(prompt="test", num_images=1)
+        cost_1 = await self.generator.estimate_cost(inputs_1)
+
+        # Four images (max)
+        inputs_4 = ReveTextToImageInput(prompt="test", num_images=4)
+        cost_4 = await self.generator.estimate_cost(inputs_4)
+
+        # Cost should scale linearly with number of images
+        assert cost_4 == cost_1 * 4
+
+        # Sanity check on absolute costs
+        assert cost_1 > 0.0
+        assert cost_1 < 0.1  # Should be well under $0.10 per image


### PR DESCRIPTION
Add FalReveTextToImageGenerator for fal-ai/reve/text-to-image model. Reve generates detailed images with strong aesthetic quality and accurate text rendering.

Features:
- Text prompt input with 2560 character limit
- Generate 1-4 images per request
- 7 aspect ratio options (16:9, 9:16, 3:2, 2:3, 4:3, 3:4, 1:1)
- PNG, JPEG, and WebP output formats

Includes comprehensive unit tests and live API tests.