### PR TITLE
Create new generator for veed/fabric-1.0

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -158,6 +158,9 @@ generators:
   - class: "boards.generators.implementations.fal.video.sync_lipsync_v2.FalSyncLipsyncV2Generator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.video.veed_fabric_1_0.FalVeedFabric10Generator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.video.veed_lipsync.FalVeedLipsyncGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
@@ -27,6 +27,7 @@ from .sora_2_image_to_video_pro import FalSora2ImageToVideoProGenerator
 from .sora_2_text_to_video_pro import FalSora2TextToVideoProGenerator
 from .sync_lipsync_v2 import FalSyncLipsyncV2Generator
 from .sync_lipsync_v2_pro import FalSyncLipsyncV2ProGenerator
+from .veed_fabric_1_0 import FalVeedFabric10Generator
 from .veed_lipsync import FalVeedLipsyncGenerator
 from .veo3 import FalVeo3Generator
 from .veo31 import FalVeo31Generator
@@ -54,6 +55,7 @@ __all__ = [
     "FalSora2ImageToVideoGenerator",
     "FalSora2ImageToVideoProGenerator",
     "FalSyncLipsyncV2Generator",
+    "FalVeedFabric10Generator",
     "FalVeedLipsyncGenerator",
     "FalSyncLipsyncV2ProGenerator",
     "FalVeo3Generator",

--- a/packages/backend/src/boards/generators/implementations/fal/video/veed_fabric_1_0.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/veed_fabric_1_0.py
@@ -1,0 +1,180 @@
+"""
+VEED Fabric 1.0 image-to-video generator.
+
+Generate talking videos from any image using VEED Fabric 1.0.
+This generator turns a static image into a talking video with synchronized
+lip movements based on provided audio.
+
+Based on Fal AI's veed/fabric-1.0 model.
+See: https://fal.ai/models/veed/fabric-1.0
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import AudioArtifact, ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+from ..utils import upload_artifacts_to_fal
+
+
+class VeedFabric10Input(BaseModel):
+    """Input schema for VEED Fabric 1.0.
+
+    Artifact fields are automatically detected via type introspection
+    and resolved from generation IDs to artifact objects.
+    """
+
+    image_url: ImageArtifact = Field(description="Image to turn into a talking video")
+    audio_url: AudioArtifact = Field(description="Audio to synchronize with the image")
+    resolution: Literal["720p", "480p"] = Field(
+        default="720p", description="Output video resolution"
+    )
+
+
+class FalVeedFabric10Generator(BaseGenerator):
+    """Generator for turning images into talking videos using VEED Fabric 1.0."""
+
+    name = "veed-fabric-1.0"
+    description = "VEED: Fabric 1.0 - Turn any image into a talking video"
+    artifact_type = "video"
+
+    def get_input_schema(self) -> type[VeedFabric10Input]:
+        """Return the input schema for this generator."""
+        return VeedFabric10Input
+
+    async def generate(
+        self, inputs: VeedFabric10Input, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate talking video using VEED Fabric 1.0."""
+        # Check for API key
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalVeedFabric10Generator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image and audio artifacts to Fal's public storage
+        # Fal API requires publicly accessible URLs
+        image_urls = await upload_artifacts_to_fal([inputs.image_url], context)
+        audio_urls = await upload_artifacts_to_fal([inputs.audio_url], context)
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "image_url": image_urls[0],
+            "audio_url": audio_urls[0],
+            "resolution": inputs.resolution,
+        }
+
+        # Submit async job
+        handler = await fal_client.submit_async(
+            "veed/fabric-1.0",
+            arguments=arguments,
+        )
+
+        # Store external job ID
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+            # Sample every 3rd event to avoid spamming progress updates
+            if event_count % 3 == 0:
+                logs = getattr(event, "logs", None)
+                if logs:
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract video from result
+        # Fabric 1.0 API returns: {"video": {"url": "...", "content_type": "video/mp4", ...}}
+        video_data = result.get("video")
+
+        if not video_data:
+            raise ValueError(
+                "No video returned from VEED Fabric 1.0 API. "
+                f"Response structure: {list(result.keys())}"
+            )
+
+        video_url = video_data.get("url")
+        if not video_url:
+            raise ValueError(
+                f"Video missing URL in VEED response. Video data keys: {list(video_data.keys())}"
+            )
+
+        # Determine video format with fallback strategy:
+        # 1. Try to extract from URL extension
+        # 2. Parse content_type only if it's a video/* MIME type
+        # 3. Default to mp4
+        video_format = "mp4"  # Default
+
+        if video_url:
+            url_parts = video_url.split(".")
+            if len(url_parts) > 1:
+                ext = url_parts[-1].split("?")[0].lower()
+                if ext in ["mp4", "webm", "mov", "avi"]:
+                    video_format = ext
+
+        if video_format == "mp4":
+            content_type = video_data.get("content_type", "")
+            if content_type.startswith("video/"):
+                video_format = content_type.split("/")[-1]
+
+        # Determine output dimensions based on resolution
+        # 720p = 1280x720, 480p = 854x480 (16:9 aspect ratio)
+        if inputs.resolution == "720p":
+            output_width = 1280
+            output_height = 720
+        else:
+            output_width = 854
+            output_height = 480
+
+        # Store the video result
+        artifact = await context.store_video_result(
+            storage_url=video_url,
+            format=video_format,
+            width=output_width,
+            height=output_height,
+            duration=inputs.audio_url.duration,
+            fps=30.0,  # Standard frame rate for talking videos
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: VeedFabric10Input) -> float:
+        """Estimate cost for VEED Fabric 1.0 generation in USD.
+
+        Pricing not specified in documentation, using estimate based on
+        typical video lipsync processing costs.
+        """
+        # Fixed cost estimate of $0.08 per generation
+        # Based on typical AI video processing costs
+        # This is a conservative estimate and should be updated when official
+        # pricing information becomes available
+        return 0.08

--- a/packages/backend/tests/generators/implementations/test_veed_fabric_1_0.py
+++ b/packages/backend/tests/generators/implementations/test_veed_fabric_1_0.py
@@ -1,0 +1,547 @@
+"""
+Tests for FalVeedFabric10Generator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from boards.generators.artifacts import AudioArtifact, ImageArtifact, VideoArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.video.veed_fabric_1_0 import (
+    FalVeedFabric10Generator,
+    VeedFabric10Input,
+)
+
+
+class DummyCtx(GeneratorExecutionContext):
+    """Shared test context for all tests."""
+
+    generation_id = "test_gen"
+    provider_correlation_id = "corr"
+    tenant_id = "test_tenant"
+    board_id = "test_board"
+
+    async def resolve_artifact(self, artifact):
+        """Resolve artifacts to temporary file paths."""
+        if isinstance(artifact, ImageArtifact):
+            return "/tmp/fake_image.png"
+        elif isinstance(artifact, AudioArtifact):
+            return "/tmp/fake_audio.wav"
+        return "/tmp/fake_file"
+
+    async def store_image_result(self, **kwargs):
+        raise NotImplementedError
+
+    async def store_video_result(self, **kwargs):
+        return VideoArtifact(
+            generation_id="test_gen",
+            storage_url=kwargs.get("storage_url", ""),
+            width=kwargs.get("width", 1280),
+            height=kwargs.get("height", 720),
+            format=kwargs.get("format", "mp4"),
+            duration=kwargs.get("duration"),
+            fps=kwargs.get("fps"),
+        )
+
+    async def store_audio_result(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def store_text_result(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def publish_progress(self, update):
+        return None
+
+    async def set_external_job_id(self, external_id: str) -> None:
+        return None
+
+
+class TestVeedFabric10Input:
+    """Tests for VeedFabric10Input schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation with all fields."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=10.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = VeedFabric10Input(
+            image_url=image_artifact,
+            audio_url=audio_artifact,
+            resolution="720p",
+        )
+
+        assert input_data.image_url == image_artifact
+        assert input_data.audio_url == audio_artifact
+        assert input_data.resolution == "720p"
+
+    def test_valid_input_480p(self):
+        """Test valid input with 480p resolution."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=10.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = VeedFabric10Input(
+            image_url=image_artifact,
+            audio_url=audio_artifact,
+            resolution="480p",
+        )
+
+        assert input_data.resolution == "480p"
+
+    def test_default_resolution(self):
+        """Test that resolution defaults to 720p."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=10.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = VeedFabric10Input(
+            image_url=image_artifact,
+            audio_url=audio_artifact,
+        )
+
+        assert input_data.resolution == "720p"
+
+    def test_invalid_resolution(self):
+        """Test that invalid resolution values are rejected."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=10.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        with pytest.raises(ValueError):
+            VeedFabric10Input(
+                image_url=image_artifact,
+                audio_url=audio_artifact,
+                resolution="1080p",  # type: ignore[arg-type]  # Not a valid option - intentionally testing validation
+            )
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalVeedFabric10Generator:
+    """Tests for FalVeedFabric10Generator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalVeedFabric10Generator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "veed-fabric-1.0"
+        assert self.generator.artifact_type == "video"
+        assert "fabric" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == VeedFabric10Input
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/image.png",
+                format="png",
+                width=512,
+                height=512,
+            )
+            audio_artifact = AudioArtifact(
+                generation_id="gen2",
+                storage_url="https://example.com/audio.wav",
+                format="wav",
+                duration=None,
+                sample_rate=None,
+                channels=None,
+            )
+
+            input_data = VeedFabric10Input(
+                image_url=image_artifact,
+                audio_url=audio_artifact,
+            )
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_720p(self):
+        """Test successful generation with 720p resolution."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/input-image.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/input-audio.wav",
+            format="wav",
+            duration=12.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = VeedFabric10Input(
+            image_url=image_artifact,
+            audio_url=audio_artifact,
+            resolution="720p",
+        )
+
+        fake_output_url = "https://v3.fal.media/files/penguin/output.mp4"
+        fake_uploaded_image_url = "https://v3.fal.media/files/uploaded-image.png"
+        fake_uploaded_audio_url = "https://v3.fal.media/files/uploaded-audio.wav"
+
+        # Create mock handler with async iterator for events
+        mock_handler = MagicMock()
+        mock_handler.request_id = "test-request-123"
+
+        mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+        mock_handler.get = AsyncMock(
+            return_value={
+                "video": {
+                    "url": fake_output_url,
+                    "content_type": "video/mp4",
+                    "file_name": "output.mp4",
+                    "file_size": 4404019,
+                }
+            }
+        )
+
+        # Track upload calls
+        upload_call_count = 0
+
+        async def mock_upload(_file_path):
+            nonlocal upload_call_count
+            url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+            upload_call_count += 1
+            return url
+
+        # Create mock fal_client module
+        mock_fal_client = ModuleType("fal_client")
+        mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+        mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+
+        # Mock storage result with 720p dimensions
+        mock_video_artifact = VideoArtifact(
+            generation_id="test_gen",
+            storage_url=fake_output_url,
+            width=1280,
+            height=720,
+            format="mp4",
+            duration=12.0,
+            fps=30.0,
+        )
+
+        class CustomCtx(DummyCtx):
+            async def store_video_result(self, **kwargs):
+                return mock_video_artifact
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            with patch.dict("sys.modules", {"fal_client": mock_fal_client}):
+                result = await self.generator.generate(input_data, CustomCtx())
+
+                assert isinstance(result, GeneratorResult)
+                assert len(result.outputs) == 1
+                assert result.outputs[0] == mock_video_artifact
+
+                # Verify file uploads were called for both image and audio
+                assert mock_fal_client.upload_file_async.call_count == 2
+
+                # Verify API calls with uploaded URLs and resolution
+                mock_fal_client.submit_async.assert_called_once_with(
+                    "veed/fabric-1.0",
+                    arguments={
+                        "image_url": fake_uploaded_image_url,
+                        "audio_url": fake_uploaded_audio_url,
+                        "resolution": "720p",
+                    },
+                )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_480p(self):
+        """Test successful generation with 480p resolution."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/input-image.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/input-audio.wav",
+            format="wav",
+            duration=10.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = VeedFabric10Input(
+            image_url=image_artifact,
+            audio_url=audio_artifact,
+            resolution="480p",
+        )
+
+        fake_output_url = "https://v3.fal.media/files/penguin/output480.mp4"
+        fake_uploaded_image_url = "https://v3.fal.media/files/uploaded-image.png"
+        fake_uploaded_audio_url = "https://v3.fal.media/files/uploaded-audio.wav"
+
+        mock_handler = MagicMock()
+        mock_handler.request_id = "test-request-456"
+        mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+        mock_handler.get = AsyncMock(
+            return_value={
+                "video": {
+                    "url": fake_output_url,
+                    "content_type": "video/mp4",
+                    "file_name": "output.mp4",
+                    "file_size": 2000000,
+                }
+            }
+        )
+
+        upload_call_count = 0
+
+        async def mock_upload(_file_path):
+            nonlocal upload_call_count
+            url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+            upload_call_count += 1
+            return url
+
+        mock_fal_client = ModuleType("fal_client")
+        mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+        mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+
+        # Mock storage result with 480p dimensions
+        mock_video_artifact = VideoArtifact(
+            generation_id="test_gen",
+            storage_url=fake_output_url,
+            width=854,
+            height=480,
+            format="mp4",
+            duration=10.0,
+            fps=30.0,
+        )
+
+        class CustomCtx(DummyCtx):
+            async def store_video_result(self, **kwargs):
+                return mock_video_artifact
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            with patch.dict("sys.modules", {"fal_client": mock_fal_client}):
+                result = await self.generator.generate(input_data, CustomCtx())
+
+                assert isinstance(result, GeneratorResult)
+                assert len(result.outputs) == 1
+
+                # Verify resolution is passed correctly
+                mock_fal_client.submit_async.assert_called_once_with(
+                    "veed/fabric-1.0",
+                    arguments={
+                        "image_url": fake_uploaded_image_url,
+                        "audio_url": fake_uploaded_audio_url,
+                        "resolution": "480p",
+                    },
+                )
+
+    @pytest.mark.asyncio
+    async def test_generate_no_video_returned(self):
+        """Test generation fails when API returns no video."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/input-image.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/input-audio.wav",
+            format="wav",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        input_data = VeedFabric10Input(
+            image_url=image_artifact,
+            audio_url=audio_artifact,
+        )
+
+        mock_handler = MagicMock()
+        mock_handler.request_id = "test-request-789"
+        mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+        mock_handler.get = AsyncMock(return_value={})  # No video in response
+
+        fake_uploaded_image_url = "https://v3.fal.media/files/uploaded-image.png"
+        fake_uploaded_audio_url = "https://v3.fal.media/files/uploaded-audio.wav"
+
+        upload_call_count = 0
+
+        async def mock_upload(_file_path):
+            nonlocal upload_call_count
+            url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+            upload_call_count += 1
+            return url
+
+        mock_fal_client = ModuleType("fal_client")
+        mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+        mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            with patch.dict("sys.modules", {"fal_client": mock_fal_client}):
+                with pytest.raises(ValueError, match="No video returned"):
+                    await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_video_missing_url(self):
+        """Test generation fails when video object has no URL."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/input-image.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/input-audio.wav",
+            format="wav",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        input_data = VeedFabric10Input(
+            image_url=image_artifact,
+            audio_url=audio_artifact,
+        )
+
+        mock_handler = MagicMock()
+        mock_handler.request_id = "test-request-999"
+        mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+        mock_handler.get = AsyncMock(
+            return_value={"video": {"content_type": "video/mp4"}}  # No url field
+        )
+
+        fake_uploaded_image_url = "https://v3.fal.media/files/uploaded-image.png"
+        fake_uploaded_audio_url = "https://v3.fal.media/files/uploaded-audio.wav"
+
+        upload_call_count = 0
+
+        async def mock_upload(_file_path):
+            nonlocal upload_call_count
+            url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+            upload_call_count += 1
+            return url
+
+        mock_fal_client = ModuleType("fal_client")
+        mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+        mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            with patch.dict("sys.modules", {"fal_client": mock_fal_client}):
+                with pytest.raises(ValueError, match="Video missing URL"):
+                    await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        input_data = VeedFabric10Input(
+            image_url=image_artifact,
+            audio_url=audio_artifact,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Fixed cost
+        assert cost == 0.08
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = VeedFabric10Input.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "image_url" in schema["properties"]
+        assert "audio_url" in schema["properties"]
+        assert "resolution" in schema["properties"]
+
+        # Check that image_url and audio_url are required
+        assert "image_url" in schema["required"]
+        assert "audio_url" in schema["required"]
+        # resolution has a default, so may not be in required

--- a/packages/backend/tests/generators/implementations/test_veed_fabric_1_0_live.py
+++ b/packages/backend/tests/generators/implementations/test_veed_fabric_1_0_live.py
@@ -1,0 +1,130 @@
+"""
+Live API tests for FalVeedFabric10Generator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_veed_fabric_1_0_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_veed_fabric_1_0_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+
+Note: These tests use example image and audio URLs since the generator requires
+artifact inputs.
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import AudioArtifact, ImageArtifact, VideoArtifact
+from boards.generators.implementations.fal.video.veed_fabric_1_0 import (
+    FalVeedFabric10Generator,
+    VeedFabric10Input,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestVeedFabric10GeneratorLive:
+    """Live API tests for FalVeedFabric10Generator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalVeedFabric10Generator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test basic VEED Fabric 1.0 generation.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses 480p resolution to minimize cost.
+        """
+        # Create image artifact with a sample portrait image
+        image_artifact = ImageArtifact(
+            generation_id="example_image",
+            storage_url="https://placehold.co/512x512/ff0000/ff0000.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        # Create audio artifact with a short sample
+        # Using a publicly accessible short audio clip
+        audio_artifact = AudioArtifact(
+            generation_id="example_audio",
+            storage_url="https://v3.fal.media/files/rabbit/Ql3ade3wEKlZXRQLRbhxm_tts.mp3",
+            format="mp3",
+            duration=5.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        # Create input with lowest resolution to reduce cost
+        inputs = VeedFabric10Input(
+            image_url=image_artifact,
+            audio_url=audio_artifact,
+            resolution="480p",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.width is not None and artifact.width > 0
+        assert artifact.height is not None and artifact.height > 0
+        assert artifact.format == "mp4"
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Create dummy artifacts (not actually used for cost estimation)
+        image_artifact = ImageArtifact(
+            generation_id="test",
+            storage_url="https://example.com/test.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="test",
+            storage_url="https://example.com/test.wav",
+            format="wav",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        inputs = VeedFabric10Input(
+            image_url=image_artifact,
+            audio_url=audio_artifact,
+        )
+        estimated_cost = await self.generator.estimate_cost(inputs)
+
+        # Verify estimate is in reasonable range
+        assert estimated_cost > 0.0
+        assert estimated_cost < 1.0  # Should be well under $1 per generation


### PR DESCRIPTION
Add FalVeedFabric10Generator that turns images into talking videos using VEED's Fabric 1.0 model. This generator:

- Accepts an image and audio as input artifacts
- Supports 720p and 480p output resolutions
- Generates synchronized talking videos from static images

Includes comprehensive unit tests and live API tests.