### PR TITLE
Create FAL generator for image editing

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -134,6 +134,9 @@ generators:
   - class: "boards.generators.implementations.fal.image.qwen_image.FalQwenImageGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.reve_edit.FalReveEditGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.image.reve_text_to_image.FalReveTextToImageGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -24,6 +24,7 @@ from .nano_banana_pro import FalNanoBananaProGenerator
 from .nano_banana_pro_edit import FalNanoBananaProEditGenerator
 from .qwen_image import FalQwenImageGenerator
 from .qwen_image_edit import FalQwenImageEditGenerator
+from .reve_edit import FalReveEditGenerator
 from .reve_text_to_image import FalReveTextToImageGenerator
 from .seedream_v45_text_to_image import FalSeedreamV45TextToImageGenerator
 
@@ -52,6 +53,7 @@ __all__ = [
     "FalNanoBananaProEditGenerator",
     "FalQwenImageEditGenerator",
     "FalQwenImageGenerator",
+    "FalReveEditGenerator",
     "FalReveTextToImageGenerator",
     "FalSeedreamV45TextToImageGenerator",
 ]

--- a/packages/backend/src/boards/generators/implementations/fal/image/reve_edit.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/reve_edit.py
@@ -1,0 +1,178 @@
+"""
+fal.ai Reve image editing generator.
+
+Edit images using fal.ai's Reve edit model.
+Allows uploading an existing image and transforming it through text prompts.
+
+See: https://fal.ai/models/fal-ai/reve/edit
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class ReveEditInput(BaseModel):
+    """Input schema for Reve image editing.
+
+    Artifact fields (like image_url) are automatically detected via type
+    introspection and resolved from generation IDs to ImageArtifact objects.
+    """
+
+    prompt: str = Field(
+        description="Text describing how to edit the image",
+        min_length=1,
+        max_length=2560,
+    )
+    image_url: ImageArtifact = Field(
+        description="Reference image to edit (from a previous generation)",
+    )
+    num_images: int = Field(
+        default=1,
+        ge=1,
+        le=4,
+        description="Number of images to generate",
+    )
+    output_format: Literal["png", "jpeg", "webp"] = Field(
+        default="png",
+        description="Output image format",
+    )
+    sync_mode: bool = Field(
+        default=False,
+        description=(
+            "If True, the media will be returned as a data URI and the output "
+            "data won't be available in the request history"
+        ),
+    )
+
+
+class FalReveEditGenerator(BaseGenerator):
+    """Reve image editing generator using fal.ai."""
+
+    name = "fal-reve-edit"
+    artifact_type = "image"
+    description = "Fal: Reve edit - AI-powered image editing and transformation"
+
+    def get_input_schema(self) -> type[ReveEditInput]:
+        return ReveEditInput
+
+    async def generate(
+        self, inputs: ReveEditInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Edit images using fal.ai Reve edit model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalReveEditGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifact to Fal's public storage
+        # Fal API requires publicly accessible URLs, but our storage_url might be:
+        # - Localhost URLs (not publicly accessible)
+        # - Private S3 buckets (not publicly accessible)
+        # So we upload to Fal's temporary storage first
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal([inputs.image_url], context)
+        uploaded_image_url = image_urls[0]
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "prompt": inputs.prompt,
+            "image_url": uploaded_image_url,
+            "num_images": inputs.num_images,
+            "output_format": inputs.output_format,
+            "sync_mode": inputs.sync_mode,
+        }
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/reve/edit",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image URLs from result
+        # fal.ai returns: {
+        #   "images": [{"url": "...", "width": ..., "height": ..., ...}, ...]
+        # }
+        images = result.get("images", [])
+
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url = image_data.get("url")
+            # Extract dimensions if available, otherwise use sensible defaults
+            width = image_data.get("width", 1024)
+            height = image_data.get("height", 1024)
+
+            if not image_url:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Store with appropriate output_index
+            artifact = await context.store_image_result(
+                storage_url=image_url,
+                format=inputs.output_format,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: ReveEditInput) -> float:
+        """Estimate cost for Reve edit generation.
+
+        Reve edit pricing is $0.04 per image generated.
+        """
+        per_image_cost = 0.04
+        return per_image_cost * inputs.num_images

--- a/packages/backend/tests/generators/implementations/test_reve_edit.py
+++ b/packages/backend/tests/generators/implementations/test_reve_edit.py
@@ -1,0 +1,587 @@
+"""
+Tests for FalReveEditGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.reve_edit import (
+    FalReveEditGenerator,
+    ReveEditInput,
+)
+
+
+class TestReveEditInput:
+    """Tests for ReveEditInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = ReveEditInput(
+            prompt="Give him a friend",
+            image_url=image_artifact,
+            num_images=2,
+            output_format="jpeg",
+        )
+
+        assert input_data.prompt == "Give him a friend"
+        assert input_data.image_url == image_artifact
+        assert input_data.num_images == 2
+        assert input_data.output_format == "jpeg"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = ReveEditInput(
+            prompt="Test prompt",
+            image_url=image_artifact,
+        )
+
+        assert input_data.num_images == 1
+        assert input_data.output_format == "png"
+        assert input_data.sync_mode is False
+
+    def test_invalid_output_format(self):
+        """Test validation fails for invalid output format."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            ReveEditInput(
+                prompt="Test",
+                image_url=image_artifact,
+                output_format="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_prompt_min_length(self):
+        """Test validation fails for empty prompt."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            ReveEditInput(
+                prompt="",
+                image_url=image_artifact,
+            )
+
+    def test_prompt_max_length(self):
+        """Test validation fails for prompt exceeding max length."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Create a prompt that exceeds 2560 characters
+        long_prompt = "a" * 2561
+
+        with pytest.raises(ValidationError):
+            ReveEditInput(
+                prompt=long_prompt,
+                image_url=image_artifact,
+            )
+
+    def test_num_images_validation(self):
+        """Test validation for num_images constraints."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            ReveEditInput(
+                prompt="Test",
+                image_url=image_artifact,
+                num_images=0,
+            )
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            ReveEditInput(
+                prompt="Test",
+                image_url=image_artifact,
+                num_images=5,
+            )
+
+    def test_output_format_options(self):
+        """Test all valid output format options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_formats = ["png", "jpeg", "webp"]
+
+        for fmt in valid_formats:
+            input_data = ReveEditInput(
+                prompt="Test",
+                image_url=image_artifact,
+                output_format=fmt,  # type: ignore[arg-type]
+            )
+            assert input_data.output_format == fmt
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalReveEditGenerator:
+    """Tests for FalReveEditGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalReveEditGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-reve-edit"
+        assert self.generator.artifact_type == "image"
+        assert "reve" in self.generator.description.lower()
+        assert "edit" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == ReveEditInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/image.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+
+            input_data = ReveEditInput(
+                prompt="Test prompt",
+                image_url=image_artifact,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation with single image output."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = ReveEditInput(
+            prompt="Give him a friend",
+            image_url=input_image,
+            num_images=1,
+            output_format="jpeg",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 1024,
+                            "height": 768,
+                        }
+                    ],
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=768,
+                format="jpeg",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    # Return a fake local file path
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            mock_fal_client.upload_file_async.assert_called_once_with("/tmp/fake_image.png")
+
+            # Verify API calls with uploaded URL
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/reve/edit",
+                arguments={
+                    "prompt": "Give him a friend",
+                    "image_url": fake_uploaded_url,  # Should use uploaded URL, not original
+                    "num_images": 1,
+                    "output_format": "jpeg",
+                    "sync_mode": False,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_multiple_images(self):
+        """Test successful generation with multiple image outputs."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = ReveEditInput(
+            prompt="Add dramatic lighting",
+            image_url=input_image,
+            num_images=3,
+            output_format="png",
+        )
+
+        fake_output_urls = [
+            "https://storage.googleapis.com/falserverless/output1.png",
+            "https://storage.googleapis.com/falserverless/output2.png",
+            "https://storage.googleapis.com/falserverless/output3.png",
+        ]
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {"url": fake_output_urls[0], "width": 1920, "height": 1080},
+                        {"url": fake_output_urls[1], "width": 1920, "height": 1080},
+                        {"url": fake_output_urls[2], "width": 1920, "height": 1080},
+                    ],
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage results
+            mock_artifacts = [
+                ImageArtifact(
+                    generation_id="test_gen",
+                    storage_url=url,
+                    width=1920,
+                    height=1080,
+                    format="png",
+                )
+                for url in fake_output_urls
+            ]
+
+            artifact_idx = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    nonlocal artifact_idx
+                    result = mock_artifacts[artifact_idx]
+                    artifact_idx += 1
+                    return result
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 3
+
+            # Verify file upload was called once (single input image)
+            assert mock_fal_client.upload_file_async.call_count == 1
+
+            # Verify API call
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["num_images"] == 3
+            assert call_args[1]["arguments"]["image_url"] == fake_uploaded_url
+
+    @pytest.mark.asyncio
+    async def test_generate_no_images_returned(self):
+        """Test generation fails when API returns no images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = ReveEditInput(
+            prompt="test",
+            image_url=input_image,
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"images": []})
+
+            fake_uploaded_url = "https://fal.media/files/uploaded.png"
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No images returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = ReveEditInput(
+            prompt="Test prompt",
+            image_url=input_image,
+            num_images=1,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.04 * 1)
+        assert cost == 0.04
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_multiple_images(self):
+        """Test cost estimation for multiple images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = ReveEditInput(
+            prompt="Test prompt",
+            image_url=input_image,
+            num_images=4,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.04 * 4)
+        assert cost == 0.16
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = ReveEditInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "image_url" in schema["properties"]
+        assert "num_images" in schema["properties"]
+        assert "output_format" in schema["properties"]
+        assert "sync_mode" in schema["properties"]
+
+        # Check that prompt has length constraints
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop["minLength"] == 1
+        assert prompt_prop["maxLength"] == 2560
+
+        # Check that num_images has constraints
+        num_images_prop = schema["properties"]["num_images"]
+        assert num_images_prop["minimum"] == 1
+        assert num_images_prop["maximum"] == 4
+        assert num_images_prop["default"] == 1

--- a/packages/backend/tests/generators/implementations/test_reve_edit_live.py
+++ b/packages/backend/tests/generators/implementations/test_reve_edit_live.py
@@ -1,0 +1,215 @@
+"""
+Live API tests for FalReveEditGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_reve_edit_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_reve_edit_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.implementations.fal.image.reve_edit import (
+    FalReveEditGenerator,
+    ReveEditInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestReveEditGeneratorLive:
+    """Live API tests for FalReveEditGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalReveEditGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test basic image editing with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses a small publicly accessible test image to minimize cost.
+        """
+        # Use a small publicly accessible test image (512x512 solid color)
+        # This is a simple red square image that's small and cheap to process
+        test_image_url = "https://placehold.co/512x512/ff0000/ff0000.png"
+
+        # Create test image artifact
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url=test_image_url,
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create minimal input to reduce cost
+        inputs = ReveEditInput(
+            prompt="Add a simple white border",
+            image_url=test_artifact,
+            num_images=1,  # Single image
+            output_format="jpeg",  # JPEG is smaller
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+        assert artifact.format == "jpeg"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_multiple_outputs(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with multiple image outputs.
+
+        Verifies that num_images parameter works correctly.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/512x512/00ff00/00ff00.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input2",
+            storage_url=test_image_url,
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create input requesting 2 images
+        inputs = ReveEditInput(
+            prompt="Change color to blue",
+            image_url=test_artifact,
+            num_images=2,  # Multiple outputs
+            output_format="jpeg",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result has 2 outputs
+        assert result.outputs is not None
+        assert len(result.outputs) == 2
+
+        # Verify both artifacts
+        for artifact in result.outputs:
+            assert isinstance(artifact, ImageArtifact)
+            assert artifact.storage_url.startswith("https://")
+            if artifact.width is not None:
+                assert artifact.width > 0
+            if artifact.height is not None:
+                assert artifact.height > 0
+            assert artifact.format == "jpeg"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_different_output_formats(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with different output formats.
+
+        Verifies that output_format parameter is correctly processed.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/512x512/0000ff/0000ff.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input3",
+            storage_url=test_image_url,
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create input with webp output format
+        inputs = ReveEditInput(
+            prompt="Add texture",
+            image_url=test_artifact,
+            num_images=1,
+            output_format="webp",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.format == "webp"
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Create dummy input (artifact won't be used for estimation)
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url="https://example.com/test.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Single image
+        inputs_1 = ReveEditInput(prompt="test", image_url=test_artifact, num_images=1)
+        cost_1 = await self.generator.estimate_cost(inputs_1)
+
+        # Multiple images
+        inputs_4 = ReveEditInput(prompt="test", image_url=test_artifact, num_images=4)
+        cost_4 = await self.generator.estimate_cost(inputs_4)
+
+        # Cost should scale linearly with number of images
+        assert cost_4 == cost_1 * 4
+
+        # Sanity check on absolute costs ($0.04 per image)
+        assert cost_1 == 0.04
+        assert cost_1 > 0.0
+        assert cost_1 < 0.1  # Should be under $0.10 per image


### PR DESCRIPTION
Add fal-ai/reve/edit image editing generator with:
- Generator implementation with image artifact input support
- Comprehensive unit tests for input validation and generation
- Live API tests for real endpoint verification
- Module exports and generators.yaml configuration