### PR TITLE
Create FAL text-to-speech generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -17,6 +17,9 @@ generators:
   - class: "boards.generators.implementations.fal.audio.beatoven_sound_effect_generation.FalBeatovenSoundEffectGenerationGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.audio.chatterbox_text_to_speech.FalChatterboxTextToSpeechGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.audio.chatterbox_tts_turbo.FalChatterboxTtsTurboGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/audio/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/audio/__init__.py
@@ -1,5 +1,6 @@
 from .beatoven_music_generation import FalBeatovenMusicGenerationGenerator
 from .beatoven_sound_effect_generation import FalBeatovenSoundEffectGenerationGenerator
+from .chatterbox_text_to_speech import FalChatterboxTextToSpeechGenerator
 from .chatterbox_tts_turbo import FalChatterboxTtsTurboGenerator
 from .elevenlabs_sound_effects_v2 import FalElevenlabsSoundEffectsV2Generator
 from .elevenlabs_tts_eleven_v3 import FalElevenlabsTtsElevenV3Generator
@@ -11,6 +12,7 @@ from .minimax_speech_2_6_turbo import FalMinimaxSpeech26TurboGenerator
 __all__ = [
     "FalBeatovenMusicGenerationGenerator",
     "FalBeatovenSoundEffectGenerationGenerator",
+    "FalChatterboxTextToSpeechGenerator",
     "FalChatterboxTtsTurboGenerator",
     "FalElevenlabsSoundEffectsV2Generator",
     "FalElevenlabsTtsElevenV3Generator",

--- a/packages/backend/src/boards/generators/implementations/fal/audio/chatterbox_text_to_speech.py
+++ b/packages/backend/src/boards/generators/implementations/fal/audio/chatterbox_text_to_speech.py
@@ -1,0 +1,176 @@
+"""
+fal.ai Chatterbox Text-to-Speech generator.
+
+Generate expressive speech from text using Resemble AI's Chatterbox model.
+Supports emotive tags for natural expressions like laughing, sighing, and more.
+
+Based on Fal AI's fal-ai/chatterbox/text-to-speech model.
+See: https://fal.ai/models/fal-ai/chatterbox/text-to-speech
+"""
+
+import os
+
+from pydantic import BaseModel, Field
+
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class ChatterboxTextToSpeechInput(BaseModel):
+    """Input schema for Chatterbox text-to-speech generation.
+
+    Supports emotive tags: <laugh>, <chuckle>, <sigh>, <cough>,
+    <sniffle>, <groan>, <yawn>, <gasp>
+    """
+
+    text: str = Field(
+        description=(
+            "The text to be converted to speech. You can add emotive tags like "
+            "<laugh>, <chuckle>, <sigh>, <cough>, <sniffle>, <groan>, <yawn>, <gasp>"
+        ),
+        min_length=1,
+    )
+    audio_url: str | None = Field(
+        default=None,
+        description=(
+            "Reference audio file URL for voice style matching. "
+            "If not provided, uses a default voice sample."
+        ),
+    )
+    exaggeration: float = Field(
+        default=0.25,
+        ge=0.0,
+        le=1.0,
+        description="Speech exaggeration intensity factor (0.0 to 1.0)",
+    )
+    temperature: float = Field(
+        default=0.7,
+        ge=0.05,
+        le=2.0,
+        description="Creativity level for generation (0.05 to 2.0)",
+    )
+    cfg: float = Field(
+        default=0.5,
+        ge=0.1,
+        le=1.0,
+        description="Configuration parameter for generation (0.1 to 1.0)",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Random seed for reproducible audio generation",
+    )
+
+
+class FalChatterboxTextToSpeechGenerator(BaseGenerator):
+    """Chatterbox text-to-speech generator using fal.ai.
+
+    Leverages Resemble AI's Chatterbox model to generate expressive speech
+    with support for emotive tags and voice cloning via reference audio.
+    """
+
+    name = "fal-chatterbox-text-to-speech"
+    artifact_type = "audio"
+    description = (
+        "Fal: Chatterbox TTS - " "Expressive text-to-speech with emotive tags and voice cloning"
+    )
+
+    def get_input_schema(self) -> type[ChatterboxTextToSpeechInput]:
+        return ChatterboxTextToSpeechInput
+
+    async def generate(
+        self, inputs: ChatterboxTextToSpeechInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate audio using fal.ai Chatterbox text-to-speech model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalChatterboxTextToSpeechGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Prepare arguments for fal.ai API
+        arguments: dict = {
+            "text": inputs.text,
+            "exaggeration": inputs.exaggeration,
+            "temperature": inputs.temperature,
+            "cfg": inputs.cfg,
+        }
+
+        # Add optional parameters if provided
+        if inputs.audio_url is not None:
+            arguments["audio_url"] = inputs.audio_url
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/chatterbox/text-to-speech",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract audio URL from result
+        # fal.ai returns: {"audio": {"url": "..."}}
+        audio_data = result.get("audio")
+        if audio_data is None:
+            raise ValueError("No audio data returned from fal.ai API")
+
+        audio_url = audio_data.get("url")
+        if not audio_url:
+            raise ValueError("Audio URL missing in fal.ai response")
+
+        # Store audio result
+        artifact = await context.store_audio_result(
+            storage_url=audio_url,
+            format="mp3",  # Chatterbox returns MP3 format
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: ChatterboxTextToSpeechInput) -> float:
+        """Estimate cost for Chatterbox text-to-speech generation.
+
+        Chatterbox pricing is approximately $0.03 per generation.
+        """
+        # Fixed cost per generation
+        return 0.03

--- a/packages/backend/tests/generators/implementations/test_chatterbox_text_to_speech.py
+++ b/packages/backend/tests/generators/implementations/test_chatterbox_text_to_speech.py
@@ -1,0 +1,524 @@
+"""
+Tests for FalChatterboxTextToSpeechGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import AudioArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.audio.chatterbox_text_to_speech import (
+    ChatterboxTextToSpeechInput,
+    FalChatterboxTextToSpeechGenerator,
+)
+
+
+class TestChatterboxTextToSpeechInput:
+    """Tests for ChatterboxTextToSpeechInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        input_data = ChatterboxTextToSpeechInput(
+            text="Hello, this is a test speech.",
+            audio_url="https://example.com/voice.mp3",
+            exaggeration=0.5,
+            temperature=1.0,
+            cfg=0.7,
+            seed=42,
+        )
+
+        assert input_data.text == "Hello, this is a test speech."
+        assert input_data.audio_url == "https://example.com/voice.mp3"
+        assert input_data.exaggeration == 0.5
+        assert input_data.temperature == 1.0
+        assert input_data.cfg == 0.7
+        assert input_data.seed == 42
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = ChatterboxTextToSpeechInput(
+            text="Test prompt",
+        )
+
+        assert input_data.text == "Test prompt"
+        assert input_data.audio_url is None
+        assert input_data.exaggeration == 0.25
+        assert input_data.temperature == 0.7
+        assert input_data.cfg == 0.5
+        assert input_data.seed is None
+
+    def test_input_with_emotive_tags(self):
+        """Test input with emotive tags."""
+        input_data = ChatterboxTextToSpeechInput(
+            text="I just won the lottery! <laugh> Can you believe it? <gasp>",
+        )
+
+        assert "<laugh>" in input_data.text
+        assert "<gasp>" in input_data.text
+
+    def test_empty_text_validation(self):
+        """Test validation fails for empty text."""
+        with pytest.raises(ValidationError):
+            ChatterboxTextToSpeechInput(text="")
+
+    def test_exaggeration_validation(self):
+        """Test validation for exaggeration range (0.0 to 1.0)."""
+        # Valid minimum
+        input_data = ChatterboxTextToSpeechInput(text="Test", exaggeration=0.0)
+        assert input_data.exaggeration == 0.0
+
+        # Valid maximum
+        input_data = ChatterboxTextToSpeechInput(text="Test", exaggeration=1.0)
+        assert input_data.exaggeration == 1.0
+
+        # Below minimum
+        with pytest.raises(ValidationError):
+            ChatterboxTextToSpeechInput(text="Test", exaggeration=-0.1)
+
+        # Above maximum
+        with pytest.raises(ValidationError):
+            ChatterboxTextToSpeechInput(text="Test", exaggeration=1.1)
+
+    def test_temperature_validation(self):
+        """Test validation for temperature range (0.05 to 2.0)."""
+        # Valid minimum
+        input_data = ChatterboxTextToSpeechInput(text="Test", temperature=0.05)
+        assert input_data.temperature == 0.05
+
+        # Valid maximum
+        input_data = ChatterboxTextToSpeechInput(text="Test", temperature=2.0)
+        assert input_data.temperature == 2.0
+
+        # Below minimum
+        with pytest.raises(ValidationError):
+            ChatterboxTextToSpeechInput(text="Test", temperature=0.01)
+
+        # Above maximum
+        with pytest.raises(ValidationError):
+            ChatterboxTextToSpeechInput(text="Test", temperature=2.5)
+
+    def test_cfg_validation(self):
+        """Test validation for cfg range (0.1 to 1.0)."""
+        # Valid minimum
+        input_data = ChatterboxTextToSpeechInput(text="Test", cfg=0.1)
+        assert input_data.cfg == 0.1
+
+        # Valid maximum
+        input_data = ChatterboxTextToSpeechInput(text="Test", cfg=1.0)
+        assert input_data.cfg == 1.0
+
+        # Below minimum
+        with pytest.raises(ValidationError):
+            ChatterboxTextToSpeechInput(text="Test", cfg=0.05)
+
+        # Above maximum
+        with pytest.raises(ValidationError):
+            ChatterboxTextToSpeechInput(text="Test", cfg=1.5)
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalChatterboxTextToSpeechGenerator:
+    """Tests for FalChatterboxTextToSpeechGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalChatterboxTextToSpeechGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-chatterbox-text-to-speech"
+        assert self.generator.artifact_type == "audio"
+        assert "Chatterbox" in self.generator.description
+        assert "text-to-speech" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == ChatterboxTextToSpeechInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = ChatterboxTextToSpeechInput(
+                text="Test speech generation",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    return AudioArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        format="mp3",
+                        duration=0.0,
+                        sample_rate=None,
+                        channels=None,
+                    )
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful(self):
+        """Test successful generation with audio output."""
+        input_data = ChatterboxTextToSpeechInput(
+            text="Hello world, this is a test.",
+            exaggeration=0.3,
+            temperature=0.8,
+        )
+
+        fake_audio_url = "https://storage.googleapis.com/falserverless/audio_output.mp3"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "audio": {
+                        "url": fake_audio_url,
+                    }
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = AudioArtifact(
+                generation_id="test_gen",
+                storage_url=fake_audio_url,
+                format="mp3",
+                duration=0.0,
+                sample_rate=None,
+                channels=None,
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify API calls
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/chatterbox/text-to-speech",
+                arguments={
+                    "text": "Hello world, this is a test.",
+                    "exaggeration": 0.3,
+                    "temperature": 0.8,
+                    "cfg": 0.5,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_with_all_parameters(self):
+        """Test generation with all optional parameters."""
+        input_data = ChatterboxTextToSpeechInput(
+            text="Test with all params",
+            audio_url="https://example.com/voice.mp3",
+            exaggeration=0.5,
+            temperature=1.0,
+            cfg=0.7,
+            seed=12345,
+        )
+
+        fake_audio_url = "https://storage.googleapis.com/falserverless/audio_output.mp3"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"audio": {"url": fake_audio_url}})
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = AudioArtifact(
+                generation_id="test_gen",
+                storage_url=fake_audio_url,
+                format="mp3",
+                duration=0.0,
+                sample_rate=None,
+                channels=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify all parameters were passed
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/chatterbox/text-to-speech",
+                arguments={
+                    "text": "Test with all params",
+                    "audio_url": "https://example.com/voice.mp3",
+                    "exaggeration": 0.5,
+                    "temperature": 1.0,
+                    "cfg": 0.7,
+                    "seed": 12345,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_no_audio_returned(self):
+        """Test generation fails when API returns no audio."""
+        input_data = ChatterboxTextToSpeechInput(
+            text="Test",
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})  # No audio field
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No audio data returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_audio_url(self):
+        """Test generation fails when audio URL is missing."""
+        input_data = ChatterboxTextToSpeechInput(
+            text="Test",
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-999"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={"audio": {}}  # Audio field exists but no URL
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="Audio URL missing"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_data = ChatterboxTextToSpeechInput(
+            text="Hello world, this is a test.",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Chatterbox has a fixed cost of $0.03 per generation
+        assert cost == 0.03
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_long_text(self):
+        """Test cost estimation for long text."""
+        # Even with long text, cost should be fixed
+        input_data = ChatterboxTextToSpeechInput(
+            text="a" * 1000,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Fixed cost regardless of text length
+        assert cost == 0.03
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = ChatterboxTextToSpeechInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "text" in schema["properties"]
+        assert "audio_url" in schema["properties"]
+        assert "exaggeration" in schema["properties"]
+        assert "temperature" in schema["properties"]
+        assert "cfg" in schema["properties"]
+        assert "seed" in schema["properties"]
+
+        # Check text constraints
+        text_prop = schema["properties"]["text"]
+        assert text_prop["minLength"] == 1
+
+        # Check exaggeration constraints
+        exag_prop = schema["properties"]["exaggeration"]
+        assert exag_prop["minimum"] == 0.0
+        assert exag_prop["maximum"] == 1.0
+
+        # Check temperature constraints
+        temp_prop = schema["properties"]["temperature"]
+        assert temp_prop["minimum"] == 0.05
+        assert temp_prop["maximum"] == 2.0
+
+        # Check cfg constraints
+        cfg_prop = schema["properties"]["cfg"]
+        assert cfg_prop["minimum"] == 0.1
+        assert cfg_prop["maximum"] == 1.0

--- a/packages/backend/tests/generators/implementations/test_chatterbox_text_to_speech_live.py
+++ b/packages/backend/tests/generators/implementations/test_chatterbox_text_to_speech_live.py
@@ -1,0 +1,151 @@
+"""
+Live API tests for FalChatterboxTextToSpeechGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_chatterbox_text_to_speech_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_chatterbox_text_to_speech_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.implementations.fal.audio.chatterbox_text_to_speech import (
+    ChatterboxTextToSpeechInput,
+    FalChatterboxTextToSpeechGenerator,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestChatterboxTextToSpeechGeneratorLive:
+    """Live API tests for FalChatterboxTextToSpeechGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalChatterboxTextToSpeechGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, dummy_context, cost_logger):
+        """
+        Test basic speech generation with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses minimal/cheap settings to reduce cost.
+        """
+        # Use short text to minimize cost
+        inputs = ChatterboxTextToSpeechInput(
+            text="Hello.",  # Very short to reduce cost
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        from boards.generators.artifacts import AudioArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, AudioArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.format == "mp3"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_emotive_tags(self, skip_if_no_fal_key, dummy_context, cost_logger):
+        """
+        Test speech generation with emotive tags.
+
+        Verifies that emotive tags like <laugh> are processed correctly.
+        """
+        # Use emotive tags in text
+        inputs = ChatterboxTextToSpeechInput(
+            text="That's hilarious! <laugh>",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        from boards.generators.artifacts import AudioArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, AudioArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.format == "mp3"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_custom_parameters(
+        self, skip_if_no_fal_key, dummy_context, cost_logger
+    ):
+        """
+        Test speech generation with custom exaggeration and temperature.
+
+        Verifies that custom parameters are correctly processed.
+        """
+        inputs = ChatterboxTextToSpeechInput(
+            text="Testing custom params.",
+            exaggeration=0.5,
+            temperature=1.0,
+            cfg=0.7,
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        from boards.generators.artifacts import AudioArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, AudioArtifact)
+        assert artifact.storage_url is not None
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Test with any text
+        inputs = ChatterboxTextToSpeechInput(text="Test")
+        cost = await self.generator.estimate_cost(inputs)
+
+        # Verify fixed cost
+        assert cost == 0.03
+
+        # Sanity check on absolute costs
+        assert cost > 0.0
+        assert cost < 0.10  # Should be well under $0.10 per generation


### PR DESCRIPTION
Add support for fal-ai/chatterbox/text-to-speech model which generates expressive speech with support for emotive tags (<laugh>, <sigh>, etc.) and optional voice cloning via reference audio.

- Add FalChatterboxTextToSpeechGenerator implementation
- Add comprehensive unit tests (17 tests)
- Add live API tests for manual verification
- Update module exports and generators.yaml