### PR TITLE
Create FAL text-to-video generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -188,6 +188,9 @@ generators:
   - class: "boards.generators.implementations.fal.video.wan_25_preview_image_to_video.FalWan25PreviewImageToVideoGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.video.wan_25_preview_text_to_video.FalWan25PreviewTextToVideoGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.video.wan_pro_image_to_video.FalWanProImageToVideoGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
@@ -36,6 +36,7 @@ from .veo31_first_last_frame_to_video import FalVeo31FirstLastFrameToVideoGenera
 from .veo31_image_to_video import FalVeo31ImageToVideoGenerator
 from .veo31_reference_to_video import FalVeo31ReferenceToVideoGenerator
 from .wan_25_preview_image_to_video import FalWan25PreviewImageToVideoGenerator
+from .wan_25_preview_text_to_video import FalWan25PreviewTextToVideoGenerator
 from .wan_pro_image_to_video import FalWanProImageToVideoGenerator
 
 __all__ = [
@@ -63,5 +64,6 @@ __all__ = [
     "FalVeo31ImageToVideoGenerator",
     "FalVeo31ReferenceToVideoGenerator",
     "FalWan25PreviewImageToVideoGenerator",
+    "FalWan25PreviewTextToVideoGenerator",
     "FalWanProImageToVideoGenerator",
 ]

--- a/packages/backend/src/boards/generators/implementations/fal/video/wan_25_preview_text_to_video.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/wan_25_preview_text_to_video.py
@@ -1,0 +1,208 @@
+"""
+Wan 2.5 Preview text-to-video generator.
+
+A text-to-video generation model that converts text prompts into video content,
+supporting both Chinese and English inputs up to 800 characters.
+
+Based on Fal AI's fal-ai/wan-25-preview/text-to-video model.
+See: https://fal.ai/models/fal-ai/wan-25-preview/text-to-video
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class Wan25PreviewTextToVideoInput(BaseModel):
+    """Input schema for Wan 2.5 Preview text-to-video generation.
+
+    Artifact fields are automatically detected via type introspection
+    and resolved from generation IDs to artifact objects.
+    """
+
+    prompt: str = Field(
+        description="Text prompt for video generation. Supports Chinese and English.",
+        min_length=1,
+        max_length=800,
+    )
+    aspect_ratio: Literal["16:9", "9:16", "1:1"] = Field(
+        default="16:9",
+        description="Aspect ratio of the generated video",
+    )
+    resolution: Literal["480p", "720p", "1080p"] = Field(
+        default="1080p",
+        description="Resolution of the generated video",
+    )
+    duration: Literal[5, 10] = Field(
+        default=5,
+        description="Duration of the generated video in seconds",
+    )
+    audio_url: str | None = Field(
+        default=None,
+        description="URL of background audio (WAV/MP3). Must be 3-30 seconds and max 15MB. "
+        "Audio longer than video is truncated; shorter audio results in silent sections.",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Random seed for reproducibility",
+    )
+    enable_safety_checker: bool = Field(
+        default=True,
+        description="Whether to enable safety filtering",
+    )
+    negative_prompt: str | None = Field(
+        default=None,
+        description="Content to avoid in generation",
+        max_length=500,
+    )
+    enable_prompt_expansion: bool = Field(
+        default=True,
+        description="Whether to expand short prompts for improved results. "
+        "Increases processing time but improves quality for short prompts.",
+    )
+
+
+class FalWan25PreviewTextToVideoGenerator(BaseGenerator):
+    """Generator for text-to-video using Wan 2.5 Preview."""
+
+    name = "fal-wan-25-preview-text-to-video"
+    description = (
+        "Fal: Wan 2.5 Preview - Text-to-video generation supporting "
+        "Chinese/English prompts up to 800 characters"
+    )
+    artifact_type = "video"
+
+    def get_input_schema(self) -> type[Wan25PreviewTextToVideoInput]:
+        """Return the input schema for this generator."""
+        return Wan25PreviewTextToVideoInput
+
+    async def generate(
+        self, inputs: Wan25PreviewTextToVideoInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate video using fal.ai Wan 2.5 Preview model."""
+        # Check for API key
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalWan25PreviewTextToVideoGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Prepare arguments for fal.ai API
+        arguments: dict = {
+            "prompt": inputs.prompt,
+            "aspect_ratio": inputs.aspect_ratio,
+            "resolution": inputs.resolution,
+            "duration": inputs.duration,
+            "enable_safety_checker": inputs.enable_safety_checker,
+            "enable_prompt_expansion": inputs.enable_prompt_expansion,
+        }
+
+        # Add optional parameters
+        if inputs.audio_url is not None:
+            arguments["audio_url"] = inputs.audio_url
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+        if inputs.negative_prompt is not None:
+            arguments["negative_prompt"] = inputs.negative_prompt
+
+        # Submit async job
+        handler = await fal_client.submit_async(
+            "fal-ai/wan-25-preview/text-to-video",
+            arguments=arguments,
+        )
+
+        # Store external job ID
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+            # Sample every 3rd event to avoid spam
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract video from result
+        video_data = result.get("video")
+        if not video_data:
+            raise ValueError("No video returned from fal.ai API")
+
+        video_url = video_data.get("url")
+        if not video_url:
+            raise ValueError("Video missing URL in fal.ai response")
+
+        # Extract video metadata from response or use defaults
+        width = video_data.get("width")
+        height = video_data.get("height")
+        duration = video_data.get("duration")
+        fps = video_data.get("fps")
+
+        # If dimensions not provided, determine based on aspect ratio and resolution
+        if width is None or height is None:
+            resolution_dimensions = {
+                "480p": {"16:9": (854, 480), "9:16": (480, 854), "1:1": (480, 480)},
+                "720p": {"16:9": (1280, 720), "9:16": (720, 1280), "1:1": (720, 720)},
+                "1080p": {"16:9": (1920, 1080), "9:16": (1080, 1920), "1:1": (1080, 1080)},
+            }
+            dims = resolution_dimensions.get(inputs.resolution, {}).get(
+                inputs.aspect_ratio, (1920, 1080)
+            )
+            width, height = dims
+
+        # Store video result
+        artifact = await context.store_video_result(
+            storage_url=video_url,
+            format="mp4",
+            width=width,
+            height=height,
+            duration=float(duration) if duration else float(inputs.duration),
+            fps=fps,
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: Wan25PreviewTextToVideoInput) -> float:
+        """Estimate cost for Wan 2.5 Preview generation.
+
+        Pricing information not provided in official documentation.
+        Estimated at $0.10 per 5-second video based on typical video generation costs.
+        Cost scales with duration.
+        """
+        # Base cost per 5-second video
+        base_cost = 0.10
+        # Scale by duration: 5s = 1x, 10s = 2x
+        duration_multiplier = inputs.duration / 5
+        return base_cost * duration_multiplier

--- a/packages/backend/tests/generators/implementations/test_wan_25_preview_text_to_video.py
+++ b/packages/backend/tests/generators/implementations/test_wan_25_preview_text_to_video.py
@@ -1,0 +1,697 @@
+"""
+Tests for FalWan25PreviewTextToVideoGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import VideoArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.video.wan_25_preview_text_to_video import (
+    FalWan25PreviewTextToVideoGenerator,
+    Wan25PreviewTextToVideoInput,
+)
+
+
+class TestWan25PreviewTextToVideoInput:
+    """Tests for Wan25PreviewTextToVideoInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        input_data = Wan25PreviewTextToVideoInput(
+            prompt="A beautiful sunset over the ocean",
+            resolution="1080p",
+            aspect_ratio="16:9",
+            duration=10,
+        )
+
+        assert input_data.prompt == "A beautiful sunset over the ocean"
+        assert input_data.resolution == "1080p"
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.duration == 10
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = Wan25PreviewTextToVideoInput(
+            prompt="Test prompt",
+        )
+
+        assert input_data.resolution == "1080p"
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.duration == 5
+        assert input_data.audio_url is None
+        assert input_data.seed is None
+        assert input_data.enable_safety_checker is True
+        assert input_data.negative_prompt is None
+        assert input_data.enable_prompt_expansion is True
+
+    def test_invalid_duration(self):
+        """Test validation fails for invalid duration."""
+        with pytest.raises(ValidationError):
+            Wan25PreviewTextToVideoInput(
+                prompt="Test",
+                duration=7,  # type: ignore[arg-type]
+            )
+
+    def test_invalid_aspect_ratio(self):
+        """Test validation fails for invalid aspect ratio."""
+        with pytest.raises(ValidationError):
+            Wan25PreviewTextToVideoInput(
+                prompt="Test",
+                aspect_ratio="4:3",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_resolution(self):
+        """Test validation fails for invalid resolution."""
+        with pytest.raises(ValidationError):
+            Wan25PreviewTextToVideoInput(
+                prompt="Test",
+                resolution="4k",  # type: ignore[arg-type]
+            )
+
+    def test_prompt_min_length(self):
+        """Test prompt min length validation."""
+        # This should fail (empty string)
+        with pytest.raises(ValidationError):
+            Wan25PreviewTextToVideoInput(prompt="")
+
+    def test_prompt_max_length(self):
+        """Test prompt max length validation."""
+        # This should succeed (exactly at limit)
+        long_prompt = "a" * 800
+        input_data = Wan25PreviewTextToVideoInput(prompt=long_prompt)
+        assert len(input_data.prompt) == 800
+
+        # This should fail (over limit)
+        too_long_prompt = "a" * 801
+        with pytest.raises(ValidationError):
+            Wan25PreviewTextToVideoInput(prompt=too_long_prompt)
+
+    def test_negative_prompt_max_length(self):
+        """Test negative_prompt max length validation."""
+        # This should succeed (exactly at limit)
+        input_data = Wan25PreviewTextToVideoInput(prompt="Test", negative_prompt="a" * 500)
+        assert len(input_data.negative_prompt) == 500  # type: ignore[arg-type]
+
+        # This should fail (over limit)
+        with pytest.raises(ValidationError):
+            Wan25PreviewTextToVideoInput(prompt="Test", negative_prompt="a" * 501)
+
+    def test_all_duration_options(self):
+        """Test all valid duration options."""
+        valid_durations = [5, 10]
+
+        for duration in valid_durations:
+            input_data = Wan25PreviewTextToVideoInput(
+                prompt="Test",
+                duration=duration,  # type: ignore[arg-type]
+            )
+            assert input_data.duration == duration
+
+    def test_all_aspect_ratio_options(self):
+        """Test all valid aspect ratio options."""
+        valid_ratios = ["16:9", "9:16", "1:1"]
+
+        for ratio in valid_ratios:
+            input_data = Wan25PreviewTextToVideoInput(
+                prompt="Test",
+                aspect_ratio=ratio,  # type: ignore[arg-type]
+            )
+            assert input_data.aspect_ratio == ratio
+
+    def test_all_resolution_options(self):
+        """Test all valid resolution options."""
+        valid_resolutions = ["480p", "720p", "1080p"]
+
+        for resolution in valid_resolutions:
+            input_data = Wan25PreviewTextToVideoInput(
+                prompt="Test",
+                resolution=resolution,  # type: ignore[arg-type]
+            )
+            assert input_data.resolution == resolution
+
+    def test_optional_parameters(self):
+        """Test optional parameters are correctly set."""
+        input_data = Wan25PreviewTextToVideoInput(
+            prompt="Test prompt",
+            audio_url="https://example.com/audio.mp3",
+            seed=42,
+            negative_prompt="blurry, low quality",
+            enable_safety_checker=False,
+            enable_prompt_expansion=False,
+        )
+
+        assert input_data.audio_url == "https://example.com/audio.mp3"
+        assert input_data.seed == 42
+        assert input_data.negative_prompt == "blurry, low quality"
+        assert input_data.enable_safety_checker is False
+        assert input_data.enable_prompt_expansion is False
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalWan25PreviewTextToVideoGenerator:
+    """Tests for FalWan25PreviewTextToVideoGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalWan25PreviewTextToVideoGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-wan-25-preview-text-to-video"
+        assert self.generator.artifact_type == "video"
+        assert "Wan 2.5 Preview" in self.generator.description
+        assert "text-to-video" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == Wan25PreviewTextToVideoInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = Wan25PreviewTextToVideoInput(
+                prompt="Test prompt",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return VideoArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="mp4",
+                        duration=5.0,
+                        fps=30,
+                    )
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_5_second_video(self):
+        """Test successful generation with 5-second video."""
+        input_data = Wan25PreviewTextToVideoInput(
+            prompt="A cinematic sunset over mountains",
+            duration=5,
+            aspect_ratio="16:9",
+            resolution="1080p",
+        )
+
+        fake_video_url = "https://storage.googleapis.com/falserverless/output.mp4"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result with metadata
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_video_url,
+                        "content_type": "video/mp4",
+                        "file_name": "output.mp4",
+                        "width": 1920,
+                        "height": 1080,
+                        "duration": 5.0,
+                        "fps": 30,
+                    },
+                    "seed": 12345,
+                    "actual_prompt": "A cinematic sunset over mountains (expanded)",
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_video_url,
+                width=1920,
+                height=1080,
+                format="mp4",
+                duration=5.0,
+                fps=30,
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    raise NotImplementedError
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify API call
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/wan-25-preview/text-to-video",
+                arguments={
+                    "prompt": "A cinematic sunset over mountains",
+                    "aspect_ratio": "16:9",
+                    "resolution": "1080p",
+                    "duration": 5,
+                    "enable_safety_checker": True,
+                    "enable_prompt_expansion": True,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_10_second_video_portrait(self):
+        """Test successful generation with 10-second portrait video."""
+        input_data = Wan25PreviewTextToVideoInput(
+            prompt="A person walking through a city",
+            duration=10,
+            aspect_ratio="9:16",
+            resolution="720p",
+        )
+
+        fake_video_url = "https://storage.googleapis.com/falserverless/output_portrait.mp4"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_video_url,
+                        "content_type": "video/mp4",
+                        "width": 720,
+                        "height": 1280,
+                        "duration": 10.0,
+                        "fps": 24,
+                    },
+                    "seed": 67890,
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_video_url,
+                width=720,
+                height=1280,
+                format="mp4",
+                duration=10.0,
+                fps=24,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    raise NotImplementedError
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify API call with custom parameters
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["duration"] == 10
+            assert call_args[1]["arguments"]["aspect_ratio"] == "9:16"
+            assert call_args[1]["arguments"]["resolution"] == "720p"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_optional_parameters(self):
+        """Test generation with optional parameters."""
+        input_data = Wan25PreviewTextToVideoInput(
+            prompt="A dynamic scene",
+            duration=5,
+            audio_url="https://example.com/audio.mp3",
+            seed=42,
+            negative_prompt="blurry, low quality",
+            enable_safety_checker=False,
+            enable_prompt_expansion=False,
+        )
+
+        fake_video_url = "https://storage.googleapis.com/falserverless/output.mp4"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_video_url,
+                        "content_type": "video/mp4",
+                        "width": 1920,
+                        "height": 1080,
+                        "duration": 5.0,
+                        "fps": 30,
+                    }
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_video_url,
+                width=1920,
+                height=1080,
+                format="mp4",
+                duration=5.0,
+                fps=30,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    raise NotImplementedError
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            await self.generator.generate(input_data, DummyCtx())
+
+            # Verify API call includes optional parameters
+            call_args = mock_fal_client.submit_async.call_args
+            arguments = call_args[1]["arguments"]
+            assert arguments["audio_url"] == "https://example.com/audio.mp3"
+            assert arguments["seed"] == 42
+            assert arguments["negative_prompt"] == "blurry, low quality"
+            assert arguments["enable_safety_checker"] is False
+            assert arguments["enable_prompt_expansion"] is False
+
+    @pytest.mark.asyncio
+    async def test_generate_with_fallback_dimensions(self):
+        """Test generation uses fallback dimensions when not provided by API."""
+        input_data = Wan25PreviewTextToVideoInput(
+            prompt="Abstract art animation",
+            aspect_ratio="1:1",
+            resolution="720p",
+        )
+
+        fake_video_url = "https://storage.googleapis.com/falserverless/output.mp4"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-fallback"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            # Return response without width/height
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_video_url,
+                        "content_type": "video/mp4",
+                        # No width, height, duration, or fps
+                    }
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_video_url,
+                width=720,
+                height=720,
+                format="mp4",
+                duration=5.0,
+                fps=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    raise NotImplementedError
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    # Verify fallback dimensions for 1:1 at 720p
+                    assert kwargs["width"] == 720
+                    assert kwargs["height"] == 720
+                    assert kwargs["duration"] == 5.0  # From input
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+            assert isinstance(result, GeneratorResult)
+
+    @pytest.mark.asyncio
+    async def test_generate_no_video_returned(self):
+        """Test generation fails when API returns no video."""
+        input_data = Wan25PreviewTextToVideoInput(
+            prompt="test",
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-error"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})  # No video in response
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    raise NotImplementedError
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No video returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_5_second(self):
+        """Test cost estimation for 5-second video."""
+        input_data = Wan25PreviewTextToVideoInput(
+            prompt="Test prompt",
+            duration=5,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # 5-second video: base cost * 1.0
+        assert cost == 0.10
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_10_second(self):
+        """Test cost estimation for 10-second video."""
+        input_data = Wan25PreviewTextToVideoInput(
+            prompt="Test prompt",
+            duration=10,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # 10-second video: base cost * 2.0
+        assert cost == 0.20
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = Wan25PreviewTextToVideoInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "resolution" in schema["properties"]
+        assert "aspect_ratio" in schema["properties"]
+        assert "duration" in schema["properties"]
+        assert "audio_url" in schema["properties"]
+        assert "seed" in schema["properties"]
+        assert "enable_safety_checker" in schema["properties"]
+        assert "negative_prompt" in schema["properties"]
+        assert "enable_prompt_expansion" in schema["properties"]
+
+        # Check prompt constraints
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop["minLength"] == 1
+        assert prompt_prop["maxLength"] == 800
+
+        # Check negative_prompt constraints
+        # Optional fields use anyOf structure in Pydantic JSON schema
+        negative_prompt_prop = schema["properties"]["negative_prompt"]
+        if "anyOf" in negative_prompt_prop:
+            # Find the string type in anyOf
+            string_type = next(
+                (t for t in negative_prompt_prop["anyOf"] if t.get("type") == "string"), None
+            )
+            assert string_type is not None
+            assert string_type.get("maxLength") == 500
+        else:
+            assert negative_prompt_prop.get("maxLength") == 500
+
+        # Check resolution enum
+        resolution_prop = schema["properties"]["resolution"]
+        assert "enum" in resolution_prop or "anyOf" in resolution_prop
+
+        # Check aspect_ratio enum
+        aspect_ratio_prop = schema["properties"]["aspect_ratio"]
+        assert "enum" in aspect_ratio_prop or "anyOf" in aspect_ratio_prop
+
+        # Check duration enum
+        duration_prop = schema["properties"]["duration"]
+        assert "enum" in duration_prop or "anyOf" in duration_prop

--- a/packages/backend/tests/generators/implementations/test_wan_25_preview_text_to_video_live.py
+++ b/packages/backend/tests/generators/implementations/test_wan_25_preview_text_to_video_live.py
@@ -1,0 +1,141 @@
+"""
+Live API tests for FalWan25PreviewTextToVideoGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_wan_25_preview_text_to_video_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_wan_25_preview_text_to_video_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.implementations.fal.video.wan_25_preview_text_to_video import (
+    FalWan25PreviewTextToVideoGenerator,
+    Wan25PreviewTextToVideoInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestWan25PreviewTextToVideoGeneratorLive:
+    """Live API tests for FalWan25PreviewTextToVideoGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalWan25PreviewTextToVideoGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, dummy_context, cost_logger):
+        """
+        Test basic video generation with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses minimal/cheap settings (5-second duration, 480p) to reduce cost.
+        """
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(
+            Wan25PreviewTextToVideoInput(prompt="test")
+        )
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Create minimal input to reduce cost
+        inputs = Wan25PreviewTextToVideoInput(
+            prompt="A simple rotating cube",
+            duration=5,  # Shortest duration
+            aspect_ratio="16:9",
+            resolution="480p",  # Lowest resolution to reduce cost
+        )
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        from boards.generators.artifacts import VideoArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.width is not None and artifact.width > 0
+        assert artifact.height is not None and artifact.height > 0
+        assert artifact.format == "mp4"
+        assert artifact.duration is not None
+        assert artifact.duration >= 5.0  # Should be at least 5 seconds
+
+    @pytest.mark.asyncio
+    async def test_generate_with_custom_parameters(
+        self, skip_if_no_fal_key, dummy_context, cost_logger
+    ):
+        """
+        Test video generation with custom parameters.
+
+        Verifies that custom aspect_ratio and resolution are correctly processed.
+        """
+        # Create input with custom parameters
+        inputs = Wan25PreviewTextToVideoInput(
+            prompt="A serene mountain landscape at sunset",
+            duration=5,  # Shortest duration to minimize cost
+            aspect_ratio="9:16",  # Portrait mode
+            resolution="480p",  # Lowest resolution to reduce cost
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        from boards.generators.artifacts import VideoArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.width is not None and artifact.width > 0
+        assert artifact.height is not None and artifact.height > 0
+        assert artifact.format == "mp4"
+        assert artifact.duration is not None
+        assert artifact.duration >= 5.0  # Should be at least 5 seconds
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_duration(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation scales with duration.
+
+        This doesn't make an API call, just verifies the cost logic.
+        """
+        # 5-second video
+        inputs_5s = Wan25PreviewTextToVideoInput(prompt="test", duration=5)
+        cost_5s = await self.generator.estimate_cost(inputs_5s)
+
+        # 10-second video
+        inputs_10s = Wan25PreviewTextToVideoInput(prompt="test", duration=10)
+        cost_10s = await self.generator.estimate_cost(inputs_10s)
+
+        # Cost should scale linearly with duration
+        assert cost_10s == cost_5s * 2
+
+        # Sanity check on absolute costs
+        assert cost_5s > 0.0
+        assert cost_5s < 1.0  # Should be under $1.00 per 5-second video


### PR DESCRIPTION
Add FalWan25PreviewTextToVideoGenerator for the fal-ai/wan-25-preview/text-to-video model. This text-to-video generator supports:

- Chinese and English prompts up to 800 characters
- Multiple aspect ratios (16:9, 9:16, 1:1)
- Multiple resolutions (480p, 720p, 1080p)
- 5 or 10 second video durations
- Optional background audio support
- Prompt expansion for improved short prompt results
- Safety filtering toggle
- Negative prompts for content to avoid