### PR TITLE
Fix the editing of boards functionality

### DIFF
--- a/packages/frontend/src/graphql/__tests__/operations.test.ts
+++ b/packages/frontend/src/graphql/__tests__/operations.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { UPDATE_BOARD, type UpdateBoardInput } from "../operations";
+
+describe("UPDATE_BOARD mutation", () => {
+  it("should have correct signature with id inside input", () => {
+    const mutationString = UPDATE_BOARD.loc?.source.body || "";
+
+    // Should have single $input parameter
+    expect(mutationString).toContain(
+      "mutation UpdateBoard($input: UpdateBoardInput!)"
+    );
+
+    // Should call updateBoard with input only
+    expect(mutationString).toContain("updateBoard(input: $input)");
+
+    // Should NOT have separate $id parameter (the bug from issue #189)
+    expect(mutationString).not.toContain("$id: UUID!");
+    expect(mutationString).not.toContain("updateBoard(id: $id");
+  });
+});
+
+describe("UpdateBoardInput interface", () => {
+  it("should include id as a required field", () => {
+    // TypeScript compile-time check - if this compiles, the interface is correct
+    const validInput: UpdateBoardInput = {
+      id: "board-123",
+      title: "Test",
+    };
+
+    expect(validInput.id).toBe("board-123");
+  });
+
+  it("should allow optional fields", () => {
+    // Should compile with just id
+    const minimalInput: UpdateBoardInput = {
+      id: "board-123",
+    };
+
+    expect(minimalInput.id).toBe("board-123");
+
+    // Should compile with all fields
+    const fullInput: UpdateBoardInput = {
+      id: "board-123",
+      title: "Test Title",
+      description: "Test Description",
+      isPublic: true,
+      settings: { foo: "bar" },
+      metadata: { baz: "qux" },
+    };
+
+    expect(fullInput.title).toBe("Test Title");
+  });
+});

--- a/packages/frontend/src/graphql/operations.ts
+++ b/packages/frontend/src/graphql/operations.ts
@@ -245,8 +245,8 @@ export const CREATE_BOARD = gql`
 
 export const UPDATE_BOARD = gql`
   ${BOARD_FRAGMENT}
-  mutation UpdateBoard($id: UUID!, $input: UpdateBoardInput!) {
-    updateBoard(id: $id, input: $input) {
+  mutation UpdateBoard($input: UpdateBoardInput!) {
+    updateBoard(input: $input) {
       ...BoardFragment
     }
   }
@@ -341,6 +341,7 @@ export interface CreateBoardInput {
 }
 
 export interface UpdateBoardInput {
+  id: string;
   title?: string;
   description?: string;
   isPublic?: boolean;

--- a/packages/frontend/src/hooks/useBoard.ts
+++ b/packages/frontend/src/hooks/useBoard.ts
@@ -189,8 +189,10 @@ export function useBoard(
       }
 
       const result = await updateBoardMutation({
-        id: boardId,
-        input: updates,
+        input: {
+          id: boardId,
+          ...updates,
+        },
       });
 
       if (result.error) {


### PR DESCRIPTION
This pull request refactors the `UPDATE_BOARD` GraphQL mutation to simplify its signature and input handling, ensuring the board ID is included inside the input object instead of as a separate parameter. It also updates related TypeScript interfaces and mutation usage to match this change, and adds tests to verify the correct structure and type safety.

**GraphQL mutation signature and input handling:**

* Refactored the `UPDATE_BOARD` mutation in `operations.ts` to accept a single `$input` parameter of type `UpdateBoardInput`, removing the separate `$id` parameter and ensuring the mutation calls `updateBoard(input: $input)` only.

**TypeScript interface updates:**

* Updated the `UpdateBoardInput` interface in `operations.ts` to require an `id` field, aligning with the new mutation signature.

**Mutation usage updates:**

* Modified the `useBoard` hook to construct the mutation input object with `id` and spread `updates` into it, matching the new input structure.

**Testing improvements:**

* Added tests in `operations.test.ts` to verify the mutation signature, input structure, and type safety of the `UpdateBoardInput` interface.