### PR TITLE
Expand GraphQL API documentation

### DIFF
--- a/apps/docs/docs/backend/graphql-api.md
+++ b/apps/docs/docs/backend/graphql-api.md
@@ -1,11 +1,181 @@
 ---
-title: GraphQL API
-description: Schema, queries, mutations, and usage of the backend GraphQL API.
+title: GraphQL API Overview
+description: Overview of the Boards GraphQL API, including schema, types, queries, and mutations.
 sidebar_position: 3
 ---
 
 # GraphQL API
 
-This section will document the GraphQL schema, queries, and mutations provided by the backend.
+The Boards backend exposes a GraphQL API built with [Strawberry](https://strawberry.rocks/), a modern Python GraphQL library that leverages type hints for schema definition. The API provides full CRUD operations for boards, generations, and users, with real-time capabilities via Server-Sent Events.
 
-Coming soon.
+## Endpoint
+
+The GraphQL endpoint is available at:
+
+```
+POST /graphql
+```
+
+In development, GraphiQL (an interactive GraphQL IDE) is enabled at the same endpoint for browser-based exploration.
+
+## Documentation Structure
+
+The GraphQL API documentation is organized to mirror the implementation structure:
+
+| Section | Description |
+|---------|-------------|
+| [Types](./graphql-api/types) | GraphQL type definitions (Board, Generation, User, etc.) |
+| [Queries](./graphql-api/queries) | Available read operations |
+| [Mutations](./graphql-api/mutations) | Available write operations |
+| [Access Control](./graphql-api/access-control) | Authentication and authorization |
+
+## Quick Start
+
+### Making a Query
+
+```graphql
+query GetMyBoards {
+  myBoards(limit: 10) {
+    id
+    title
+    description
+    isPublic
+    createdAt
+    owner {
+      displayName
+    }
+    generationCount
+  }
+}
+```
+
+### Creating a Board
+
+```graphql
+mutation CreateBoard {
+  createBoard(input: {
+    title: "My New Board"
+    description: "A board for AI-generated art"
+    isPublic: false
+  }) {
+    id
+    title
+    createdAt
+  }
+}
+```
+
+### Starting a Generation
+
+```graphql
+mutation CreateGeneration {
+  createGeneration(input: {
+    boardId: "board-uuid-here"
+    generatorName: "flux-1-dev"
+    artifactType: IMAGE
+    inputParams: {
+      prompt: "A beautiful sunset over mountains"
+      width: 1024
+      height: 1024
+    }
+  }) {
+    id
+    status
+    progress
+  }
+}
+```
+
+## Authentication
+
+Most operations require authentication. Include the JWT token in the `Authorization` header:
+
+```http
+Authorization: Bearer <your-jwt-token>
+```
+
+For multi-tenant deployments, include the tenant identifier:
+
+```http
+X-Tenant: <tenant-id>
+```
+
+See [Access Control](./graphql-api/access-control) for detailed authentication documentation.
+
+## Schema Introspection
+
+The schema supports introspection, allowing tools like GraphiQL to auto-discover available types and operations:
+
+```graphql
+query IntrospectionQuery {
+  __schema {
+    types {
+      name
+      description
+    }
+  }
+}
+```
+
+## Implementation Details
+
+The GraphQL schema is implemented in `packages/backend/src/boards/graphql/`:
+
+```
+graphql/
+├── schema.py           # Main schema definition
+├── types/              # Type definitions
+│   ├── board.py        # Board, BoardMember, BoardRole
+│   ├── generation.py   # Generation, ArtifactType, GenerationStatus
+│   ├── generator.py    # GeneratorInfo
+│   └── user.py         # User
+├── queries/
+│   └── root.py         # Query root type
+├── mutations/
+│   └── root.py         # Mutation root type
+├── resolvers/          # Field resolvers
+│   ├── auth.py
+│   ├── board.py
+│   ├── generation.py
+│   ├── generator.py
+│   ├── lineage.py
+│   ├── upload.py
+│   └── user.py
+└── access_control.py   # Authorization helpers
+```
+
+## Error Handling
+
+GraphQL errors are returned in the standard format:
+
+```json
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Not authenticated",
+      "path": ["myBoards"],
+      "extensions": {
+        "code": "UNAUTHENTICATED"
+      }
+    }
+  ]
+}
+```
+
+Common error codes:
+
+| Code | Description |
+|------|-------------|
+| `UNAUTHENTICATED` | Request lacks valid authentication |
+| `FORBIDDEN` | User lacks permission for the operation |
+| `NOT_FOUND` | Requested resource does not exist |
+| `BAD_USER_INPUT` | Invalid input parameters |
+| `INTERNAL_SERVER_ERROR` | Server-side error |
+
+## Next Steps
+
+- Learn about [Types](./graphql-api/types) to understand the data model
+- Explore available [Queries](./graphql-api/queries) for reading data
+- See [Mutations](./graphql-api/mutations) for creating and modifying data
+- Understand [Access Control](./graphql-api/access-control) for authentication patterns

--- a/apps/docs/docs/backend/graphql-api/access-control.md
+++ b/apps/docs/docs/backend/graphql-api/access-control.md
@@ -1,0 +1,355 @@
+---
+title: Access Control
+description: Authentication and authorization for the Boards GraphQL API.
+sidebar_position: 4
+---
+
+# Access Control
+
+This page documents how authentication and authorization work in the Boards GraphQL API.
+
+## Overview
+
+The Boards API uses a layered security model:
+
+1. **Authentication** - Verifying user identity via JWT tokens
+2. **Authorization** - Checking permissions for specific operations
+3. **Multi-tenancy** - Isolating data between tenants
+
+## Authentication
+
+### Request Headers
+
+Include authentication credentials in HTTP headers:
+
+```http
+POST /graphql HTTP/1.1
+Authorization: Bearer <jwt-token>
+X-Tenant: <tenant-id>
+Content-Type: application/json
+```
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `Authorization` | Yes* | JWT bearer token |
+| `X-Tenant` | Depends | Tenant identifier (for multi-tenant deployments) |
+
+*Required for authenticated operations. Public queries work without authentication.
+
+### JWT Token Format
+
+The API expects standard JWT tokens with these claims:
+
+```json
+{
+  "sub": "user-unique-id",
+  "email": "user@example.com",
+  "iat": 1704067200,
+  "exp": 1704153600
+}
+```
+
+| Claim | Description |
+|-------|-------------|
+| `sub` | Subject - unique user identifier from auth provider |
+| `email` | User's email address |
+| `iat` | Issued at timestamp |
+| `exp` | Expiration timestamp |
+
+### Auth Providers
+
+Boards supports multiple authentication providers:
+
+| Provider | Configuration | Description |
+|----------|---------------|-------------|
+| `none` | `BOARDS_AUTH_PROVIDER=none` | No authentication (development only) |
+| `jwt` | `BOARDS_AUTH_PROVIDER=jwt` | Generic JWT validation |
+| `supabase` | `BOARDS_AUTH_PROVIDER=supabase` | Supabase Auth integration |
+
+See [Auth Providers](/docs/auth/providers/jwt) for detailed configuration.
+
+---
+
+## Authorization
+
+### Permission Model
+
+Authorization is based on user relationships to resources:
+
+```
+User
+ ├── Owns Boards (owner_id)
+ └── Member of Boards (board_members)
+       └── Has Role (VIEWER, EDITOR, ADMIN)
+```
+
+### Board Access Rules
+
+Access to boards is determined by:
+
+1. **Public boards** - Accessible to everyone (read-only without auth)
+2. **Owner** - Full access to all operations
+3. **Admin member** - Can manage members and edit
+4. **Editor member** - Can create generations
+5. **Viewer member** - Read-only access
+
+```python
+def can_access_board(board, auth_context):
+    # Public boards are accessible to everyone
+    if board.is_public:
+        return True
+
+    # Private boards require authentication
+    if not auth_context.is_authenticated:
+        return False
+
+    # Owner has access
+    if board.owner_id == auth_context.user_id:
+        return True
+
+    # Check membership
+    return any(
+        member.user_id == auth_context.user_id
+        for member in board.board_members
+    )
+```
+
+### Query Authorization
+
+| Query | Auth Required | Access Rule |
+|-------|---------------|-------------|
+| `me` | Yes | Returns authenticated user |
+| `user` | Yes | Any authenticated user |
+| `board` | Depends | Public or user has access |
+| `myBoards` | Yes | Owned or member boards |
+| `publicBoards` | No | All public boards |
+| `searchBoards` | Yes | Accessible boards only |
+| `generation` | Depends | Board access required |
+| `recentGenerations` | Yes | Accessible boards only |
+| `generators` | No | Public information |
+
+### Mutation Authorization
+
+| Mutation | Required Role |
+|----------|---------------|
+| `createBoard` | Authenticated |
+| `updateBoard` | Owner or Admin |
+| `deleteBoard` | Owner only |
+| `addBoardMember` | Owner or Admin |
+| `removeBoardMember` | Owner or Admin |
+| `updateBoardMemberRole` | Owner or Admin |
+| `createGeneration` | Owner, Admin, or Editor |
+| `cancelGeneration` | Creator, Owner, or Admin |
+| `deleteGeneration` | Creator, Owner, or Admin |
+| `regenerate` | Owner, Admin, or Editor |
+| `uploadArtifact` | Owner, Admin, or Editor |
+
+---
+
+## Board Roles
+
+### BoardRole Enum
+
+```graphql
+enum BoardRole {
+  VIEWER
+  EDITOR
+  ADMIN
+}
+```
+
+### Role Permissions
+
+| Permission | Viewer | Editor | Admin | Owner |
+|------------|--------|--------|-------|-------|
+| View board | Yes | Yes | Yes | Yes |
+| View generations | Yes | Yes | Yes | Yes |
+| Create generations | No | Yes | Yes | Yes |
+| Delete own generations | No | Yes | Yes | Yes |
+| Delete any generation | No | No | Yes | Yes |
+| Add members | No | No | Yes | Yes |
+| Remove members | No | No | Yes | Yes |
+| Update member roles | No | No | Yes | Yes |
+| Update board settings | No | No | Yes | Yes |
+| Delete board | No | No | No | Yes |
+
+---
+
+## Query Filters
+
+### BoardQueryRole
+
+Filter boards by your relationship:
+
+```graphql
+enum BoardQueryRole {
+  ANY      # All accessible boards
+  OWNER    # Only boards you own
+  MEMBER   # Only boards where you're a member (not owner)
+}
+```
+
+#### Example
+
+```graphql
+query GetOwnedBoards {
+  myBoards(role: OWNER) {
+    id
+    title
+  }
+}
+
+query GetSharedBoards {
+  myBoards(role: MEMBER) {
+    id
+    title
+    owner {
+      displayName
+    }
+  }
+}
+```
+
+### SortOrder
+
+Sort results by creation or update time:
+
+```graphql
+enum SortOrder {
+  CREATED_ASC    # Oldest first
+  CREATED_DESC   # Newest first
+  UPDATED_ASC    # Least recently updated
+  UPDATED_DESC   # Most recently updated
+}
+```
+
+---
+
+## Multi-Tenancy
+
+### Tenant Isolation
+
+In multi-tenant deployments, all data is scoped to a tenant:
+
+- Users belong to a tenant
+- Boards belong to a tenant
+- Generations belong to a tenant
+
+Cross-tenant access is never permitted.
+
+### Specifying Tenant
+
+Include the `X-Tenant` header:
+
+```http
+X-Tenant: my-tenant-id
+```
+
+Or use a subdomain (if configured):
+
+```
+https://my-tenant.boards.example.com/graphql
+```
+
+See [Multi-Tenancy](/docs/auth/multi-tenant) for detailed configuration.
+
+---
+
+## Error Responses
+
+### Authentication Errors
+
+```json
+{
+  "errors": [
+    {
+      "message": "Not authenticated",
+      "path": ["myBoards"],
+      "extensions": {
+        "code": "UNAUTHENTICATED"
+      }
+    }
+  ]
+}
+```
+
+### Authorization Errors
+
+```json
+{
+  "errors": [
+    {
+      "message": "You don't have permission to access this board",
+      "path": ["board"],
+      "extensions": {
+        "code": "FORBIDDEN"
+      }
+    }
+  ]
+}
+```
+
+### Invalid Token
+
+```json
+{
+  "errors": [
+    {
+      "message": "Invalid or expired token",
+      "path": ["me"],
+      "extensions": {
+        "code": "UNAUTHENTICATED"
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Security Best Practices
+
+### Client-Side
+
+1. **Store tokens securely** - Use httpOnly cookies or secure storage
+2. **Handle expiration** - Refresh tokens before they expire
+3. **Validate responses** - Check for auth errors and redirect to login
+
+### Server-Side
+
+1. **Validate all inputs** - Never trust client data
+2. **Use parameterized queries** - Prevent injection attacks
+3. **Log access attempts** - Audit sensitive operations
+4. **Rate limit** - Prevent brute force attacks
+
+---
+
+## Implementation Details
+
+Access control logic is implemented in:
+
+- `packages/backend/src/boards/graphql/access_control.py` - Core authorization functions
+- `packages/backend/src/boards/auth/` - Authentication providers
+- `packages/backend/src/boards/auth/middleware.py` - Request middleware
+
+### Key Functions
+
+```python
+# Get auth context from GraphQL info
+async def get_auth_context_from_info(info: strawberry.Info) -> AuthContext | None
+
+# Check if user can access a board
+def can_access_board(board: Boards, auth_context: AuthContext | None) -> bool
+
+# Check if user is owner or member
+def is_board_owner_or_member(board: Boards, auth_context: AuthContext | None) -> bool
+```
+
+---
+
+## Related Documentation
+
+- [Auth Overview](/docs/auth/overview)
+- [Auth Providers](/docs/auth/providers/jwt)
+- [Multi-Tenancy](/docs/auth/multi-tenant)
+- [Backend Authorization](/docs/auth/backend/authorization)

--- a/apps/docs/docs/backend/graphql-api/mutations.md
+++ b/apps/docs/docs/backend/graphql-api/mutations.md
@@ -1,0 +1,572 @@
+---
+title: Mutations
+description: GraphQL mutation operations for the Boards API.
+sidebar_position: 3
+---
+
+# GraphQL Mutations
+
+This page documents all available GraphQL mutations in the Boards API. Mutations are operations that create, update, or delete data.
+
+## Mutation Overview
+
+| Mutation | Description | Auth Required |
+|----------|-------------|---------------|
+| [`createBoard`](#createboard) | Create a new board | Yes |
+| [`updateBoard`](#updateboard) | Update an existing board | Yes (owner/admin) |
+| [`deleteBoard`](#deleteboard) | Delete a board | Yes (owner) |
+| [`addBoardMember`](#addboardmember) | Add a member to a board | Yes (owner/admin) |
+| [`removeBoardMember`](#removeboardmember) | Remove a member from a board | Yes (owner/admin) |
+| [`updateBoardMemberRole`](#updateboardmemberrole) | Change a member's role | Yes (owner/admin) |
+| [`createGeneration`](#creategeneration) | Start a new generation | Yes |
+| [`cancelGeneration`](#cancelgeneration) | Cancel a pending generation | Yes |
+| [`deleteGeneration`](#deletegeneration) | Delete a generation | Yes |
+| [`regenerate`](#regenerate) | Re-run a generation | Yes |
+| [`uploadArtifact`](#uploadartifact) | Upload an artifact from URL | Yes |
+
+---
+
+## Board Mutations
+
+### createBoard
+
+Create a new board owned by the current user.
+
+```graphql
+mutation {
+  createBoard(input: CreateBoardInput!): Board!
+}
+```
+
+#### Input Type
+
+```graphql
+input CreateBoardInput {
+  title: String!
+  description: String
+  isPublic: Boolean = false
+  settings: JSON
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `title` | `String!` | - | Board title (required) |
+| `description` | `String` | `null` | Optional description |
+| `isPublic` | `Boolean` | `false` | Whether board is publicly visible |
+| `settings` | `JSON` | `null` | Custom board settings |
+
+#### Example
+
+```graphql
+mutation CreateMyBoard {
+  createBoard(input: {
+    title: "AI Art Gallery"
+    description: "My collection of AI-generated artwork"
+    isPublic: true
+    settings: {
+      theme: "dark",
+      gridColumns: 4
+    }
+  }) {
+    id
+    title
+    description
+    isPublic
+    settings
+    createdAt
+  }
+}
+```
+
+---
+
+### updateBoard
+
+Update an existing board. Only the owner or admins can update a board.
+
+```graphql
+mutation {
+  updateBoard(input: UpdateBoardInput!): Board!
+}
+```
+
+#### Input Type
+
+```graphql
+input UpdateBoardInput {
+  id: UUID!
+  title: String
+  description: String
+  isPublic: Boolean
+  settings: JSON
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `UUID!` | Board ID (required) |
+| `title` | `String` | New title |
+| `description` | `String` | New description |
+| `isPublic` | `Boolean` | New visibility |
+| `settings` | `JSON` | New settings (merges with existing) |
+
+#### Example
+
+```graphql
+mutation UpdateMyBoard($boardId: UUID!) {
+  updateBoard(input: {
+    id: $boardId
+    title: "Updated Gallery Name"
+    isPublic: false
+  }) {
+    id
+    title
+    isPublic
+    updatedAt
+  }
+}
+```
+
+---
+
+### deleteBoard
+
+Delete a board and all its generations. Only the owner can delete a board.
+
+```graphql
+mutation {
+  deleteBoard(id: UUID!): Boolean!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `id` | `UUID!` | Board ID to delete |
+
+#### Returns
+
+`true` if deletion was successful.
+
+#### Example
+
+```graphql
+mutation DeleteMyBoard($boardId: UUID!) {
+  deleteBoard(id: $boardId)
+}
+```
+
+:::warning
+This operation is destructive and cannot be undone. All generations in the board will also be deleted.
+:::
+
+---
+
+### addBoardMember
+
+Add a user as a member of a board. Requires owner or admin role.
+
+```graphql
+mutation {
+  addBoardMember(input: AddBoardMemberInput!): Board!
+}
+```
+
+#### Input Type
+
+```graphql
+input AddBoardMemberInput {
+  boardId: UUID!
+  userId: UUID!
+  role: BoardRole = VIEWER
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `boardId` | `UUID!` | - | Board to add member to |
+| `userId` | `UUID!` | - | User to add |
+| `role` | `BoardRole` | `VIEWER` | Role to assign |
+
+#### Example
+
+```graphql
+mutation AddMember($boardId: UUID!, $userId: UUID!) {
+  addBoardMember(input: {
+    boardId: $boardId
+    userId: $userId
+    role: EDITOR
+  }) {
+    id
+    members {
+      user {
+        id
+        displayName
+      }
+      role
+      joinedAt
+    }
+  }
+}
+```
+
+---
+
+### removeBoardMember
+
+Remove a member from a board. Requires owner or admin role.
+
+```graphql
+mutation {
+  removeBoardMember(boardId: UUID!, userId: UUID!): Board!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `boardId` | `UUID!` | Board ID |
+| `userId` | `UUID!` | User ID to remove |
+
+#### Example
+
+```graphql
+mutation RemoveMember($boardId: UUID!, $userId: UUID!) {
+  removeBoardMember(boardId: $boardId, userId: $userId) {
+    id
+    members {
+      user {
+        id
+      }
+    }
+  }
+}
+```
+
+---
+
+### updateBoardMemberRole
+
+Change a board member's role. Requires owner or admin role.
+
+```graphql
+mutation {
+  updateBoardMemberRole(
+    boardId: UUID!
+    userId: UUID!
+    role: BoardRole!
+  ): Board!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `boardId` | `UUID!` | Board ID |
+| `userId` | `UUID!` | User ID to update |
+| `role` | `BoardRole!` | New role |
+
+#### Example
+
+```graphql
+mutation PromoteToAdmin($boardId: UUID!, $userId: UUID!) {
+  updateBoardMemberRole(
+    boardId: $boardId
+    userId: $userId
+    role: ADMIN
+  ) {
+    id
+    members {
+      user {
+        id
+      }
+      role
+    }
+  }
+}
+```
+
+---
+
+## Generation Mutations
+
+### createGeneration
+
+Start a new generation job. The generation runs asynchronously; use subscriptions or polling to track progress.
+
+```graphql
+mutation {
+  createGeneration(input: CreateGenerationInput!): Generation!
+}
+```
+
+#### Input Type
+
+```graphql
+input CreateGenerationInput {
+  boardId: UUID!
+  generatorName: String!
+  artifactType: ArtifactType!
+  inputParams: JSON!
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `boardId` | `UUID!` | Board to add the generation to |
+| `generatorName` | `String!` | Name of the generator to use |
+| `artifactType` | `ArtifactType!` | Type of artifact to generate |
+| `inputParams` | `JSON!` | Parameters for the generator (schema varies by generator) |
+
+#### Example
+
+```graphql
+mutation GenerateImage($boardId: UUID!) {
+  createGeneration(input: {
+    boardId: $boardId
+    generatorName: "flux-1-dev"
+    artifactType: IMAGE
+    inputParams: {
+      prompt: "A serene mountain landscape at sunset, digital art"
+      width: 1024
+      height: 768
+      num_inference_steps: 28
+      guidance_scale: 3.5
+    }
+  }) {
+    id
+    status
+    progress
+    generatorName
+    artifactType
+    createdAt
+  }
+}
+```
+
+#### Lineage Tracking
+
+Input parameters that reference other generations (by ID) are automatically resolved and tracked as lineage. For example, for image-to-image generation:
+
+```graphql
+mutation ImageToImage($boardId: UUID!, $sourceGenId: UUID!) {
+  createGeneration(input: {
+    boardId: $boardId
+    generatorName: "flux-1-dev-img2img"
+    artifactType: IMAGE
+    inputParams: {
+      image: $sourceGenId
+      prompt: "Transform to watercolor style"
+      strength: 0.75
+    }
+  }) {
+    id
+    inputArtifacts {
+      role
+      generation {
+        id
+      }
+    }
+  }
+}
+```
+
+---
+
+### cancelGeneration
+
+Cancel a pending or processing generation.
+
+```graphql
+mutation {
+  cancelGeneration(id: UUID!): Generation!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `id` | `UUID!` | Generation ID to cancel |
+
+#### Returns
+
+The generation with status updated to `CANCELLED`.
+
+#### Example
+
+```graphql
+mutation CancelJob($genId: UUID!) {
+  cancelGeneration(id: $genId) {
+    id
+    status
+  }
+}
+```
+
+:::note
+Only generations with status `PENDING` or `PROCESSING` can be cancelled. Completed or failed generations cannot be cancelled.
+:::
+
+---
+
+### deleteGeneration
+
+Delete a generation and its associated files.
+
+```graphql
+mutation {
+  deleteGeneration(id: UUID!): Boolean!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `id` | `UUID!` | Generation ID to delete |
+
+#### Returns
+
+`true` if deletion was successful.
+
+#### Example
+
+```graphql
+mutation DeleteGeneration($genId: UUID!) {
+  deleteGeneration(id: $genId)
+}
+```
+
+---
+
+### regenerate
+
+Create a new generation using the same parameters as an existing one.
+
+```graphql
+mutation {
+  regenerate(id: UUID!): Generation!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `id` | `UUID!` | Generation ID to regenerate from |
+
+#### Returns
+
+A new `Generation` with the same parameters but a new ID.
+
+#### Example
+
+```graphql
+mutation RegenerateImage($genId: UUID!) {
+  regenerate(id: $genId) {
+    id
+    status
+    generatorName
+    inputParams
+  }
+}
+```
+
+---
+
+### uploadArtifact
+
+Upload an artifact from an external URL. This creates a generation record for an externally-created asset.
+
+```graphql
+mutation {
+  uploadArtifact(input: UploadArtifactInput!): Generation!
+}
+```
+
+#### Input Type
+
+```graphql
+input UploadArtifactInput {
+  boardId: UUID!
+  artifactType: ArtifactType!
+  fileUrl: String
+  originalFilename: String
+  userDescription: String
+  parentGenerationId: UUID
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `boardId` | `UUID!` | Board to add the artifact to |
+| `artifactType` | `ArtifactType!` | Type of the artifact |
+| `fileUrl` | `String` | URL to fetch the file from |
+| `originalFilename` | `String` | Original filename |
+| `userDescription` | `String` | User-provided description |
+| `parentGenerationId` | `UUID` | Optional parent generation for lineage |
+
+#### Example
+
+```graphql
+mutation UploadImage($boardId: UUID!) {
+  uploadArtifact(input: {
+    boardId: $boardId
+    artifactType: IMAGE
+    fileUrl: "https://example.com/my-image.png"
+    originalFilename: "my-image.png"
+    userDescription: "Reference image for style transfer"
+  }) {
+    id
+    status
+    storageUrl
+    thumbnailUrl
+  }
+}
+```
+
+---
+
+## Error Handling
+
+Mutations return errors in the standard GraphQL format:
+
+```json
+{
+  "data": {
+    "createBoard": null
+  },
+  "errors": [
+    {
+      "message": "Not authenticated",
+      "path": ["createBoard"],
+      "extensions": {
+        "code": "UNAUTHENTICATED"
+      }
+    }
+  ]
+}
+```
+
+### Common Errors
+
+| Code | Description |
+|------|-------------|
+| `UNAUTHENTICATED` | No valid authentication token |
+| `FORBIDDEN` | User lacks permission for this operation |
+| `NOT_FOUND` | Referenced resource doesn't exist |
+| `BAD_USER_INPUT` | Invalid input parameters |
+
+---
+
+## Source Files
+
+Mutation definitions are implemented in:
+
+- `packages/backend/src/boards/graphql/mutations/root.py`
+- `packages/backend/src/boards/graphql/resolvers/`

--- a/apps/docs/docs/backend/graphql-api/queries.md
+++ b/apps/docs/docs/backend/graphql-api/queries.md
@@ -1,0 +1,539 @@
+---
+title: Queries
+description: GraphQL query operations for the Boards API.
+sidebar_position: 2
+---
+
+# GraphQL Queries
+
+This page documents all available GraphQL queries in the Boards API. Queries are read-only operations for fetching data.
+
+## Query Overview
+
+| Query | Description | Auth Required |
+|-------|-------------|---------------|
+| [`me`](#me) | Get current authenticated user | Yes |
+| [`user`](#user) | Get user by ID | Yes |
+| [`board`](#board) | Get board by ID | Depends* |
+| [`myBoards`](#myboards) | Get boards owned by or shared with current user | Yes |
+| [`publicBoards`](#publicboards) | Get public boards | No |
+| [`searchBoards`](#searchboards) | Search boards by title/description | Yes |
+| [`generation`](#generation) | Get generation by ID | Depends* |
+| [`recentGenerations`](#recentgenerations) | Get recent generations with filters | Yes |
+| [`generators`](#generators) | Get available generators | No |
+
+*Depends on board visibility (public boards accessible without auth)
+
+---
+
+## User Queries
+
+### me
+
+Get the currently authenticated user.
+
+```graphql
+query {
+  me: User
+}
+```
+
+#### Returns
+
+`User` or `null` if not authenticated.
+
+#### Example
+
+```graphql
+query GetCurrentUser {
+  me {
+    id
+    email
+    displayName
+    avatarUrl
+    createdAt
+  }
+}
+```
+
+#### Response
+
+```json
+{
+  "data": {
+    "me": {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "email": "user@example.com",
+      "displayName": "John Doe",
+      "avatarUrl": "https://example.com/avatar.jpg",
+      "createdAt": "2024-01-15T10:30:00Z"
+    }
+  }
+}
+```
+
+---
+
+### user
+
+Get a user by their ID.
+
+```graphql
+query {
+  user(id: UUID!): User
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `id` | `UUID!` | The user's unique identifier |
+
+#### Returns
+
+`User` or `null` if not found.
+
+#### Example
+
+```graphql
+query GetUser($userId: UUID!) {
+  user(id: $userId) {
+    id
+    displayName
+    avatarUrl
+    boards {
+      id
+      title
+      isPublic
+    }
+  }
+}
+```
+
+---
+
+## Board Queries
+
+### board
+
+Get a single board by ID. Returns the board if it's public or if the authenticated user has access.
+
+```graphql
+query {
+  board(id: UUID!): Board
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `id` | `UUID!` | The board's unique identifier |
+
+#### Returns
+
+`Board` or `null` if not found or not accessible.
+
+#### Example
+
+```graphql
+query GetBoard($boardId: UUID!) {
+  board(id: $boardId) {
+    id
+    title
+    description
+    isPublic
+    createdAt
+    updatedAt
+    owner {
+      id
+      displayName
+    }
+    members {
+      user {
+        displayName
+      }
+      role
+      joinedAt
+    }
+    generationCount
+    generations(limit: 20) {
+      id
+      thumbnailUrl
+      artifactType
+      status
+      createdAt
+    }
+  }
+}
+```
+
+---
+
+### myBoards
+
+Get boards owned by or shared with the current authenticated user.
+
+```graphql
+query {
+  myBoards(
+    limit: Int = 50
+    offset: Int = 0
+    role: BoardQueryRole
+    sort: SortOrder
+  ): [Board!]!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `limit` | `Int` | `50` | Maximum number of boards to return |
+| `offset` | `Int` | `0` | Number of boards to skip |
+| `role` | `BoardQueryRole` | `ANY` | Filter by user's role |
+| `sort` | `SortOrder` | `UPDATED_DESC` | Sort order |
+
+#### Enums
+
+**BoardQueryRole:**
+
+| Value | Description |
+|-------|-------------|
+| `ANY` | All accessible boards |
+| `OWNER` | Only boards user owns |
+| `MEMBER` | Only boards where user is a member (not owner) |
+
+**SortOrder:**
+
+| Value | Description |
+|-------|-------------|
+| `CREATED_ASC` | Oldest first |
+| `CREATED_DESC` | Newest first |
+| `UPDATED_ASC` | Least recently updated first |
+| `UPDATED_DESC` | Most recently updated first |
+
+#### Example
+
+```graphql
+query GetMyBoards {
+  myBoards(limit: 10, role: OWNER, sort: UPDATED_DESC) {
+    id
+    title
+    description
+    isPublic
+    updatedAt
+    generationCount
+  }
+}
+```
+
+---
+
+### publicBoards
+
+Get publicly visible boards.
+
+```graphql
+query {
+  publicBoards(
+    limit: Int = 50
+    offset: Int = 0
+    sort: SortOrder
+  ): [Board!]!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `limit` | `Int` | `50` | Maximum number of boards to return |
+| `offset` | `Int` | `0` | Number of boards to skip |
+| `sort` | `SortOrder` | `UPDATED_DESC` | Sort order |
+
+#### Example
+
+```graphql
+query GetPublicBoards {
+  publicBoards(limit: 20, sort: CREATED_DESC) {
+    id
+    title
+    description
+    owner {
+      displayName
+    }
+    generationCount
+    createdAt
+  }
+}
+```
+
+---
+
+### searchBoards
+
+Search for boards by title or description. Only returns boards accessible to the current user.
+
+```graphql
+query {
+  searchBoards(
+    query: String!
+    limit: Int = 50
+    offset: Int = 0
+  ): [Board!]!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `query` | `String!` | - | Search query string |
+| `limit` | `Int` | `50` | Maximum number of boards to return |
+| `offset` | `Int` | `0` | Number of boards to skip |
+
+#### Example
+
+```graphql
+query SearchBoards($searchQuery: String!) {
+  searchBoards(query: $searchQuery, limit: 10) {
+    id
+    title
+    description
+    isPublic
+    owner {
+      displayName
+    }
+  }
+}
+```
+
+---
+
+## Generation Queries
+
+### generation
+
+Get a single generation by ID.
+
+```graphql
+query {
+  generation(id: UUID!): Generation
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `id` | `UUID!` | The generation's unique identifier |
+
+#### Returns
+
+`Generation` or `null` if not found or not accessible.
+
+#### Example
+
+```graphql
+query GetGeneration($genId: UUID!) {
+  generation(id: $genId) {
+    id
+    generatorName
+    artifactType
+    status
+    progress
+    errorMessage
+    storageUrl
+    thumbnailUrl
+    inputParams
+    outputMetadata
+    createdAt
+    startedAt
+    completedAt
+    user {
+      displayName
+    }
+    board {
+      id
+      title
+    }
+    inputArtifacts {
+      role
+      artifactType
+      generation {
+        id
+        thumbnailUrl
+      }
+    }
+  }
+}
+```
+
+---
+
+### recentGenerations
+
+Get recent generations with optional filters.
+
+```graphql
+query {
+  recentGenerations(
+    boardId: UUID
+    status: GenerationStatus
+    artifactType: ArtifactType
+    limit: Int = 50
+    offset: Int = 0
+  ): [Generation!]!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `boardId` | `UUID` | - | Filter by board |
+| `status` | `GenerationStatus` | - | Filter by status |
+| `artifactType` | `ArtifactType` | - | Filter by artifact type |
+| `limit` | `Int` | `50` | Maximum number to return |
+| `offset` | `Int` | `0` | Number to skip |
+
+#### Example
+
+```graphql
+query GetRecentImages($boardId: UUID!) {
+  recentGenerations(
+    boardId: $boardId
+    artifactType: IMAGE
+    status: COMPLETED
+    limit: 20
+  ) {
+    id
+    generatorName
+    storageUrl
+    thumbnailUrl
+    inputParams
+    createdAt
+  }
+}
+```
+
+---
+
+## Generator Queries
+
+### generators
+
+Get all available generators, optionally filtered by artifact type.
+
+```graphql
+query {
+  generators(artifactType: String): [GeneratorInfo!]!
+}
+```
+
+#### Arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `artifactType` | `String` | Filter by artifact type (e.g., "image", "video") |
+
+#### Example
+
+```graphql
+query GetImageGenerators {
+  generators(artifactType: "image") {
+    name
+    description
+    artifactType
+    inputSchema
+  }
+}
+```
+
+#### Response
+
+```json
+{
+  "data": {
+    "generators": [
+      {
+        "name": "flux-1-dev",
+        "description": "FLUX.1 Dev - High quality image generation",
+        "artifactType": "IMAGE",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "prompt": {
+              "type": "string",
+              "description": "Text prompt for image generation"
+            },
+            "width": {
+              "type": "integer",
+              "default": 1024
+            },
+            "height": {
+              "type": "integer",
+              "default": 1024
+            }
+          },
+          "required": ["prompt"]
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Pagination
+
+All list queries support pagination via `limit` and `offset` arguments:
+
+```graphql
+query PaginatedBoards($page: Int!) {
+  myBoards(limit: 10, offset: $page * 10) {
+    id
+    title
+  }
+}
+```
+
+For large datasets, consider using cursor-based pagination patterns in your application layer.
+
+---
+
+## Error Handling
+
+Queries return `null` for single-item queries when:
+- The resource doesn't exist
+- The user doesn't have permission to access it
+
+List queries return empty arrays when no results match.
+
+Authentication errors are returned in the `errors` array:
+
+```json
+{
+  "data": {
+    "myBoards": null
+  },
+  "errors": [
+    {
+      "message": "Not authenticated",
+      "path": ["myBoards"]
+    }
+  ]
+}
+```
+
+---
+
+## Source Files
+
+Query definitions are implemented in:
+
+- `packages/backend/src/boards/graphql/queries/root.py`
+- `packages/backend/src/boards/graphql/resolvers/`

--- a/apps/docs/docs/backend/graphql-api/types.md
+++ b/apps/docs/docs/backend/graphql-api/types.md
@@ -1,0 +1,538 @@
+---
+title: Types
+description: GraphQL type definitions for the Boards API.
+sidebar_position: 1
+---
+
+# GraphQL Types
+
+This page documents all GraphQL types available in the Boards API. Types are organized by domain: Boards, Generations, Generators, and Users.
+
+## Type Overview
+
+| Type | Description |
+|------|-------------|
+| [`Board`](#board) | A collection of generations |
+| [`BoardMember`](#boardmember) | A user's membership in a board |
+| [`BoardRole`](#boardrole) | Enum for member permissions |
+| [`Generation`](#generation) | An AI-generated artifact |
+| [`GenerationStatus`](#generationstatus) | Enum for generation states |
+| [`ArtifactType`](#artifacttype) | Enum for content types |
+| [`ArtifactLineage`](#artifactlineage) | Input artifact relationship |
+| [`AncestryNode`](#ancestrynode) | Node in ancestry tree |
+| [`DescendantNode`](#descendantnode) | Node in descendants tree |
+| [`AdditionalFile`](#additionalfile) | Extra files from generation |
+| [`GeneratorInfo`](#generatorinfo) | Available generator metadata |
+| [`User`](#user) | User account information |
+
+---
+
+## Board Types
+
+### Board
+
+A board is a collection of AI-generated content. Boards can be public or private, and support collaborative access through board members.
+
+```graphql
+type Board {
+  id: UUID!
+  tenantId: UUID!
+  ownerId: UUID!
+  title: String!
+  description: String
+  isPublic: Boolean!
+  settings: JSON!
+  metadata: JSON!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+
+  # Resolved fields
+  owner: User!
+  members: [BoardMember!]!
+  generations(limit: Int = 50, offset: Int = 0): [Generation!]!
+  generationCount: Int!
+}
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `UUID!` | Unique identifier |
+| `tenantId` | `UUID!` | Tenant the board belongs to |
+| `ownerId` | `UUID!` | ID of the board owner |
+| `title` | `String!` | Board title |
+| `description` | `String` | Optional description |
+| `isPublic` | `Boolean!` | Whether the board is publicly visible |
+| `settings` | `JSON!` | Board-specific settings |
+| `metadata` | `JSON!` | Additional metadata |
+| `createdAt` | `DateTime!` | Creation timestamp |
+| `updatedAt` | `DateTime!` | Last update timestamp |
+| `owner` | `User!` | The user who owns the board |
+| `members` | `[BoardMember!]!` | Users with access to this board |
+| `generations` | `[Generation!]!` | Generations in this board (paginated) |
+| `generationCount` | `Int!` | Total number of generations |
+
+#### Example Query
+
+```graphql
+query GetBoard($id: UUID!) {
+  board(id: $id) {
+    id
+    title
+    description
+    isPublic
+    owner {
+      displayName
+      avatarUrl
+    }
+    members {
+      user {
+        displayName
+      }
+      role
+    }
+    generationCount
+    generations(limit: 10) {
+      id
+      thumbnailUrl
+      artifactType
+    }
+  }
+}
+```
+
+---
+
+### BoardMember
+
+Represents a user's membership in a board with their assigned role.
+
+```graphql
+type BoardMember {
+  id: UUID!
+  boardId: UUID!
+  userId: UUID!
+  role: BoardRole!
+  invitedBy: UUID
+  joinedAt: DateTime!
+
+  # Resolved fields
+  user: User!
+  inviter: User
+}
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `UUID!` | Unique identifier |
+| `boardId` | `UUID!` | ID of the board |
+| `userId` | `UUID!` | ID of the member user |
+| `role` | `BoardRole!` | Member's permission level |
+| `invitedBy` | `UUID` | ID of user who sent the invite |
+| `joinedAt` | `DateTime!` | When the user joined |
+| `user` | `User!` | The member's user object |
+| `inviter` | `User` | User who invited this member |
+
+---
+
+### BoardRole
+
+Enumeration of possible board member roles.
+
+```graphql
+enum BoardRole {
+  VIEWER
+  EDITOR
+  ADMIN
+}
+```
+
+| Value | Description |
+|-------|-------------|
+| `VIEWER` | Can view board content |
+| `EDITOR` | Can view and create generations |
+| `ADMIN` | Full access including member management |
+
+---
+
+## Generation Types
+
+### Generation
+
+A generation represents an AI-generated artifact (image, video, audio, text, etc.) with its input parameters, output files, and lineage information.
+
+```graphql
+type Generation {
+  id: UUID!
+  tenantId: UUID!
+  boardId: UUID!
+  userId: UUID!
+
+  # Generation details
+  generatorName: String!
+  artifactType: ArtifactType!
+
+  # Storage
+  storageUrl: String
+  thumbnailUrl: String
+  additionalFiles: [AdditionalFile!]!
+
+  # Parameters and metadata
+  inputParams: JSON!
+  outputMetadata: JSON!
+
+  # Job tracking
+  externalJobId: String
+  status: GenerationStatus!
+  progress: Float!
+  errorMessage: String
+
+  # Timestamps
+  startedAt: DateTime
+  completedAt: DateTime
+  createdAt: DateTime!
+  updatedAt: DateTime!
+
+  # Resolved fields
+  board: Board!
+  user: User!
+  inputArtifacts: [ArtifactLineage!]!
+  ancestry(maxDepth: Int = 25): AncestryNode!
+  descendants(maxDepth: Int = 25): DescendantNode!
+}
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `UUID!` | Unique identifier |
+| `tenantId` | `UUID!` | Tenant this generation belongs to |
+| `boardId` | `UUID!` | Board containing this generation |
+| `userId` | `UUID!` | User who created this generation |
+| `generatorName` | `String!` | Name of the generator used |
+| `artifactType` | `ArtifactType!` | Type of content generated |
+| `storageUrl` | `String` | URL to the generated artifact |
+| `thumbnailUrl` | `String` | URL to thumbnail (for images/videos) |
+| `additionalFiles` | `[AdditionalFile!]!` | Extra output files |
+| `inputParams` | `JSON!` | Parameters passed to the generator |
+| `outputMetadata` | `JSON!` | Metadata from the generation |
+| `externalJobId` | `String` | ID from external generation service |
+| `status` | `GenerationStatus!` | Current job status |
+| `progress` | `Float!` | Progress (0.0 to 1.0) |
+| `errorMessage` | `String` | Error details if failed |
+| `startedAt` | `DateTime` | When processing started |
+| `completedAt` | `DateTime` | When processing finished |
+| `createdAt` | `DateTime!` | When the job was created |
+| `updatedAt` | `DateTime!` | Last update time |
+| `board` | `Board!` | The board this belongs to |
+| `user` | `User!` | User who created this |
+| `inputArtifacts` | `[ArtifactLineage!]!` | Input artifacts with roles |
+| `ancestry` | `AncestryNode!` | Full ancestry tree |
+| `descendants` | `DescendantNode!` | All derived generations |
+
+#### Example Query
+
+```graphql
+query GetGeneration($id: UUID!) {
+  generation(id: $id) {
+    id
+    generatorName
+    artifactType
+    status
+    progress
+    storageUrl
+    thumbnailUrl
+    inputParams
+    outputMetadata
+    createdAt
+    completedAt
+    user {
+      displayName
+    }
+    inputArtifacts {
+      role
+      artifactType
+      generation {
+        id
+        thumbnailUrl
+      }
+    }
+  }
+}
+```
+
+---
+
+### GenerationStatus
+
+Enumeration of generation job states.
+
+```graphql
+enum GenerationStatus {
+  PENDING
+  PROCESSING
+  COMPLETED
+  FAILED
+  CANCELLED
+}
+```
+
+| Value | Description |
+|-------|-------------|
+| `PENDING` | Job is queued, waiting to start |
+| `PROCESSING` | Job is currently running |
+| `COMPLETED` | Job finished successfully |
+| `FAILED` | Job encountered an error |
+| `CANCELLED` | Job was cancelled by user |
+
+---
+
+### ArtifactType
+
+Enumeration of supported artifact content types.
+
+```graphql
+enum ArtifactType {
+  IMAGE
+  VIDEO
+  AUDIO
+  TEXT
+  LORA
+  MODEL
+}
+```
+
+| Value | Description |
+|-------|-------------|
+| `IMAGE` | Static image (PNG, JPEG, WebP, etc.) |
+| `VIDEO` | Video file (MP4, WebM, etc.) |
+| `AUDIO` | Audio file (MP3, WAV, etc.) |
+| `TEXT` | Text content |
+| `LORA` | LoRA model weights |
+| `MODEL` | Full model weights |
+
+---
+
+### ArtifactLineage
+
+Represents a relationship between a generation and one of its input artifacts.
+
+```graphql
+type ArtifactLineage {
+  generationId: UUID!
+  role: String!
+  artifactType: ArtifactType!
+
+  # Resolved fields
+  generation: Generation
+}
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `generationId` | `UUID!` | ID of the input generation |
+| `role` | `String!` | Role of this input (e.g., "image", "mask", "reference") |
+| `artifactType` | `ArtifactType!` | Type of the input artifact |
+| `generation` | `Generation` | Full generation object |
+
+---
+
+### AncestryNode
+
+Represents a node in the ancestry tree, showing all inputs that led to a generation.
+
+```graphql
+type AncestryNode {
+  generation: Generation!
+  depth: Int!
+  role: String
+  parents: [AncestryNode!]!
+}
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `generation` | `Generation!` | The generation at this node |
+| `depth` | `Int!` | Depth in the tree (0 = root) |
+| `role` | `String` | Role this generation played as input |
+| `parents` | `[AncestryNode!]!` | Parent nodes (inputs to this generation) |
+
+---
+
+### DescendantNode
+
+Represents a node in the descendants tree, showing all generations derived from an artifact.
+
+```graphql
+type DescendantNode {
+  generation: Generation!
+  depth: Int!
+  role: String
+  children: [DescendantNode!]!
+}
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `generation` | `Generation!` | The generation at this node |
+| `depth` | `Int!` | Depth in the tree (0 = root) |
+| `role` | `String` | Role the parent played for this generation |
+| `children` | `[DescendantNode!]!` | Child nodes (generations using this as input) |
+
+---
+
+### AdditionalFile
+
+Represents an additional file produced by a generation (e.g., depth maps, masks).
+
+```graphql
+type AdditionalFile {
+  url: String!
+  type: String!
+  metadata: JSON!
+}
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `url` | `String!` | URL to the file |
+| `type` | `String!` | File type identifier |
+| `metadata` | `JSON!` | Additional file metadata |
+
+---
+
+## Generator Types
+
+### GeneratorInfo
+
+Information about an available generator.
+
+```graphql
+type GeneratorInfo {
+  name: String!
+  description: String!
+  artifactType: ArtifactType!
+  inputSchema: JSON!
+}
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String!` | Unique generator identifier |
+| `description` | `String!` | Human-readable description |
+| `artifactType` | `ArtifactType!` | Type of content this generator produces |
+| `inputSchema` | `JSON!` | JSON Schema for input parameters |
+
+#### Example Query
+
+```graphql
+query GetGenerators {
+  generators {
+    name
+    description
+    artifactType
+    inputSchema
+  }
+}
+```
+
+---
+
+## User Types
+
+### User
+
+Represents a user account in the system.
+
+```graphql
+type User {
+  id: UUID!
+  tenantId: UUID!
+  authProvider: String!
+  authSubject: String!
+  email: String
+  displayName: String
+  avatarUrl: String
+  createdAt: DateTime!
+  updatedAt: DateTime!
+
+  # Resolved fields
+  boards: [Board!]!
+  memberBoards: [Board!]!
+}
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `UUID!` | Unique identifier |
+| `tenantId` | `UUID!` | Tenant this user belongs to |
+| `authProvider` | `String!` | Authentication provider (supabase, clerk, etc.) |
+| `authSubject` | `String!` | Subject ID from the auth provider |
+| `email` | `String` | User's email address |
+| `displayName` | `String` | Display name |
+| `avatarUrl` | `String` | URL to avatar image |
+| `createdAt` | `DateTime!` | Account creation time |
+| `updatedAt` | `DateTime!` | Last update time |
+| `boards` | `[Board!]!` | Boards owned by this user |
+| `memberBoards` | `[Board!]!` | Boards where user is a member |
+
+#### Example Query
+
+```graphql
+query GetCurrentUser {
+  me {
+    id
+    email
+    displayName
+    avatarUrl
+    boards {
+      id
+      title
+    }
+    memberBoards {
+      id
+      title
+      owner {
+        displayName
+      }
+    }
+  }
+}
+```
+
+---
+
+## Scalar Types
+
+The API uses the following scalar types:
+
+| Scalar | Description |
+|--------|-------------|
+| `UUID` | UUID string (e.g., `"550e8400-e29b-41d4-a716-446655440000"`) |
+| `DateTime` | ISO 8601 datetime string (e.g., `"2024-01-15T10:30:00Z"`) |
+| `JSON` | Arbitrary JSON object |
+
+## Source Files
+
+Type definitions are implemented in:
+
+- `packages/backend/src/boards/graphql/types/board.py`
+- `packages/backend/src/boards/graphql/types/generation.py`
+- `packages/backend/src/boards/graphql/types/generator.py`
+- `packages/backend/src/boards/graphql/types/user.py`

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -41,7 +41,18 @@ const sidebars: SidebarsConfig = {
       items: [
         "backend/index",
         "backend/getting-started",
-        "backend/graphql-api",
+        {
+          type: "category",
+          label: "GraphQL API",
+          collapsed: true,
+          items: [
+            "backend/graphql-api",
+            "backend/graphql-api/types",
+            "backend/graphql-api/queries",
+            "backend/graphql-api/mutations",
+            "backend/graphql-api/access-control",
+          ],
+        },
         "backend/storage",
         "backend/migrations",
         "backend/testing",


### PR DESCRIPTION
Expand the GraphQL API documentation with detailed pages for types, queries, mutations, and access control. The documentation structure mirrors the backend implementation in packages/backend/src/boards/graphql.

New documentation pages:
- graphql-api/types.md: All GraphQL type definitions
- graphql-api/queries.md: Available query operations
- graphql-api/mutations.md: Available mutation operations
- graphql-api/access-control.md: Authentication and authorization