### PR TITLE
A couple of fixes for baseboards 0.6

### DIFF
--- a/packages/backend/src/boards/generators/implementations/fal/image/flux_2_pro_edit.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/flux_2_pro_edit.py
@@ -62,8 +62,8 @@ class Flux2ProEditInput(BaseModel):
             "data won't be available in the request history."
         ),
     )
-    safety_tolerance: Literal[1, 2, 3, 4, 5] = Field(
-        default=2,
+    safety_tolerance: Literal["1", "2", "3", "4", "5"] = Field(
+        default="2",
         description=(
             "The safety tolerance level for the generated image. "
             "1 is most strict, 5 is most permissive."

--- a/packages/backend/src/boards/graphql/resolvers/lineage.py
+++ b/packages/backend/src/boards/graphql/resolvers/lineage.py
@@ -140,7 +140,7 @@ async def resolve_ancestry(
                     0 as depth,
                     NULL::text as role,
                     ARRAY[id] as path  -- cycle detection
-                FROM generations
+                FROM boards.generations
                 WHERE id = :gen_id AND tenant_id = :tenant_id
 
                 UNION ALL
@@ -172,7 +172,7 @@ async def resolve_ancestry(
                     at.path || g.id
                 FROM ancestry_tree at
                 CROSS JOIN LATERAL jsonb_array_elements(at.input_artifacts) AS artifact
-                JOIN generations g ON
+                JOIN boards.generations g ON
                     g.id = (artifact->>'generation_id')::uuid
                     AND NOT (g.id = ANY(at.path))  -- prevent cycles
                     AND at.depth < :max_depth
@@ -281,7 +281,7 @@ async def resolve_descendants(
                     NULL::text as role,
                     NULL::uuid as parent_id,
                     ARRAY[id] as path  -- cycle detection
-                FROM generations
+                FROM boards.generations
                 WHERE id = :gen_id AND tenant_id = :tenant_id
 
                 UNION ALL
@@ -312,7 +312,7 @@ async def resolve_descendants(
                     artifact->>'role' as role,
                     dt.id as parent_id,
                     dt.path || g.id
-                FROM generations g
+                FROM boards.generations g
                 CROSS JOIN LATERAL jsonb_array_elements(g.input_artifacts) AS artifact
                 JOIN descendants_tree dt ON
                     dt.id = (artifact->>'generation_id')::uuid

--- a/packages/backend/tests/generators/implementations/test_flux_2_pro_edit.py
+++ b/packages/backend/tests/generators/implementations/test_flux_2_pro_edit.py
@@ -67,7 +67,7 @@ class TestFlux2ProEditInput:
         assert input_data.image_size == "auto"
         assert input_data.output_format == "jpeg"
         assert input_data.sync_mode is False
-        assert input_data.safety_tolerance == 2
+        assert input_data.safety_tolerance == "2"
         assert input_data.enable_safety_checker is True
         assert input_data.seed is None
 
@@ -115,6 +115,22 @@ class TestFlux2ProEditInput:
             height=768,
         )
 
+        # Test invalid string values
+        with pytest.raises(ValidationError):
+            Flux2ProEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                safety_tolerance="0",  # type: ignore[arg-type]
+            )
+
+        with pytest.raises(ValidationError):
+            Flux2ProEditInput(
+                prompt="Test",
+                image_sources=[image_artifact],
+                safety_tolerance="6",  # type: ignore[arg-type]
+            )
+
+        # Test invalid integer values (should also fail since we expect strings)
         with pytest.raises(ValidationError):
             Flux2ProEditInput(
                 prompt="Test",
@@ -194,7 +210,7 @@ class TestFlux2ProEditInput:
             height=768,
         )
 
-        for tolerance in [1, 2, 3, 4, 5]:
+        for tolerance in ["1", "2", "3", "4", "5"]:
             input_data = Flux2ProEditInput(
                 prompt="Test",
                 image_sources=[image_artifact],
@@ -389,7 +405,7 @@ class TestFalFlux2ProEditGenerator:
                     "image_urls": [fake_uploaded_url],  # Should use uploaded URL, not original
                     "output_format": "jpeg",
                     "sync_mode": False,
-                    "safety_tolerance": 2,
+                    "safety_tolerance": "2",
                     "enable_safety_checker": True,
                     "image_size": "auto",
                 },


### PR DESCRIPTION
This pull request updates the handling of the `safety_tolerance` field in the `Flux2ProEditInput` model to use string values instead of integers, and refactors related tests accordingly. Additionally, it corrects several SQL queries to explicitly reference the `boards.generations` table, improving schema clarity and correctness.

**Safety tolerance type update:**

* Changed the `safety_tolerance` field in the `Flux2ProEditInput` model from an integer literal to a string literal, updating the default and all related usages to expect string values instead of integers. (`flux_2_pro_edit.py`, `test_flux_2_pro_edit.py`) [[1]](diffhunk://#diff-1824ca49f78aea116a4e076dc3db33ee101f063a4c13de919bb6b8dfd0556a60L65-R66) [[2]](diffhunk://#diff-cb90437b68d02dedf6537a497c630ec6bb3592e5f6ba97f03ad28c3dc5bf2a85L70-R70) [[3]](diffhunk://#diff-cb90437b68d02dedf6537a497c630ec6bb3592e5f6ba97f03ad28c3dc5bf2a85L197-R213) [[4]](diffhunk://#diff-cb90437b68d02dedf6537a497c630ec6bb3592e5f6ba97f03ad28c3dc5bf2a85L392-R408)
* Enhanced test coverage to check for invalid string and integer values for `safety_tolerance`, ensuring only valid string literals ("1"–"5") are accepted. (`test_flux_2_pro_edit.py`)

**Database schema reference corrections:**

* Updated all relevant SQL queries in the lineage resolver to explicitly reference the `boards.generations` table, rather than just `generations`, for both ancestry and descendant resolution. (`lineage.py`) [[1]](diffhunk://#diff-7ab34acb4d0fa3e17fa04107c4a26bee125a40bc73569593320bfc2bba3e4ca5L143-R143) [[2]](diffhunk://#diff-7ab34acb4d0fa3e17fa04107c4a26bee125a40bc73569593320bfc2bba3e4ca5L175-R175) [[3]](diffhunk://#diff-7ab34acb4d0fa3e17fa04107c4a26bee125a40bc73569593320bfc2bba3e4ca5L284-R284) [[4]](diffhunk://#diff-7ab34acb4d0fa3e17fa04107c4a26bee125a40bc73569593320bfc2bba3e4ca5L315-R315)