### PR TITLE
Create FAL generator for Veo 3.1

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -167,6 +167,9 @@ generators:
   - class: "boards.generators.implementations.fal.video.veo3.FalVeo3Generator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.video.veo31.FalVeo31Generator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.video.veo31_fast.FalVeo31FastGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
@@ -29,6 +29,7 @@ from .sync_lipsync_v2 import FalSyncLipsyncV2Generator
 from .sync_lipsync_v2_pro import FalSyncLipsyncV2ProGenerator
 from .veed_lipsync import FalVeedLipsyncGenerator
 from .veo3 import FalVeo3Generator
+from .veo31 import FalVeo31Generator
 from .veo31_fast import FalVeo31FastGenerator
 from .veo31_fast_image_to_video import FalVeo31FastImageToVideoGenerator
 from .veo31_first_last_frame_to_video import FalVeo31FirstLastFrameToVideoGenerator
@@ -54,6 +55,7 @@ __all__ = [
     "FalVeedLipsyncGenerator",
     "FalSyncLipsyncV2ProGenerator",
     "FalVeo3Generator",
+    "FalVeo31Generator",
     "FalVeo31FastGenerator",
     "FalVeo31FastImageToVideoGenerator",
     "FalVeo31FirstLastFrameToVideoGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/video/veo31.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/veo31.py
@@ -1,0 +1,190 @@
+"""
+Google Veo 3.1 text-to-video generator.
+
+The most advanced AI video generation model in the world by Google, featuring
+audio generation capabilities and enhanced quality over Veo 3.
+
+Based on Fal AI's fal-ai/veo3.1 model.
+See: https://fal.ai/models/fal-ai/veo3.1
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class Veo31Input(BaseModel):
+    """Input schema for Google Veo 3.1 text-to-video generation."""
+
+    prompt: str = Field(description="The text prompt describing the video you want to generate")
+    aspect_ratio: Literal["9:16", "16:9"] = Field(
+        default="16:9",
+        description="Aspect ratio of the generated video",
+    )
+    duration: Literal["4s", "6s", "8s"] = Field(
+        default="8s",
+        description="Duration of the generated video",
+    )
+    resolution: Literal["720p", "1080p"] = Field(
+        default="720p",
+        description="Resolution of the generated video",
+    )
+    generate_audio: bool = Field(
+        default=True,
+        description="Whether to generate audio for the video. If false, 50% less credits used",
+    )
+    enhance_prompt: bool = Field(
+        default=True,
+        description="Whether to enhance video generation quality",
+    )
+    auto_fix: bool = Field(
+        default=True,
+        description="Automatically attempt to rewrite prompts that fail content policy validation",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Seed value for reproducible generation",
+    )
+    negative_prompt: str | None = Field(
+        default=None,
+        description="Guidance text to exclude elements from generation",
+    )
+
+
+class FalVeo31Generator(BaseGenerator):
+    """Generator for text-to-video using Google Veo 3.1."""
+
+    name = "fal-veo31"
+    description = "Fal: Veo 3.1 - Google's most advanced AI video generation model with audio"
+    artifact_type = "video"
+
+    def get_input_schema(self) -> type[Veo31Input]:
+        """Return the input schema for this generator."""
+        return Veo31Input
+
+    async def generate(
+        self, inputs: Veo31Input, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate video using fal.ai veo3.1."""
+        # Check for API key
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalVeo31Generator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "prompt": inputs.prompt,
+            "aspect_ratio": inputs.aspect_ratio,
+            "duration": inputs.duration,
+            "resolution": inputs.resolution,
+            "generate_audio": inputs.generate_audio,
+            "enhance_prompt": inputs.enhance_prompt,
+            "auto_fix": inputs.auto_fix,
+        }
+
+        # Add optional parameters if provided
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+        if inputs.negative_prompt is not None:
+            arguments["negative_prompt"] = inputs.negative_prompt
+
+        # Submit async job
+        handler = await fal_client.submit_async(
+            "fal-ai/veo3.1",
+            arguments=arguments,
+        )
+
+        # Store external job ID
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+            # Sample every 3rd event to avoid spam
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract video from result
+        # Expected structure: {"video": {"url": "...", "content_type": "...", ...}}
+        video_data = result.get("video")
+        if not video_data:
+            raise ValueError("No video returned from fal.ai API")
+
+        video_url = video_data.get("url")
+        if not video_url:
+            raise ValueError("Video missing URL in fal.ai response")
+
+        # Determine video dimensions based on resolution and aspect ratio
+        if inputs.resolution == "720p":
+            if inputs.aspect_ratio == "16:9":
+                width, height = 1280, 720
+            else:  # 9:16
+                width, height = 720, 1280
+        else:  # 1080p
+            if inputs.aspect_ratio == "16:9":
+                width, height = 1920, 1080
+            else:  # 9:16
+                width, height = 1080, 1920
+
+        # Parse duration from "8s" format
+        duration_seconds = int(inputs.duration.rstrip("s"))
+
+        # Store video result
+        artifact = await context.store_video_result(
+            storage_url=video_url,
+            format="mp4",
+            width=width,
+            height=height,
+            duration=duration_seconds,
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: Veo31Input) -> float:
+        """Estimate cost for this generation in USD.
+
+        Note: Pricing information not available in Fal documentation.
+        Using placeholder value that should be updated with actual pricing.
+        """
+        # TODO: Update with actual pricing from Fal when available
+        # Base cost, with 50% reduction if audio is disabled
+        base_cost = 0.15  # Placeholder estimate
+        if not inputs.generate_audio:
+            return base_cost * 0.5
+        return base_cost

--- a/packages/backend/tests/generators/implementations/test_veo31.py
+++ b/packages/backend/tests/generators/implementations/test_veo31.py
@@ -1,0 +1,496 @@
+"""
+Tests for FalVeo31Generator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import VideoArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.video.veo31 import (
+    FalVeo31Generator,
+    Veo31Input,
+)
+
+
+class TestVeo31Input:
+    """Tests for Veo31Input schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        input_data = Veo31Input(
+            prompt="A scenic sunset over the ocean",
+            aspect_ratio="16:9",
+            duration="8s",
+            resolution="1080p",
+            generate_audio=True,
+            enhance_prompt=True,
+            auto_fix=True,
+            seed=42,
+            negative_prompt="low quality, blurry",
+        )
+
+        assert input_data.prompt == "A scenic sunset over the ocean"
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.duration == "8s"
+        assert input_data.resolution == "1080p"
+        assert input_data.generate_audio is True
+        assert input_data.enhance_prompt is True
+        assert input_data.auto_fix is True
+        assert input_data.seed == 42
+        assert input_data.negative_prompt == "low quality, blurry"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = Veo31Input(prompt="Test prompt")
+
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.duration == "8s"
+        assert input_data.resolution == "720p"
+        assert input_data.generate_audio is True
+        assert input_data.enhance_prompt is True
+        assert input_data.auto_fix is True
+        assert input_data.seed is None
+        assert input_data.negative_prompt is None
+
+    def test_invalid_aspect_ratio(self):
+        """Test validation fails for invalid aspect ratio."""
+        with pytest.raises(ValidationError):
+            Veo31Input(
+                prompt="Test",
+                aspect_ratio="4:3",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_aspect_ratio_square(self):
+        """Test validation fails for 1:1 aspect ratio (not supported in Veo 3.1)."""
+        with pytest.raises(ValidationError):
+            Veo31Input(
+                prompt="Test",
+                aspect_ratio="1:1",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_duration(self):
+        """Test validation fails for invalid duration."""
+        with pytest.raises(ValidationError):
+            Veo31Input(
+                prompt="Test",
+                duration="10s",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_resolution(self):
+        """Test validation fails for invalid resolution."""
+        with pytest.raises(ValidationError):
+            Veo31Input(
+                prompt="Test",
+                resolution="4k",  # type: ignore[arg-type]
+            )
+
+    def test_all_aspect_ratio_options(self):
+        """Test all valid aspect ratio options."""
+        valid_ratios = ["9:16", "16:9"]
+
+        for ratio in valid_ratios:
+            input_data = Veo31Input(
+                prompt="Test",
+                aspect_ratio=ratio,  # type: ignore[arg-type]
+            )
+            assert input_data.aspect_ratio == ratio
+
+    def test_all_duration_options(self):
+        """Test all valid duration options."""
+        valid_durations = ["4s", "6s", "8s"]
+
+        for duration in valid_durations:
+            input_data = Veo31Input(
+                prompt="Test",
+                duration=duration,  # type: ignore[arg-type]
+            )
+            assert input_data.duration == duration
+
+    def test_all_resolution_options(self):
+        """Test all valid resolution options."""
+        valid_resolutions = ["720p", "1080p"]
+
+        for resolution in valid_resolutions:
+            input_data = Veo31Input(
+                prompt="Test",
+                resolution=resolution,  # type: ignore[arg-type]
+            )
+            assert input_data.resolution == resolution
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalVeo31Generator:
+    """Tests for FalVeo31Generator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalVeo31Generator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-veo31"
+        assert self.generator.artifact_type == "video"
+        assert "Veo 3.1" in self.generator.description
+        assert "Google" in self.generator.description
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == Veo31Input
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = Veo31Input(
+                prompt="Test prompt",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return VideoArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="mp4",
+                        duration=8.0,
+                        fps=30,
+                    )
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_720p(self):
+        """Test successful generation with 720p resolution."""
+        input_data = Veo31Input(
+            prompt="A cinematic sunset over mountains",
+            duration="8s",
+            aspect_ratio="16:9",
+            resolution="720p",
+        )
+
+        fake_video_url = "https://storage.googleapis.com/falserverless/output.mp4"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_video_url,
+                        "content_type": "video/mp4",
+                        "file_name": "output.mp4",
+                    }
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_video_url,
+                width=1280,
+                height=720,
+                format="mp4",
+                duration=8,
+                fps=30,
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    raise NotImplementedError
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify API call
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/veo3.1",
+                arguments={
+                    "prompt": "A cinematic sunset over mountains",
+                    "aspect_ratio": "16:9",
+                    "duration": "8s",
+                    "resolution": "720p",
+                    "generate_audio": True,
+                    "enhance_prompt": True,
+                    "auto_fix": True,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_1080p_portrait(self):
+        """Test successful generation with 1080p portrait video."""
+        input_data = Veo31Input(
+            prompt="A person walking through a city",
+            duration="6s",
+            aspect_ratio="9:16",
+            resolution="1080p",
+            generate_audio=False,
+            enhance_prompt=False,
+            auto_fix=False,
+            seed=123,
+            negative_prompt="blurry, distorted",
+        )
+
+        fake_video_url = "https://storage.googleapis.com/falserverless/output_portrait.mp4"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_video_url,
+                        "content_type": "video/mp4",
+                    }
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_video_url,
+                width=1080,
+                height=1920,
+                format="mp4",
+                duration=6,
+                fps=30,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    raise NotImplementedError
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify API call with custom parameters
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["duration"] == "6s"
+            assert call_args[1]["arguments"]["aspect_ratio"] == "9:16"
+            assert call_args[1]["arguments"]["resolution"] == "1080p"
+            assert call_args[1]["arguments"]["generate_audio"] is False
+            assert call_args[1]["arguments"]["enhance_prompt"] is False
+            assert call_args[1]["arguments"]["auto_fix"] is False
+            assert call_args[1]["arguments"]["seed"] == 123
+            assert call_args[1]["arguments"]["negative_prompt"] == "blurry, distorted"
+
+    @pytest.mark.asyncio
+    async def test_generate_no_video_returned(self):
+        """Test generation fails when API returns no video."""
+        input_data = Veo31Input(prompt="test")
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-error"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})  # No video field
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    raise NotImplementedError
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No video returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_with_audio(self):
+        """Test cost estimation with audio enabled."""
+        input_data = Veo31Input(
+            prompt="Test prompt",
+            generate_audio=True,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Base cost with audio
+        assert cost == 0.15
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_without_audio(self):
+        """Test cost estimation with audio disabled (50% cheaper)."""
+        input_data = Veo31Input(
+            prompt="Test prompt",
+            generate_audio=False,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # 50% of base cost when audio disabled
+        assert cost == 0.075
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = Veo31Input.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "aspect_ratio" in schema["properties"]
+        assert "duration" in schema["properties"]
+        assert "resolution" in schema["properties"]
+        assert "generate_audio" in schema["properties"]
+        assert "enhance_prompt" in schema["properties"]
+        assert "auto_fix" in schema["properties"]
+        assert "seed" in schema["properties"]
+        assert "negative_prompt" in schema["properties"]
+
+        # Check that required fields are marked
+        assert schema["required"] == ["prompt"]
+
+        # Check defaults
+        aspect_ratio_prop = schema["properties"]["aspect_ratio"]
+        assert aspect_ratio_prop["default"] == "16:9"
+
+        duration_prop = schema["properties"]["duration"]
+        assert duration_prop["default"] == "8s"
+
+        resolution_prop = schema["properties"]["resolution"]
+        assert resolution_prop["default"] == "720p"
+
+        generate_audio_prop = schema["properties"]["generate_audio"]
+        assert generate_audio_prop["default"] is True
+
+        enhance_prompt_prop = schema["properties"]["enhance_prompt"]
+        assert enhance_prompt_prop["default"] is True
+
+        auto_fix_prop = schema["properties"]["auto_fix"]
+        assert auto_fix_prop["default"] is True

--- a/packages/backend/tests/generators/implementations/test_veo31_live.py
+++ b/packages/backend/tests/generators/implementations/test_veo31_live.py
@@ -1,0 +1,145 @@
+"""
+Live API tests for FalVeo31Generator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_veo31_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_veo31_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.implementations.fal.video.veo31 import (
+    FalVeo31Generator,
+    Veo31Input,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestVeo31GeneratorLive:
+    """Live API tests for FalVeo31Generator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalVeo31Generator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, dummy_context, cost_logger):
+        """
+        Test basic video generation with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses minimal/cheap settings to reduce cost.
+        """
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(Veo31Input(prompt="test"))
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Create minimal input to reduce cost
+        inputs = Veo31Input(
+            prompt="A simple rotating sphere",
+            duration="4s",  # Shortest duration
+            resolution="720p",  # Lowest resolution
+            aspect_ratio="16:9",  # Standard format
+            generate_audio=False,  # Save 50% cost by disabling audio
+        )
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        from boards.generators.artifacts import VideoArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.width is not None and artifact.width > 0
+        assert artifact.height is not None and artifact.height > 0
+        assert artifact.format == "mp4"
+        assert artifact.duration == 4
+
+    @pytest.mark.asyncio
+    async def test_generate_with_custom_parameters(
+        self, skip_if_no_fal_key, dummy_context, cost_logger
+    ):
+        """
+        Test video generation with custom parameters.
+
+        Verifies that custom parameters like seed and negative_prompt are correctly processed.
+        """
+        # Create input with custom parameters
+        inputs = Veo31Input(
+            prompt="A serene mountain landscape at sunset",
+            duration="6s",
+            aspect_ratio="16:9",
+            resolution="720p",  # Use 720p to reduce cost
+            generate_audio=False,  # Save 50% cost
+            enhance_prompt=True,
+            auto_fix=True,
+            seed=42,
+            negative_prompt="motion blur, shaky camera, low quality",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        from boards.generators.artifacts import VideoArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.width == 1280
+        assert artifact.height == 720
+        assert artifact.format == "mp4"
+        assert artifact.duration == 6
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Test with audio enabled (full cost)
+        inputs_with_audio = Veo31Input(prompt="test", generate_audio=True)
+        cost_with_audio = await self.generator.estimate_cost(inputs_with_audio)
+
+        # Test without audio (50% cost)
+        inputs_without_audio = Veo31Input(prompt="test", generate_audio=False)
+        cost_without_audio = await self.generator.estimate_cost(inputs_without_audio)
+
+        # Without audio should be 50% of with audio
+        assert cost_without_audio == cost_with_audio * 0.5
+
+        # Verify estimates are in reasonable range
+        assert cost_with_audio > 0.0
+        assert cost_with_audio < 1.0  # Sanity check - should be well under $1.00
+        assert cost_without_audio > 0.0
+        assert cost_without_audio < 0.5


### PR DESCRIPTION
Add FalVeo31Generator for Google's Veo 3.1 model via Fal.ai. This is a text-to-video generator with audio synthesis capabilities.

Features:
- Configurable duration (4s, 6s, 8s)
- Resolution options (720p, 1080p)
- Aspect ratios (16:9, 9:16)
- Optional audio generation (50% cost reduction when disabled)
- Prompt enhancement and auto-fix options
- Seed-based reproducibility
- Negative prompt support

Includes comprehensive unit tests and live API test suite.