### PR TITLE
Create FAL image-to-video generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -185,6 +185,9 @@ generators:
   - class: "boards.generators.implementations.fal.video.veo31_reference_to_video.FalVeo31ReferenceToVideoGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.video.wan_25_preview_image_to_video.FalWan25PreviewImageToVideoGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.video.wan_pro_image_to_video.FalWanProImageToVideoGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
@@ -35,6 +35,7 @@ from .veo31_fast_image_to_video import FalVeo31FastImageToVideoGenerator
 from .veo31_first_last_frame_to_video import FalVeo31FirstLastFrameToVideoGenerator
 from .veo31_image_to_video import FalVeo31ImageToVideoGenerator
 from .veo31_reference_to_video import FalVeo31ReferenceToVideoGenerator
+from .wan_25_preview_image_to_video import FalWan25PreviewImageToVideoGenerator
 from .wan_pro_image_to_video import FalWanProImageToVideoGenerator
 
 __all__ = [
@@ -61,5 +62,6 @@ __all__ = [
     "FalVeo31FirstLastFrameToVideoGenerator",
     "FalVeo31ImageToVideoGenerator",
     "FalVeo31ReferenceToVideoGenerator",
+    "FalWan25PreviewImageToVideoGenerator",
     "FalWanProImageToVideoGenerator",
 ]

--- a/packages/backend/src/boards/generators/implementations/fal/video/wan_25_preview_image_to_video.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/wan_25_preview_image_to_video.py
@@ -1,0 +1,212 @@
+"""
+WAN 2.5 Preview image-to-video generator.
+
+An image-to-video generation model that creates dynamic video content from static
+images using text prompts to guide motion and camera movement. Supports durations
+of 5 or 10 seconds at 480p, 720p, or 1080p resolution.
+
+Based on Fal AI's fal-ai/wan-25-preview/image-to-video model.
+See: https://fal.ai/models/fal-ai/wan-25-preview/image-to-video
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class Wan25PreviewImageToVideoInput(BaseModel):
+    """Input schema for WAN 2.5 Preview image-to-video generation.
+
+    Artifact fields (image) are automatically detected via type introspection
+    and resolved from generation IDs to ImageArtifact objects.
+    """
+
+    image: ImageArtifact = Field(
+        description="The image to use as the first frame for video generation"
+    )
+    prompt: str = Field(
+        description="The text prompt describing the desired video motion. Max 800 characters.",
+        max_length=800,
+    )
+    duration: Literal["5", "10"] = Field(
+        default="5",
+        description="Duration of the generated video in seconds",
+    )
+    resolution: Literal["480p", "720p", "1080p"] = Field(
+        default="1080p",
+        description="Resolution of the generated video",
+    )
+    audio_url: str | None = Field(
+        default=None,
+        description=(
+            "URL of a WAV or MP3 audio file (3-30 seconds, max 15MB) for background music. "
+            "Audio is truncated or padded to match video duration."
+        ),
+    )
+    seed: int | None = Field(
+        default=None,
+        description=(
+            "Random seed for reproducibility. " "If not specified, a random seed will be used."
+        ),
+    )
+    negative_prompt: str | None = Field(
+        default=None,
+        description="Content to avoid in the generated video. Max 500 characters.",
+        max_length=500,
+    )
+    enable_prompt_expansion: bool = Field(
+        default=True,
+        description="Enable LLM-based prompt rewriting to improve results",
+    )
+    enable_safety_checker: bool = Field(
+        default=True,
+        description="Enable content safety filtering",
+    )
+
+
+class FalWan25PreviewImageToVideoGenerator(BaseGenerator):
+    """Generator for creating videos from static images using WAN 2.5 Preview."""
+
+    name = "fal-wan-25-preview-image-to-video"
+    description = "Fal: WAN 2.5 Preview - Generate videos from images with motion guidance"
+    artifact_type = "video"
+
+    def get_input_schema(self) -> type[Wan25PreviewImageToVideoInput]:
+        """Return the input schema for this generator."""
+        return Wan25PreviewImageToVideoInput
+
+    async def generate(
+        self, inputs: Wan25PreviewImageToVideoInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate video using fal.ai wan-25-preview/image-to-video."""
+        # Check for API key
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalWan25PreviewImageToVideoGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifact to Fal's public storage
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal([inputs.image], context)
+
+        # Prepare arguments for fal.ai API
+        arguments: dict = {
+            "image_url": image_urls[0],
+            "prompt": inputs.prompt,
+            "duration": inputs.duration,
+            "resolution": inputs.resolution,
+            "enable_prompt_expansion": inputs.enable_prompt_expansion,
+            "enable_safety_checker": inputs.enable_safety_checker,
+        }
+
+        # Only add optional parameters if provided
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+
+        if inputs.negative_prompt is not None:
+            arguments["negative_prompt"] = inputs.negative_prompt
+
+        if inputs.audio_url is not None:
+            arguments["audio_url"] = inputs.audio_url
+
+        # Submit async job
+        handler = await fal_client.submit_async(
+            "fal-ai/wan-25-preview/image-to-video",
+            arguments=arguments,
+        )
+
+        # Store external job ID
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+            # Sample every 3rd event to avoid spam
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract video from result
+        # Expected structure: {"video": {"url": "...", "width": ..., "height": ..., ...}}
+        video_data = result.get("video")
+        if not video_data:
+            raise ValueError("No video returned from fal.ai API")
+
+        video_url = video_data.get("url")
+        if not video_url:
+            raise ValueError("Video missing URL in fal.ai response")
+
+        # Get video dimensions based on resolution setting
+        resolution_map = {
+            "480p": (854, 480),
+            "720p": (1280, 720),
+            "1080p": (1920, 1080),
+        }
+        default_width, default_height = resolution_map.get(inputs.resolution, (1920, 1080))
+
+        # Use actual dimensions from response if available, otherwise use defaults
+        width = video_data.get("width", default_width)
+        height = video_data.get("height", default_height)
+        fps = video_data.get("fps", 30)
+        duration = video_data.get("duration", int(inputs.duration))
+
+        # Store video result
+        artifact = await context.store_video_result(
+            storage_url=video_url,
+            format="mp4",
+            width=width,
+            height=height,
+            duration=duration,
+            fps=fps,
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: Wan25PreviewImageToVideoInput) -> float:
+        """Estimate cost for this generation in USD.
+
+        Note: Pricing information not available in Fal documentation.
+        Using placeholder value that should be updated with actual pricing.
+        """
+        # TODO: Update with actual pricing from Fal when available
+        # Estimate based on duration - longer videos cost more
+        base_cost = 0.10
+        if inputs.duration == "10":
+            return base_cost * 2.0  # 10 second videos cost more
+        return base_cost

--- a/packages/backend/tests/generators/implementations/test_wan_25_preview_image_to_video.py
+++ b/packages/backend/tests/generators/implementations/test_wan_25_preview_image_to_video.py
@@ -1,0 +1,630 @@
+"""
+Tests for FalWan25PreviewImageToVideoGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from boards.generators.artifacts import ImageArtifact, VideoArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.video.wan_25_preview_image_to_video import (
+    FalWan25PreviewImageToVideoGenerator,
+    Wan25PreviewImageToVideoInput,
+)
+
+
+class TestWan25PreviewImageToVideoInput:
+    """Tests for Wan25PreviewImageToVideoInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        prompt = "A stylish woman walks down a Tokyo street filled with warm glowing neon"
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt=prompt,
+            duration="10",
+            resolution="1080p",
+            seed=42,
+            negative_prompt="blurry, distorted",
+            enable_prompt_expansion=True,
+            enable_safety_checker=True,
+        )
+
+        assert input_data.prompt == prompt
+        assert input_data.image == image
+        assert input_data.duration == "10"
+        assert input_data.resolution == "1080p"
+        assert input_data.seed == 42
+        assert input_data.negative_prompt == "blurry, distorted"
+        assert input_data.enable_prompt_expansion is True
+        assert input_data.enable_safety_checker is True
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="Test prompt",
+        )
+
+        assert input_data.duration == "5"
+        assert input_data.resolution == "1080p"
+        assert input_data.seed is None
+        assert input_data.negative_prompt is None
+        assert input_data.audio_url is None
+        assert input_data.enable_prompt_expansion is True
+        assert input_data.enable_safety_checker is True
+
+    def test_duration_values(self):
+        """Test that duration accepts valid values."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Test 5 seconds
+        input_data_5 = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="Test prompt",
+            duration="5",
+        )
+        assert input_data_5.duration == "5"
+
+        # Test 10 seconds
+        input_data_10 = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="Test prompt",
+            duration="10",
+        )
+        assert input_data_10.duration == "10"
+
+    def test_resolution_values(self):
+        """Test that resolution accepts valid values."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        for resolution in ["480p", "720p", "1080p"]:
+            input_data = Wan25PreviewImageToVideoInput(
+                image=image,
+                prompt="Test prompt",
+                resolution=resolution,  # type: ignore[arg-type]
+            )
+            assert input_data.resolution == resolution
+
+    def test_seed_optional(self):
+        """Test that seed can be None."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="Test prompt",
+            seed=None,
+        )
+
+        assert input_data.seed is None
+
+    def test_audio_url_optional(self):
+        """Test that audio_url can be provided."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="Test prompt",
+            audio_url="https://example.com/background.mp3",
+        )
+
+        assert input_data.audio_url == "https://example.com/background.mp3"
+
+    def test_prompt_expansion_disabled(self):
+        """Test that prompt expansion can be disabled."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="Test prompt",
+            enable_prompt_expansion=False,
+        )
+
+        assert input_data.enable_prompt_expansion is False
+
+    def test_safety_checker_disabled(self):
+        """Test that safety checker can be disabled."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="Test prompt",
+            enable_safety_checker=False,
+        )
+
+        assert input_data.enable_safety_checker is False
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalWan25PreviewImageToVideoGenerator:
+    """Tests for FalWan25PreviewImageToVideoGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalWan25PreviewImageToVideoGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-wan-25-preview-image-to-video"
+        assert self.generator.artifact_type == "video"
+        assert "WAN 2.5" in self.generator.description
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == Wan25PreviewImageToVideoInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/input.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+
+            input_data = Wan25PreviewImageToVideoInput(
+                image=image,
+                prompt="Test prompt",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return VideoArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        duration=1,
+                        format="mp4",
+                        fps=None,
+                    )
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful(self):
+        """Test successful generation with default parameters."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="cinematic camera movement through a vibrant city",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.mp4"
+        fake_uploaded_image = "https://fal.media/files/input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                        "file_name": "output.mp4",
+                        "file_size": 2048000,
+                        "width": 1920,
+                        "height": 1080,
+                        "fps": 30,
+                        "duration": 5,
+                    },
+                    "seed": 12345,
+                    "actual_prompt": "expanded prompt",
+                }
+            )
+
+            # Mock file upload
+            async def mock_upload(file_path):
+                return fake_uploaded_image
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1920,
+                height=1080,
+                duration=5,
+                format="mp4",
+                fps=30,
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            assert mock_fal_client.upload_file_async.call_count == 1
+
+            # Verify API call arguments
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/wan-25-preview/image-to-video",
+                arguments={
+                    "image_url": fake_uploaded_image,
+                    "prompt": "cinematic camera movement through a vibrant city",
+                    "duration": "5",
+                    "resolution": "1080p",
+                    "enable_prompt_expansion": True,
+                    "enable_safety_checker": True,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_with_all_parameters(self):
+        """Test successful generation with all parameters."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="Test prompt",
+            duration="10",
+            resolution="720p",
+            seed=12345,
+            negative_prompt="blurry, low quality",
+            audio_url="https://example.com/music.mp3",
+            enable_prompt_expansion=False,
+            enable_safety_checker=False,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.mp4"
+        fake_uploaded_image = "https://fal.media/files/input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                        "width": 1280,
+                        "height": 720,
+                        "fps": 30,
+                        "duration": 10,
+                    }
+                }
+            )
+
+            async def mock_upload(file_path):
+                return fake_uploaded_image
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1280,
+                height=720,
+                duration=10,
+                format="mp4",
+                fps=30,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify API call includes all parameters
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["seed"] == 12345
+            assert call_args[1]["arguments"]["negative_prompt"] == "blurry, low quality"
+            assert call_args[1]["arguments"]["audio_url"] == "https://example.com/music.mp3"
+            assert call_args[1]["arguments"]["duration"] == "10"
+            assert call_args[1]["arguments"]["resolution"] == "720p"
+            assert call_args[1]["arguments"]["enable_prompt_expansion"] is False
+            assert call_args[1]["arguments"]["enable_safety_checker"] is False
+
+    @pytest.mark.asyncio
+    async def test_generate_no_video_returned(self):
+        """Test generation fails when API returns no video."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="test",
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})  # No video field
+
+            fake_uploaded_image = "https://fal.media/files/input.png"
+
+            async def mock_upload(file_path):
+                return fake_uploaded_image
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No video returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_5_seconds(self):
+        """Test cost estimation for 5 second video."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="Test prompt",
+            duration="5",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Base cost for 5 seconds
+        assert cost == 0.10
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_10_seconds(self):
+        """Test cost estimation for 10 second video."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = Wan25PreviewImageToVideoInput(
+            image=image,
+            prompt="Test prompt",
+            duration="10",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Double cost for 10 seconds
+        assert cost == 0.20
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = Wan25PreviewImageToVideoInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "image" in schema["properties"]
+        assert "prompt" in schema["properties"]
+        assert "duration" in schema["properties"]
+        assert "resolution" in schema["properties"]
+        assert "seed" in schema["properties"]
+        assert "negative_prompt" in schema["properties"]
+        assert "audio_url" in schema["properties"]
+        assert "enable_prompt_expansion" in schema["properties"]
+        assert "enable_safety_checker" in schema["properties"]
+
+        # Check that required fields are marked
+        assert set(schema["required"]) == {"image", "prompt"}
+
+        # Check defaults
+        assert schema["properties"]["duration"]["default"] == "5"
+        assert schema["properties"]["resolution"]["default"] == "1080p"
+        assert schema["properties"]["enable_prompt_expansion"]["default"] is True
+        assert schema["properties"]["enable_safety_checker"]["default"] is True

--- a/packages/backend/tests/generators/implementations/test_wan_25_preview_image_to_video_live.py
+++ b/packages/backend/tests/generators/implementations/test_wan_25_preview_image_to_video_live.py
@@ -1,0 +1,177 @@
+"""
+Live API tests for FalWan25PreviewImageToVideoGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_wan_25_preview_image_to_video_live.py \
+        -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_wan_25_preview_image_to_video_live.py \
+        -v -m live_api
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+
+Note: Video generation is expensive. This test uses a small input image and
+short duration to reduce costs.
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.implementations.fal.video.wan_25_preview_image_to_video import (
+    FalWan25PreviewImageToVideoGenerator,
+    Wan25PreviewImageToVideoInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+@pytest.fixture
+def test_image_artifact():
+    """Provide sample image artifact for video generation testing."""
+    # Use small publicly accessible test image from placehold.co
+    return ImageArtifact(
+        generation_id="test_input_image",
+        storage_url="https://placehold.co/512x512/0088ff/ffffff.png?text=Test",
+        format="png",
+        width=512,
+        height=512,
+    )
+
+
+class TestWan25PreviewImageToVideoGeneratorLive:
+    """Live API tests for FalWan25PreviewImageToVideoGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalWan25PreviewImageToVideoGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(
+        self,
+        skip_if_no_fal_key,
+        image_resolving_context,
+        cost_logger,
+        test_image_artifact,
+    ):
+        """
+        Test basic video generation with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses a small input image, short duration, and low resolution to minimize cost.
+        """
+        # Create minimal input to reduce cost
+        inputs = Wan25PreviewImageToVideoInput(
+            image=test_image_artifact,
+            prompt="gentle camera movement",  # Short, simple prompt
+            duration="5",  # Shortest duration
+            resolution="480p",  # Lowest resolution
+            enable_safety_checker=True,
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        from boards.generators.artifacts import VideoArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+        assert artifact.duration is not None and artifact.duration > 0
+        assert artifact.format == "mp4"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_seed(
+        self,
+        skip_if_no_fal_key,
+        image_resolving_context,
+        cost_logger,
+        test_image_artifact,
+    ):
+        """
+        Test video generation with seed for reproducibility.
+
+        This test makes a real API call to verify seed parameter works.
+        Uses minimal settings to reduce cost.
+        """
+        # Create input with seed
+        inputs = Wan25PreviewImageToVideoInput(
+            image=test_image_artifact,
+            prompt="slow zoom out",
+            duration="5",
+            resolution="480p",
+            seed=42,
+            enable_safety_checker=True,
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact
+        from boards.generators.artifacts import VideoArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_reasonable(self, skip_if_no_fal_key, test_image_artifact):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Test 5 second video
+        inputs_5s = Wan25PreviewImageToVideoInput(
+            image=test_image_artifact,
+            prompt="test",
+            duration="5",
+        )
+        estimated_cost_5s = await self.generator.estimate_cost(inputs_5s)
+
+        # Test 10 second video
+        inputs_10s = Wan25PreviewImageToVideoInput(
+            image=test_image_artifact,
+            prompt="test",
+            duration="10",
+        )
+        estimated_cost_10s = await self.generator.estimate_cost(inputs_10s)
+
+        # Verify estimates are in reasonable range
+        assert estimated_cost_5s > 0.0
+        assert estimated_cost_5s < 1.0  # Sanity check - should be under $1 per video
+        assert estimated_cost_10s > estimated_cost_5s  # 10s should cost more than 5s
+        assert estimated_cost_10s < 2.0  # Should be under $2


### PR DESCRIPTION
Add FalWan25PreviewImageToVideoGenerator for fal-ai/wan-25-preview/image-to-video model. This generator creates dynamic video content from static images using text prompts to guide motion and camera movement.

Features:
- Supports 5 or 10 second video durations
- Resolution options: 480p, 720p, 1080p
- Optional background audio support
- Prompt expansion and safety checker options
- Seed parameter for reproducibility
- Negative prompt support

Includes comprehensive unit tests and live API tests.