### PR TITLE
Create FAL generator for Veo 3.1 image-to-video

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -167,6 +167,9 @@ generators:
   - class: "boards.generators.implementations.fal.video.veo3.FalVeo3Generator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.video.veo31_fast_image_to_video.FalVeo31FastImageToVideoGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.video.veo31_first_last_frame_to_video.FalVeo31FirstLastFrameToVideoGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
@@ -29,6 +29,7 @@ from .sync_lipsync_v2 import FalSyncLipsyncV2Generator
 from .sync_lipsync_v2_pro import FalSyncLipsyncV2ProGenerator
 from .veed_lipsync import FalVeedLipsyncGenerator
 from .veo3 import FalVeo3Generator
+from .veo31_fast_image_to_video import FalVeo31FastImageToVideoGenerator
 from .veo31_first_last_frame_to_video import FalVeo31FirstLastFrameToVideoGenerator
 from .veo31_image_to_video import FalVeo31ImageToVideoGenerator
 from .veo31_reference_to_video import FalVeo31ReferenceToVideoGenerator
@@ -52,6 +53,7 @@ __all__ = [
     "FalVeedLipsyncGenerator",
     "FalSyncLipsyncV2ProGenerator",
     "FalVeo3Generator",
+    "FalVeo31FastImageToVideoGenerator",
     "FalVeo31FirstLastFrameToVideoGenerator",
     "FalVeo31ImageToVideoGenerator",
     "FalVeo31ReferenceToVideoGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/video/veo31_fast_image_to_video.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/veo31_fast_image_to_video.py
@@ -1,0 +1,191 @@
+"""
+Google Veo 3.1 Fast image-to-video generator.
+
+Converts static images into animated videos based on text prompts using
+Google's Veo 3.1 Fast technology via fal.ai. This is a faster version
+with per-second pricing.
+
+Based on Fal AI's fal-ai/veo3.1/fast/image-to-video model.
+See: https://fal.ai/models/fal-ai/veo3.1/fast/image-to-video
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class Veo31FastImageToVideoInput(BaseModel):
+    """Input schema for Veo 3.1 Fast image-to-video generation.
+
+    Artifact fields (image) are automatically detected via type introspection
+    and resolved from generation IDs to ImageArtifact objects.
+    """
+
+    prompt: str = Field(description="Text prompt describing the desired video content and motion")
+    image: ImageArtifact = Field(
+        description="Input image to animate. Should be 720p or higher in 16:9 or 9:16 aspect ratio"
+    )
+    aspect_ratio: Literal["auto", "9:16", "16:9"] = Field(
+        default="auto",
+        description="Aspect ratio of the generated video. "
+        "'auto' automatically detects from input image",
+    )
+    duration: Literal["4s", "6s", "8s"] = Field(
+        default="8s",
+        description="Duration of the generated video in seconds",
+    )
+    generate_audio: bool = Field(
+        default=True,
+        description="Whether to generate audio for the video. Disabling reduces cost by ~33%",
+    )
+    resolution: Literal["720p", "1080p"] = Field(
+        default="720p",
+        description="Resolution of the generated video",
+    )
+
+
+class FalVeo31FastImageToVideoGenerator(BaseGenerator):
+    """Generator for creating videos from static images using Google Veo 3.1 Fast."""
+
+    name = "fal-veo31-fast-image-to-video"
+    description = "Fal: Veo 3.1 Fast - Convert images to videos with text-guided animation"
+    artifact_type = "video"
+
+    def get_input_schema(self) -> type[Veo31FastImageToVideoInput]:
+        """Return the input schema for this generator."""
+        return Veo31FastImageToVideoInput
+
+    async def generate(
+        self, inputs: Veo31FastImageToVideoInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate video using fal.ai veo3.1/fast/image-to-video."""
+        # Check for API key
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalVeo31FastImageToVideoGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifact to Fal's public storage
+        # Fal API requires publicly accessible URLs, but our storage_url might be:
+        # - Localhost URLs (not publicly accessible)
+        # - Private S3 buckets (not publicly accessible)
+        # So we upload to Fal's temporary storage first
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal([inputs.image], context)
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "prompt": inputs.prompt,
+            "image_url": image_urls[0],
+            "aspect_ratio": inputs.aspect_ratio,
+            "duration": inputs.duration,
+            "generate_audio": inputs.generate_audio,
+            "resolution": inputs.resolution,
+        }
+
+        # Submit async job
+        handler = await fal_client.submit_async(
+            "fal-ai/veo3.1/fast/image-to-video",
+            arguments=arguments,
+        )
+
+        # Store external job ID
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+            # Sample every 3rd event to avoid spam
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract video from result
+        # Expected structure: {"video": {"url": "...", "content_type": "...", ...}}
+        video_data = result.get("video")
+        if not video_data:
+            raise ValueError("No video returned from fal.ai API")
+
+        video_url = video_data.get("url")
+        if not video_url:
+            raise ValueError("Video missing URL in fal.ai response")
+
+        # Calculate video dimensions based on resolution and aspect ratio
+        # For "auto" aspect ratio, assume 16:9 as the most common format
+        effective_aspect_ratio = inputs.aspect_ratio if inputs.aspect_ratio != "auto" else "16:9"
+
+        if inputs.resolution == "720p":
+            if effective_aspect_ratio == "16:9":
+                width, height = 1280, 720
+            else:  # 9:16
+                width, height = 720, 1280
+        else:  # 1080p
+            if effective_aspect_ratio == "16:9":
+                width, height = 1920, 1080
+            else:  # 9:16
+                width, height = 1080, 1920
+
+        # Parse duration from "Xs" format
+        duration_seconds = int(inputs.duration.rstrip("s"))
+
+        artifact = await context.store_video_result(
+            storage_url=video_url,
+            format="mp4",
+            width=width,
+            height=height,
+            duration=duration_seconds,
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: Veo31FastImageToVideoInput) -> float:
+        """Estimate cost for this generation in USD.
+
+        Pricing: $0.10 per second (audio off) or $0.15 per second (audio on).
+        """
+        # Parse duration from "Xs" format
+        duration_seconds = int(inputs.duration.rstrip("s"))
+
+        # Per-second pricing
+        if inputs.generate_audio:
+            cost_per_second = 0.15
+        else:
+            cost_per_second = 0.10
+
+        return duration_seconds * cost_per_second

--- a/packages/backend/tests/generators/implementations/test_veo31_fast_image_to_video.py
+++ b/packages/backend/tests/generators/implementations/test_veo31_fast_image_to_video.py
@@ -1,0 +1,763 @@
+"""
+Tests for FalVeo31FastImageToVideoGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact, VideoArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.video.veo31_fast_image_to_video import (
+    FalVeo31FastImageToVideoGenerator,
+    Veo31FastImageToVideoInput,
+)
+
+
+class TestVeo31FastImageToVideoInput:
+    """Tests for Veo31FastImageToVideoInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = Veo31FastImageToVideoInput(
+            prompt="A camera slowly panning across the landscape",
+            image=image,
+            aspect_ratio="16:9",
+            duration="8s",
+            generate_audio=True,
+            resolution="1080p",
+        )
+
+        assert input_data.prompt == "A camera slowly panning across the landscape"
+        assert input_data.image == image
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.duration == "8s"
+        assert input_data.generate_audio is True
+        assert input_data.resolution == "1080p"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Veo31FastImageToVideoInput(
+            prompt="Test prompt",
+            image=image,
+        )
+
+        assert input_data.aspect_ratio == "auto"
+        assert input_data.duration == "8s"
+        assert input_data.generate_audio is True
+        assert input_data.resolution == "720p"
+
+    def test_invalid_aspect_ratio(self):
+        """Test validation fails for invalid aspect ratio."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            Veo31FastImageToVideoInput(
+                prompt="Test",
+                image=image,
+                aspect_ratio="4:3",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_resolution(self):
+        """Test validation fails for invalid resolution."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            Veo31FastImageToVideoInput(
+                prompt="Test",
+                image=image,
+                resolution="4k",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_duration(self):
+        """Test validation fails for invalid duration."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            Veo31FastImageToVideoInput(
+                prompt="Test",
+                image=image,
+                duration="10s",  # type: ignore[arg-type]
+            )
+
+    def test_aspect_ratio_options(self):
+        """Test all valid aspect ratio options."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_ratios = ["auto", "9:16", "16:9"]
+
+        for ratio in valid_ratios:
+            input_data = Veo31FastImageToVideoInput(
+                prompt="Test",
+                image=image,
+                aspect_ratio=ratio,  # type: ignore[arg-type]
+            )
+            assert input_data.aspect_ratio == ratio
+
+    def test_duration_options(self):
+        """Test all valid duration options."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_durations = ["4s", "6s", "8s"]
+
+        for duration in valid_durations:
+            input_data = Veo31FastImageToVideoInput(
+                prompt="Test",
+                image=image,
+                duration=duration,  # type: ignore[arg-type]
+            )
+            assert input_data.duration == duration
+
+    def test_resolution_options(self):
+        """Test all valid resolution options."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_resolutions = ["720p", "1080p"]
+
+        for resolution in valid_resolutions:
+            input_data = Veo31FastImageToVideoInput(
+                prompt="Test",
+                image=image,
+                resolution=resolution,  # type: ignore[arg-type]
+            )
+            assert input_data.resolution == resolution
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalVeo31FastImageToVideoGenerator:
+    """Tests for FalVeo31FastImageToVideoGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalVeo31FastImageToVideoGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-veo31-fast-image-to-video"
+        assert self.generator.artifact_type == "video"
+        assert "Veo 3.1 Fast" in self.generator.description
+        assert "image" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == Veo31FastImageToVideoInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/input.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+
+            input_data = Veo31FastImageToVideoInput(
+                prompt="Test prompt",
+                image=image,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return VideoArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        duration=1,
+                        format="mp4",
+                        fps=None,
+                    )
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_720p_16_9(self):
+        """Test successful generation with 720p 16:9 resolution."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1280,
+            height=720,
+        )
+
+        input_data = Veo31FastImageToVideoInput(
+            prompt="A slow camera pan across a beautiful landscape",
+            image=image,
+            resolution="720p",
+            aspect_ratio="16:9",
+            duration="6s",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.mp4"
+        fake_uploaded_url = "https://fal.media/files/input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                        "file_name": "output.mp4",
+                        "file_size": 1024000,
+                    }
+                }
+            )
+
+            # Mock file upload
+            async def mock_upload(file_path):
+                return fake_uploaded_url
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1280,
+                height=720,
+                duration=6,
+                format="mp4",
+                fps=None,
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_input.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            assert mock_fal_client.upload_file_async.call_count == 1
+
+            # Verify API calls with uploaded URL
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/veo3.1/fast/image-to-video",
+                arguments={
+                    "prompt": "A slow camera pan across a beautiful landscape",
+                    "image_url": fake_uploaded_url,
+                    "aspect_ratio": "16:9",
+                    "duration": "6s",
+                    "generate_audio": True,
+                    "resolution": "720p",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_auto_aspect_ratio(self):
+        """Test successful generation with 'auto' aspect ratio (default)."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = Veo31FastImageToVideoInput(
+            prompt="Auto detect aspect ratio test",
+            image=image,
+            # aspect_ratio defaults to "auto"
+            duration="4s",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.mp4"
+        fake_uploaded_url = "https://fal.media/files/input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-auto"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                    }
+                }
+            )
+
+            async def mock_upload(file_path):
+                return fake_uploaded_url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1280,
+                height=720,
+                duration=4,
+                format="mp4",
+                fps=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_input.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify API call includes "auto" aspect ratio
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["aspect_ratio"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_1080p_9_16(self):
+        """Test successful generation with 1080p 9:16 resolution (portrait)."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1080,
+            height=1920,
+        )
+
+        input_data = Veo31FastImageToVideoInput(
+            prompt="Vertical video with dramatic zoom",
+            image=image,
+            resolution="1080p",
+            aspect_ratio="9:16",
+            duration="4s",
+            generate_audio=False,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.mp4"
+        fake_uploaded_url = "https://fal.media/files/input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                    }
+                }
+            )
+
+            async def mock_upload(file_path):
+                return fake_uploaded_url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1080,
+                height=1920,
+                duration=4,
+                format="mp4",
+                fps=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_input.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify API call arguments
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["resolution"] == "1080p"
+            assert call_args[1]["arguments"]["aspect_ratio"] == "9:16"
+            assert call_args[1]["arguments"]["duration"] == "4s"
+            assert call_args[1]["arguments"]["generate_audio"] is False
+
+    @pytest.mark.asyncio
+    async def test_generate_no_video_returned(self):
+        """Test generation fails when API returns no video."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Veo31FastImageToVideoInput(
+            prompt="Test",
+            image=image,
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})  # No video field
+
+            fake_uploaded_url = "https://fal.media/files/input.png"
+
+            async def mock_upload(file_path):
+                return fake_uploaded_url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_input.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No video returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_with_audio_4s(self):
+        """Test cost estimation with audio enabled and 4s duration."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Veo31FastImageToVideoInput(
+            prompt="Test prompt",
+            image=image,
+            generate_audio=True,
+            duration="4s",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # 4 seconds * $0.15/second = $0.60
+        assert cost == 0.60
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_with_audio_8s(self):
+        """Test cost estimation with audio enabled and 8s duration."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Veo31FastImageToVideoInput(
+            prompt="Test prompt",
+            image=image,
+            generate_audio=True,
+            duration="8s",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # 8 seconds * $0.15/second = $1.20
+        assert cost == 1.20
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_without_audio(self):
+        """Test cost estimation with audio disabled."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Veo31FastImageToVideoInput(
+            prompt="Test prompt",
+            image=image,
+            generate_audio=False,
+            duration="6s",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # 6 seconds * $0.10/second = $0.60
+        assert abs(cost - 0.60) < 0.001
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_audio_discount_percentage(self):
+        """Test that audio-off is ~33% cheaper than audio-on."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_with_audio = Veo31FastImageToVideoInput(
+            prompt="Test",
+            image=image,
+            generate_audio=True,
+            duration="6s",
+        )
+
+        input_without_audio = Veo31FastImageToVideoInput(
+            prompt="Test",
+            image=image,
+            generate_audio=False,
+            duration="6s",
+        )
+
+        cost_with_audio = await self.generator.estimate_cost(input_with_audio)
+        cost_without_audio = await self.generator.estimate_cost(input_without_audio)
+
+        # With audio: 6 * $0.15 = $0.90
+        # Without audio: 6 * $0.10 = $0.60
+        # Discount: ($0.90 - $0.60) / $0.90 = 33.3%
+        assert abs(cost_with_audio - 0.90) < 0.001
+        assert abs(cost_without_audio - 0.60) < 0.001
+        assert cost_without_audio < cost_with_audio
+        assert abs(cost_without_audio / cost_with_audio - (2 / 3)) < 0.001  # ~66.7% of audio price
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = Veo31FastImageToVideoInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "image" in schema["properties"]
+        assert "aspect_ratio" in schema["properties"]
+        assert "duration" in schema["properties"]
+        assert "generate_audio" in schema["properties"]
+        assert "resolution" in schema["properties"]
+
+        # Check that required fields are marked
+        assert set(schema["required"]) == {"prompt", "image"}
+
+        # Check defaults - note: "auto" is the default for this fast version
+        aspect_ratio_prop = schema["properties"]["aspect_ratio"]
+        assert aspect_ratio_prop["default"] == "auto"
+
+        duration_prop = schema["properties"]["duration"]
+        assert duration_prop["default"] == "8s"
+
+        resolution_prop = schema["properties"]["resolution"]
+        assert resolution_prop["default"] == "720p"
+
+        generate_audio_prop = schema["properties"]["generate_audio"]
+        assert generate_audio_prop["default"] is True

--- a/packages/backend/tests/generators/implementations/test_veo31_fast_image_to_video_live.py
+++ b/packages/backend/tests/generators/implementations/test_veo31_fast_image_to_video_live.py
@@ -1,0 +1,195 @@
+"""
+Live API tests for FalVeo31FastImageToVideoGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_veo31_fast_image_to_video_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_veo31_fast_image_to_video_live.py -v -m live_api
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+
+Note: Video generation costs $0.10-$0.15 per second.
+These tests use minimal settings (4s, no audio) to reduce costs.
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.implementations.fal.video.veo31_fast_image_to_video import (
+    FalVeo31FastImageToVideoGenerator,
+    Veo31FastImageToVideoInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+@pytest.fixture
+def test_image_artifact():
+    """Provide a sample image artifact for video generation testing."""
+    # Use a small publicly accessible test image from placehold.co
+    return ImageArtifact(
+        generation_id="test_input_image",
+        storage_url="https://placehold.co/256x256/ff0000/ff0000.png",
+        format="png",
+        width=256,
+        height=256,
+    )
+
+
+class TestVeo31FastImageToVideoGeneratorLive:
+    """Live API tests for FalVeo31FastImageToVideoGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalVeo31FastImageToVideoGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic_720p(
+        self,
+        skip_if_no_fal_key,
+        image_resolving_context,
+        cost_logger,
+        test_image_artifact,
+    ):
+        """
+        Test basic video generation with minimal parameters (720p, 4s, no audio).
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses 720p resolution, shortest duration (4s), and disabled audio to minimize cost.
+        Cost: 4 seconds * $0.10 = $0.40
+        """
+        # Create minimal input to reduce cost
+        inputs = Veo31FastImageToVideoInput(
+            prompt="gentle zoom in",
+            image=test_image_artifact,
+            resolution="720p",  # Lower resolution to reduce cost
+            aspect_ratio="auto",  # Use auto detection
+            duration="4s",  # Shortest duration to reduce cost
+            generate_audio=False,  # Disable audio (cheaper)
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        from boards.generators.artifacts import VideoArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.width is not None and artifact.width > 0
+        assert artifact.height is not None and artifact.height > 0
+        assert artifact.duration is not None and artifact.duration > 0
+        assert artifact.format == "mp4"
+
+        # Verify duration matches requested
+        assert artifact.duration == 4
+
+    @pytest.mark.asyncio
+    async def test_generate_with_explicit_aspect_ratio(
+        self,
+        skip_if_no_fal_key,
+        image_resolving_context,
+        cost_logger,
+        test_image_artifact,
+    ):
+        """
+        Test video generation with explicit 16:9 aspect ratio.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses minimal settings to reduce cost.
+        Cost: 4 seconds * $0.10 = $0.40
+        """
+        # Create input with explicit aspect ratio
+        inputs = Veo31FastImageToVideoInput(
+            prompt="slow pan across scene",
+            image=test_image_artifact,
+            resolution="720p",
+            aspect_ratio="16:9",  # Explicit aspect ratio instead of auto
+            duration="4s",
+            generate_audio=False,
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        from boards.generators.artifacts import VideoArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.format == "mp4"
+
+        # Verify expected dimensions for 720p 16:9
+        assert artifact.width == 1280
+        assert artifact.height == 720
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_per_second_pricing(self, skip_if_no_fal_key, test_image_artifact):
+        """
+        Test that cost estimation reflects per-second pricing.
+
+        This doesn't make an API call, just verifies the cost logic.
+        """
+        # Test 4s with audio ($0.15/sec)
+        inputs_4s_audio = Veo31FastImageToVideoInput(
+            prompt="test",
+            image=test_image_artifact,
+            duration="4s",
+            generate_audio=True,
+        )
+        cost_4s_audio = await self.generator.estimate_cost(inputs_4s_audio)
+        assert cost_4s_audio == 4 * 0.15  # $0.60
+
+        # Test 8s with audio ($0.15/sec)
+        inputs_8s_audio = Veo31FastImageToVideoInput(
+            prompt="test",
+            image=test_image_artifact,
+            duration="8s",
+            generate_audio=True,
+        )
+        cost_8s_audio = await self.generator.estimate_cost(inputs_8s_audio)
+        assert cost_8s_audio == 8 * 0.15  # $1.20
+
+        # Test 6s without audio ($0.10/sec)
+        inputs_6s_no_audio = Veo31FastImageToVideoInput(
+            prompt="test",
+            image=test_image_artifact,
+            duration="6s",
+            generate_audio=False,
+        )
+        cost_6s_no_audio = await self.generator.estimate_cost(inputs_6s_no_audio)
+        assert cost_6s_no_audio == 6 * 0.10  # $0.60
+
+        # Verify pricing scales linearly with duration
+        assert cost_8s_audio == 2 * cost_4s_audio


### PR DESCRIPTION
Add FalVeo31FastImageToVideoGenerator for converting static images to animated videos using Google Veo 3.1 Fast technology via fal.ai.

Key features:
- Per-second pricing: $0.10/sec (no audio), $0.15/sec (with audio)
- Auto aspect ratio detection option (in addition to 16:9, 9:16)
- Durations: 4s, 6s, 8s
- Resolutions: 720p, 1080p
- Optional audio generation

Includes comprehensive unit tests (20 tests) and live API tests.