### PR TITLE
Create FAL text-to-speech turbo generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -17,6 +17,9 @@ generators:
   - class: "boards.generators.implementations.fal.audio.beatoven_sound_effect_generation.FalBeatovenSoundEffectGenerationGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.audio.chatterbox_tts_turbo.FalChatterboxTtsTurboGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.image.clarity_upscaler.FalClarityUpscalerGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/audio/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/audio/__init__.py
@@ -1,5 +1,6 @@
 from .beatoven_music_generation import FalBeatovenMusicGenerationGenerator
 from .beatoven_sound_effect_generation import FalBeatovenSoundEffectGenerationGenerator
+from .chatterbox_tts_turbo import FalChatterboxTtsTurboGenerator
 from .elevenlabs_sound_effects_v2 import FalElevenlabsSoundEffectsV2Generator
 from .elevenlabs_tts_eleven_v3 import FalElevenlabsTtsElevenV3Generator
 from .fal_elevenlabs_tts_turbo_v2_5 import FalElevenlabsTtsTurboV25Generator
@@ -10,6 +11,7 @@ from .minimax_speech_2_6_turbo import FalMinimaxSpeech26TurboGenerator
 __all__ = [
     "FalBeatovenMusicGenerationGenerator",
     "FalBeatovenSoundEffectGenerationGenerator",
+    "FalChatterboxTtsTurboGenerator",
     "FalElevenlabsSoundEffectsV2Generator",
     "FalElevenlabsTtsElevenV3Generator",
     "FalElevenlabsTtsTurboV25Generator",

--- a/packages/backend/src/boards/generators/implementations/fal/audio/chatterbox_tts_turbo.py
+++ b/packages/backend/src/boards/generators/implementations/fal/audio/chatterbox_tts_turbo.py
@@ -1,0 +1,195 @@
+"""
+fal.ai Chatterbox Text-to-Speech Turbo generator.
+
+Generate expressive speech from text with paralinguistic controls like laughs,
+sighs, coughs, and more. Supports voice cloning with custom audio samples.
+
+Based on Fal AI's fal-ai/chatterbox/text-to-speech/turbo model.
+See: https://fal.ai/models/fal-ai/chatterbox/text-to-speech/turbo
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import AudioArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+# Voice presets available in Chatterbox
+ChatterboxVoice = Literal[
+    "aaron",
+    "abigail",
+    "anaya",
+    "andy",
+    "archer",
+    "brian",
+    "chloe",
+    "dylan",
+    "emmanuel",
+    "ethan",
+    "evelyn",
+    "gavin",
+    "gordon",
+    "ivan",
+    "laura",
+    "lucy",
+    "madison",
+    "marisol",
+    "meera",
+    "walter",
+]
+
+
+class ChatterboxTtsTurboInput(BaseModel):
+    """Input schema for Chatterbox TTS Turbo.
+
+    Artifact fields are automatically detected via type introspection
+    and resolved from generation IDs to artifact objects.
+    """
+
+    text: str = Field(
+        description=(
+            "The text to be converted to speech. Supports paralinguistic tags: "
+            "[clear throat], [sigh], [shush], [cough], [groan], [sniff], [gasp], "
+            "[chuckle], [laugh]"
+        ),
+        min_length=1,
+    )
+    voice: ChatterboxVoice = Field(
+        default="lucy",
+        description="Preset voice to use for synthesis",
+    )
+    audio_url: AudioArtifact | None = Field(
+        default=None,
+        description=(
+            "Optional audio file (5-10 seconds) for voice cloning. "
+            "If provided, this overrides the preset voice selection."
+        ),
+    )
+    temperature: float = Field(
+        default=0.8,
+        ge=0.05,
+        le=2.0,
+        description="Temperature for generation. Higher values create more varied speech patterns.",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Random seed for reproducible results. Set for consistent generations.",
+    )
+
+
+class FalChatterboxTtsTurboGenerator(BaseGenerator):
+    """Chatterbox TTS Turbo text-to-speech generator using fal.ai."""
+
+    name = "fal-chatterbox-tts-turbo"
+    artifact_type = "audio"
+    description = (
+        "Fal: Chatterbox TTS Turbo - "
+        "Expressive text-to-speech with paralinguistic controls and voice cloning"
+    )
+
+    def get_input_schema(self) -> type[ChatterboxTtsTurboInput]:
+        return ChatterboxTtsTurboInput
+
+    async def generate(
+        self, inputs: ChatterboxTtsTurboInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate audio using fal.ai Chatterbox TTS Turbo model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalChatterboxTtsTurboGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Prepare arguments for fal.ai API
+        arguments: dict[str, str | float | int] = {
+            "text": inputs.text,
+            "voice": inputs.voice,
+            "temperature": inputs.temperature,
+        }
+
+        # Add seed if provided
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+
+        # Handle voice cloning audio upload
+        if inputs.audio_url is not None:
+            from ..utils import upload_artifacts_to_fal
+
+            audio_urls = await upload_artifacts_to_fal([inputs.audio_url], context)
+            arguments["audio_url"] = audio_urls[0]
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/chatterbox/text-to-speech/turbo",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract audio URL from result
+        # fal.ai returns: {"audio": {"url": "..."}}
+        audio_data = result.get("audio")
+        if audio_data is None:
+            raise ValueError("No audio data returned from fal.ai API")
+
+        audio_url = audio_data.get("url")
+        if not audio_url:
+            raise ValueError("Audio URL missing in fal.ai response")
+
+        # Store audio result
+        artifact = await context.store_audio_result(
+            storage_url=audio_url,
+            format="wav",  # Chatterbox TTS returns WAV format
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: ChatterboxTtsTurboInput) -> float:
+        """Estimate cost for Chatterbox TTS Turbo generation.
+
+        Chatterbox TTS Turbo pricing is approximately $0.03 per generation.
+        """
+        return 0.03

--- a/packages/backend/tests/generators/implementations/test_chatterbox_tts_turbo.py
+++ b/packages/backend/tests/generators/implementations/test_chatterbox_tts_turbo.py
@@ -1,0 +1,624 @@
+"""
+Tests for FalChatterboxTtsTurboGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import AudioArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.audio.chatterbox_tts_turbo import (
+    ChatterboxTtsTurboInput,
+    FalChatterboxTtsTurboGenerator,
+)
+
+
+class TestChatterboxTtsTurboInput:
+    """Tests for ChatterboxTtsTurboInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        input_data = ChatterboxTtsTurboInput(
+            text="Hello, this is a test [laugh] with some expression.",
+            voice="lucy",
+            temperature=0.9,
+            seed=42,
+        )
+
+        assert input_data.text == "Hello, this is a test [laugh] with some expression."
+        assert input_data.voice == "lucy"
+        assert input_data.temperature == 0.9
+        assert input_data.seed == 42
+        assert input_data.audio_url is None
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = ChatterboxTtsTurboInput(
+            text="Test prompt",
+        )
+
+        # Check defaults
+        assert input_data.voice == "lucy"
+        assert input_data.temperature == 0.8
+        assert input_data.seed is None
+        assert input_data.audio_url is None
+
+    def test_all_preset_voices(self):
+        """Test all preset voice options are valid."""
+        voices = [
+            "aaron",
+            "abigail",
+            "anaya",
+            "andy",
+            "archer",
+            "brian",
+            "chloe",
+            "dylan",
+            "emmanuel",
+            "ethan",
+            "evelyn",
+            "gavin",
+            "gordon",
+            "ivan",
+            "laura",
+            "lucy",
+            "madison",
+            "marisol",
+            "meera",
+            "walter",
+        ]
+
+        for voice in voices:
+            input_data = ChatterboxTtsTurboInput(
+                text="Test",
+                voice=voice,  # type: ignore[arg-type]
+            )
+            assert input_data.voice == voice
+
+    def test_invalid_voice(self):
+        """Test validation fails for invalid voice."""
+        with pytest.raises(ValidationError):
+            ChatterboxTtsTurboInput(
+                text="Test",
+                voice="invalid_voice",  # type: ignore[arg-type]
+            )
+
+    def test_empty_text_validation(self):
+        """Test validation for empty text."""
+        with pytest.raises(ValidationError):
+            ChatterboxTtsTurboInput(text="")
+
+    def test_temperature_validation_min(self):
+        """Test temperature below minimum."""
+        with pytest.raises(ValidationError):
+            ChatterboxTtsTurboInput(
+                text="Test",
+                temperature=0.01,  # Below 0.05 minimum
+            )
+
+    def test_temperature_validation_max(self):
+        """Test temperature above maximum."""
+        with pytest.raises(ValidationError):
+            ChatterboxTtsTurboInput(
+                text="Test",
+                temperature=2.5,  # Above 2.0 maximum
+            )
+
+    def test_temperature_at_boundaries(self):
+        """Test temperature at boundary values."""
+        # Minimum boundary
+        input_min = ChatterboxTtsTurboInput(
+            text="Test",
+            temperature=0.05,
+        )
+        assert input_min.temperature == 0.05
+
+        # Maximum boundary
+        input_max = ChatterboxTtsTurboInput(
+            text="Test",
+            temperature=2.0,
+        )
+        assert input_max.temperature == 2.0
+
+    def test_with_audio_artifact(self):
+        """Test input with voice cloning audio artifact."""
+        audio_artifact = AudioArtifact(
+            generation_id="test_audio",
+            storage_url="https://example.com/voice_sample.wav",
+            format="wav",
+            duration=7.5,
+            sample_rate=44100,
+            channels=1,
+        )
+
+        input_data = ChatterboxTtsTurboInput(
+            text="Test voice cloning",
+            audio_url=audio_artifact,
+        )
+
+        assert input_data.audio_url == audio_artifact
+
+    def test_paralinguistic_tags_in_text(self):
+        """Test that paralinguistic tags are accepted in text."""
+        input_data = ChatterboxTtsTurboInput(
+            text="[clear throat] Hello there [sigh] how are you [laugh]",
+        )
+
+        assert "[clear throat]" in input_data.text
+        assert "[sigh]" in input_data.text
+        assert "[laugh]" in input_data.text
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalChatterboxTtsTurboGenerator:
+    """Tests for FalChatterboxTtsTurboGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalChatterboxTtsTurboGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-chatterbox-tts-turbo"
+        assert self.generator.artifact_type == "audio"
+        assert "text-to-speech" in self.generator.description.lower()
+        assert "Chatterbox" in self.generator.description
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == ChatterboxTtsTurboInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = ChatterboxTtsTurboInput(
+                text="Test speech generation",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    return AudioArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        format="wav",
+                        duration=0.0,
+                        sample_rate=None,
+                        channels=None,
+                    )
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful(self):
+        """Test successful generation with audio output."""
+        input_data = ChatterboxTtsTurboInput(
+            text="Hello world, this is a test [laugh].",
+            voice="lucy",
+            temperature=0.8,
+        )
+
+        fake_audio_url = "https://storage.googleapis.com/falserverless/audio_output.wav"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "audio": {
+                        "url": fake_audio_url,
+                    }
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = AudioArtifact(
+                generation_id="test_gen",
+                storage_url=fake_audio_url,
+                format="wav",
+                duration=0.0,
+                sample_rate=None,
+                channels=None,
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify API calls
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/chatterbox/text-to-speech/turbo",
+                arguments={
+                    "text": "Hello world, this is a test [laugh].",
+                    "voice": "lucy",
+                    "temperature": 0.8,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_with_seed(self):
+        """Test generation with seed parameter."""
+        input_data = ChatterboxTtsTurboInput(
+            text="Test with seed",
+            seed=12345,
+        )
+
+        fake_audio_url = "https://storage.googleapis.com/falserverless/audio_output.wav"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-seed"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"audio": {"url": fake_audio_url}})
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = AudioArtifact(
+                generation_id="test_gen",
+                storage_url=fake_audio_url,
+                format="wav",
+                duration=0.0,
+                sample_rate=None,
+                channels=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            await self.generator.generate(input_data, DummyCtx())
+
+            # Verify seed is included in API call
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["seed"] == 12345
+
+    @pytest.mark.asyncio
+    async def test_generate_with_voice_cloning(self):
+        """Test generation with voice cloning audio artifact."""
+        audio_artifact = AudioArtifact(
+            generation_id="test_audio",
+            storage_url="https://example.com/voice_sample.wav",
+            format="wav",
+            duration=7.5,
+            sample_rate=44100,
+            channels=1,
+        )
+
+        input_data = ChatterboxTtsTurboInput(
+            text="Test voice cloning",
+            audio_url=audio_artifact,
+        )
+
+        fake_audio_url = "https://storage.googleapis.com/falserverless/audio_output.wav"
+        fake_uploaded_url = "https://fal.ai/uploads/voice_sample.wav"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-clone"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"audio": {"url": fake_audio_url}})
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = AudioArtifact(
+                generation_id="test_gen",
+                storage_url=fake_audio_url,
+                format="wav",
+                duration=0.0,
+                sample_rate=None,
+                channels=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/voice_sample.wav"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            # Mock upload_artifacts_to_fal in the utils module where it's defined
+            with patch(
+                "boards.generators.implementations.fal.utils.upload_artifacts_to_fal",
+                new_callable=AsyncMock,
+                return_value=[fake_uploaded_url],
+            ):
+                await self.generator.generate(input_data, DummyCtx())
+
+                # Verify audio_url is included in API call
+                call_args = mock_fal_client.submit_async.call_args
+                assert call_args[1]["arguments"]["audio_url"] == fake_uploaded_url
+
+    @pytest.mark.asyncio
+    async def test_generate_no_audio_returned(self):
+        """Test generation fails when API returns no audio."""
+        input_data = ChatterboxTtsTurboInput(
+            text="Test",
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})  # No audio field
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No audio data returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_audio_url(self):
+        """Test generation fails when audio URL is missing."""
+        input_data = ChatterboxTtsTurboInput(
+            text="Test",
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-999"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={"audio": {}}  # Audio field exists but no URL
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="Audio URL missing"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_data = ChatterboxTtsTurboInput(
+            text="Test prompt for cost estimation",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Chatterbox TTS Turbo costs $0.03 per generation
+        assert cost == 0.03
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_consistent(self):
+        """Test cost estimation is consistent regardless of text length."""
+        # Short text
+        short_input = ChatterboxTtsTurboInput(text="Hi")
+        short_cost = await self.generator.estimate_cost(short_input)
+
+        # Long text
+        long_input = ChatterboxTtsTurboInput(text="a" * 1000)
+        long_cost = await self.generator.estimate_cost(long_input)
+
+        # Cost should be the same (flat rate per generation)
+        assert short_cost == long_cost == 0.03
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = ChatterboxTtsTurboInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "text" in schema["properties"]
+        assert "voice" in schema["properties"]
+        assert "audio_url" in schema["properties"]
+        assert "temperature" in schema["properties"]
+        assert "seed" in schema["properties"]
+
+        # Check text has min_length constraint
+        text_prop = schema["properties"]["text"]
+        assert text_prop.get("minLength") == 1
+
+        # Check temperature constraints
+        temp_prop = schema["properties"]["temperature"]
+        assert temp_prop.get("minimum") == 0.05
+        assert temp_prop.get("maximum") == 2.0
+
+        # Check voice is enum
+        voice_prop = schema["properties"]["voice"]
+        assert "enum" in voice_prop or "anyOf" in voice_prop
+
+    def test_different_voices(self):
+        """Test generation with different voice presets."""
+        voices_to_test = ["aaron", "chloe", "walter", "marisol"]
+
+        for voice in voices_to_test:
+            input_data = ChatterboxTtsTurboInput(
+                text="Test",
+                voice=voice,  # type: ignore[arg-type]
+            )
+            assert input_data.voice == voice

--- a/packages/backend/tests/generators/implementations/test_chatterbox_tts_turbo_live.py
+++ b/packages/backend/tests/generators/implementations/test_chatterbox_tts_turbo_live.py
@@ -1,0 +1,178 @@
+"""
+Live API tests for FalChatterboxTtsTurboGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_chatterbox_tts_turbo_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_chatterbox_tts_turbo_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.implementations.fal.audio.chatterbox_tts_turbo import (
+    ChatterboxTtsTurboInput,
+    FalChatterboxTtsTurboGenerator,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestChatterboxTtsTurboGeneratorLive:
+    """Live API tests for FalChatterboxTtsTurboGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalChatterboxTtsTurboGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, dummy_context, cost_logger):
+        """
+        Test basic speech generation with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses minimal/cheap settings to reduce cost.
+        """
+        # Use short text to minimize cost
+        inputs = ChatterboxTtsTurboInput(
+            text="Hello.",  # Very short to reduce cost
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        from boards.generators.artifacts import AudioArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, AudioArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.format == "wav"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_different_voice(
+        self, skip_if_no_fal_key, dummy_context, cost_logger
+    ):
+        """
+        Test speech generation with a different voice preset.
+
+        Verifies that voice parameter is correctly processed.
+        """
+        # Use short text to minimize cost
+        inputs = ChatterboxTtsTurboInput(
+            text="Testing voice.",
+            voice="walter",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        from boards.generators.artifacts import AudioArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, AudioArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.format == "wav"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_paralinguistic_tags(
+        self, skip_if_no_fal_key, dummy_context, cost_logger
+    ):
+        """
+        Test speech generation with paralinguistic tags.
+
+        Verifies that inline tags like [laugh], [sigh] are processed.
+        """
+        # Use text with paralinguistic tag
+        inputs = ChatterboxTtsTurboInput(
+            text="Ha [laugh] that's funny.",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        from boards.generators.artifacts import AudioArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, AudioArtifact)
+        assert artifact.storage_url is not None
+
+    @pytest.mark.asyncio
+    async def test_generate_with_temperature(self, skip_if_no_fal_key, dummy_context, cost_logger):
+        """
+        Test speech generation with custom temperature.
+
+        Verifies that temperature parameter affects generation.
+        """
+        inputs = ChatterboxTtsTurboInput(
+            text="Testing temperature.",
+            temperature=1.2,  # Higher temperature for more variation
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        from boards.generators.artifacts import AudioArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, AudioArtifact)
+        assert artifact.storage_url is not None
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        inputs = ChatterboxTtsTurboInput(text="Test")
+        estimated_cost = await self.generator.estimate_cost(inputs)
+
+        # Verify estimate is in reasonable range
+        assert estimated_cost > 0.0
+        assert estimated_cost < 0.10  # Should be well under $0.10 per generation
+        assert estimated_cost == 0.03  # Expected flat rate


### PR DESCRIPTION
Implements a new Fal AI generator for the chatterbox/text-to-speech/turbo model with the following features:
- 20 preset voices (lucy, aaron, walter, etc.)
- Paralinguistic tag support ([laugh], [sigh], [cough], etc.)
- Voice cloning via custom audio upload (5-10 second samples)
- Temperature control for speech variation (0.05-2.0)
- Reproducible results with optional seed parameter

Includes comprehensive unit tests (22 tests) and live API test suite.