### PR TITLE
Create FAL AI avatar video generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -98,6 +98,9 @@ generators:
   - class: "boards.generators.implementations.fal.video.infinitalk.FalInfinitalkGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.video.kling_video_ai_avatar_v2_pro.FalKlingVideoAiAvatarV2ProGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.video.kling_video_v2_5_turbo_pro_image_to_video.FalKlingVideoV25TurboProImageToVideoGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
@@ -13,6 +13,7 @@ from .fal_minimax_hailuo_02_standard_text_to_video import (
 from .fal_pixverse_lipsync import FalPixverseLipsyncGenerator
 from .fal_sora_2_text_to_video import FalSora2TextToVideoGenerator
 from .infinitalk import FalInfinitalkGenerator
+from .kling_video_ai_avatar_v2_pro import FalKlingVideoAiAvatarV2ProGenerator
 from .kling_video_v2_5_turbo_pro_image_to_video import (
     FalKlingVideoV25TurboProImageToVideoGenerator,
 )
@@ -45,6 +46,7 @@ __all__ = [
     "FalCreatifyLipsyncGenerator",
     "FalBytedanceSeedanceV1ProImageToVideoGenerator",
     "FalBytedanceSeedanceV1ProTextToVideoGenerator",
+    "FalKlingVideoAiAvatarV2ProGenerator",
     "FalKlingVideoV25TurboProImageToVideoGenerator",
     "FalKlingVideoV25TurboProTextToVideoGenerator",
     "FalPixverseLipsyncGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/video/kling_video_ai_avatar_v2_pro.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/kling_video_ai_avatar_v2_pro.py
@@ -1,0 +1,168 @@
+"""
+fal.ai Kling Video AI Avatar v2 Pro generator.
+
+Transforms static portrait images into synchronized talking avatar videos
+with audio-driven facial animation. Supports realistic humans, animals,
+cartoons, and stylized figures.
+
+Based on Fal AI's fal-ai/kling-video/ai-avatar/v2/pro model.
+See: https://fal.ai/models/fal-ai/kling-video/ai-avatar/v2/pro
+"""
+
+import os
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import AudioArtifact, ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class KlingVideoAiAvatarV2ProInput(BaseModel):
+    """Input schema for kling-video/ai-avatar/v2/pro.
+
+    Artifact fields are automatically detected via type introspection
+    and resolved from generation IDs to artifact objects.
+    """
+
+    image: ImageArtifact = Field(description="The image to use as your avatar")
+    audio: AudioArtifact = Field(description="The audio file for lip-sync animation")
+    prompt: str = Field(
+        default=".",
+        description="Optional prompt to refine animation details",
+    )
+
+
+class FalKlingVideoAiAvatarV2ProGenerator(BaseGenerator):
+    """Generator for AI avatar talking videos using Kling Video AI Avatar v2 Pro."""
+
+    name = "fal-kling-video-ai-avatar-v2-pro"
+    description = (
+        "Fal: Kling Video AI Avatar v2 Pro - "
+        "Transform portraits into talking avatar videos with audio-driven facial animation"
+    )
+    artifact_type = "video"
+
+    def get_input_schema(self) -> type[KlingVideoAiAvatarV2ProInput]:
+        """Return the input schema for this generator."""
+        return KlingVideoAiAvatarV2ProInput
+
+    async def generate(
+        self, inputs: KlingVideoAiAvatarV2ProInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate talking avatar video using fal.ai kling-video/ai-avatar/v2/pro."""
+        # Check for API key
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalKlingVideoAiAvatarV2ProGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image and audio artifacts to Fal's public storage
+        # Fal API requires publicly accessible URLs
+        from ..utils import upload_artifacts_to_fal
+
+        # Upload image and audio separately
+        image_urls = await upload_artifacts_to_fal([inputs.image], context)
+        audio_urls = await upload_artifacts_to_fal([inputs.audio], context)
+
+        # Prepare arguments for fal.ai API
+        arguments: dict[str, str] = {
+            "image_url": image_urls[0],
+            "audio_url": audio_urls[0],
+            "prompt": inputs.prompt,
+        }
+
+        # Submit async job
+        handler = await fal_client.submit_async(
+            "fal-ai/kling-video/ai-avatar/v2/pro",
+            arguments=arguments,
+        )
+
+        # Store external job ID
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+            # Sample every 3rd event to avoid spam
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract video from result
+        # fal.ai returns: {"video": {"url": "...", "content_type": "..."}, "duration": ...}
+        video_data = result.get("video")
+
+        if not video_data:
+            raise ValueError("No video returned from fal.ai API")
+
+        video_url = video_data.get("url")
+        if not video_url:
+            raise ValueError("Video missing URL in fal.ai response")
+
+        # Extract format from content_type (e.g., "video/mp4" -> "mp4")
+        content_type = video_data.get("content_type", "video/mp4")
+        if content_type.startswith("video/"):
+            video_format = content_type.split("/")[-1]
+        else:
+            # Default to mp4 if content_type is not a video mime type
+            video_format = "mp4"
+
+        # Get duration from result if available
+        duration = result.get("duration")
+
+        # Store the video result
+        # Note: The API doesn't return width/height/fps, so we use reasonable defaults
+        artifact = await context.store_video_result(
+            storage_url=video_url,
+            format=video_format,
+            width=None,
+            height=None,
+            duration=duration,
+            fps=None,
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: KlingVideoAiAvatarV2ProInput) -> float:
+        """Estimate cost for this generation in USD.
+
+        Pricing: $0.115 per second of generated video.
+        Cost depends on audio duration since the output video matches audio length.
+        """
+        # If audio duration is available, calculate based on that
+        if inputs.audio.duration is not None:
+            return 0.115 * inputs.audio.duration
+
+        # Default estimate for unknown duration (assume ~10 second video)
+        return 1.15

--- a/packages/backend/tests/generators/implementations/test_kling_video_ai_avatar_v2_pro.py
+++ b/packages/backend/tests/generators/implementations/test_kling_video_ai_avatar_v2_pro.py
@@ -1,0 +1,681 @@
+"""
+Tests for FalKlingVideoAiAvatarV2ProGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from boards.generators.artifacts import AudioArtifact, ImageArtifact, VideoArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.video.kling_video_ai_avatar_v2_pro import (
+    FalKlingVideoAiAvatarV2ProGenerator,
+    KlingVideoAiAvatarV2ProInput,
+)
+
+
+class TestKlingVideoAiAvatarV2ProInput:
+    """Tests for KlingVideoAiAvatarV2ProInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/avatar.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=10.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+            prompt="Generate natural facial movements",
+        )
+
+        assert input_data.image == image_artifact
+        assert input_data.audio == audio_artifact
+        assert input_data.prompt == "Generate natural facial movements"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/avatar.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        input_data = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        # Default prompt is "."
+        assert input_data.prompt == "."
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalKlingVideoAiAvatarV2ProGenerator:
+    """Tests for FalKlingVideoAiAvatarV2ProGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalKlingVideoAiAvatarV2ProGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-kling-video-ai-avatar-v2-pro"
+        assert self.generator.artifact_type == "video"
+        assert "avatar" in self.generator.description.lower()
+        assert "kling" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == KlingVideoAiAvatarV2ProInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/avatar.png",
+                format="png",
+                width=512,
+                height=512,
+            )
+            audio_artifact = AudioArtifact(
+                generation_id="gen2",
+                storage_url="https://example.com/audio.wav",
+                format="wav",
+                duration=None,
+                sample_rate=None,
+                channels=None,
+            )
+
+            input_data = KlingVideoAiAvatarV2ProInput(
+                image=image_artifact,
+                audio=audio_artifact,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    return VideoArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=None,
+                        height=None,
+                        format="mp4",
+                        duration=None,
+                        fps=None,
+                    )
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful(self):
+        """Test successful generation with default parameters."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/avatar.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/speech.wav",
+            format="wav",
+            duration=5.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        fake_output_url = "https://v3.fal.media/files/koala/avatar_output.mp4"
+        fake_uploaded_image_url = "https://fal.media/files/uploaded-image.png"
+        fake_uploaded_audio_url = "https://fal.media/files/uploaded-audio.wav"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                        "file_name": "output.mp4",
+                        "file_size": 4404019,
+                    },
+                    "duration": 5.0,
+                }
+            )
+
+            # Track upload calls to return different URLs for image and audio
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+                upload_call_count += 1
+                return url
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_video_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=None,
+                height=None,
+                format="mp4",
+                duration=5.0,
+                fps=None,
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    # Return different fake paths for image and audio
+                    if isinstance(artifact, ImageArtifact):
+                        return "/tmp/fake_image.png"
+                    elif isinstance(artifact, AudioArtifact):
+                        return "/tmp/fake_audio.wav"
+                    return "/tmp/fake_file"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_video_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_video_artifact
+
+            # Verify file uploads were called for both image and audio
+            assert mock_fal_client.upload_file_async.call_count == 2
+
+            # Verify API calls with uploaded URLs
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/kling-video/ai-avatar/v2/pro",
+                arguments={
+                    "image_url": fake_uploaded_image_url,
+                    "audio_url": fake_uploaded_audio_url,
+                    "prompt": ".",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_with_custom_prompt(self):
+        """Test successful generation with custom prompt."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/avatar.jpg",
+            format="jpg",
+            width=1024,
+            height=1024,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/speech.mp3",
+            format="mp3",
+            duration=8.0,
+            sample_rate=48000,
+            channels=1,
+        )
+
+        input_data = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+            prompt="Generate expressive facial movements with natural head motion",
+        )
+
+        fake_output_url = "https://v3.fal.media/files/koala/avatar_custom.mp4"
+        fake_uploaded_image_url = "https://fal.media/files/uploaded-image.jpg"
+        fake_uploaded_audio_url = "https://fal.media/files/uploaded-audio.mp3"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                        "file_name": "output.mp4",
+                        "file_size": 8808038,
+                    },
+                    "duration": 8.0,
+                }
+            )
+
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_video_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=None,
+                height=None,
+                format="mp4",
+                duration=8.0,
+                fps=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    if isinstance(artifact, ImageArtifact):
+                        return "/tmp/fake_image.jpg"
+                    elif isinstance(artifact, AudioArtifact):
+                        return "/tmp/fake_audio.mp3"
+                    return "/tmp/fake_file"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_video_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_video_artifact
+
+            # Verify API call used custom prompt
+            call_args = mock_fal_client.submit_async.call_args
+            assert (
+                call_args[1]["arguments"]["prompt"]
+                == "Generate expressive facial movements with natural head motion"
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_no_video_returned(self):
+        """Test generation fails when API returns no video."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/avatar.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        input_data = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})  # No video in response
+
+            fake_uploaded_image_url = "https://fal.media/files/uploaded-image.png"
+            fake_uploaded_audio_url = "https://fal.media/files/uploaded-audio.wav"
+
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    if isinstance(artifact, ImageArtifact):
+                        return "/tmp/fake_image.png"
+                    elif isinstance(artifact, AudioArtifact):
+                        return "/tmp/fake_audio.wav"
+                    return "/tmp/fake_file"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No video returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_with_octet_stream_content_type(self):
+        """Test that application/octet-stream content type defaults to mp4 format."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/avatar.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=5.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        fake_output_url = "https://v3.fal.media/files/koala/test_output.mp4"
+        fake_uploaded_image_url = "https://fal.media/files/uploaded-image.png"
+        fake_uploaded_audio_url = "https://fal.media/files/uploaded-audio.wav"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-octet"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Return application/octet-stream instead of video/mp4
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "application/octet-stream",  # Non-video content type
+                        "file_name": "output.mp4",
+                        "file_size": 3000000,
+                    },
+                    "duration": 5.0,
+                }
+            )
+
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock the returned artifact - should have format="mp4" despite octet-stream
+            mock_video_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=None,
+                height=None,
+                format="mp4",  # Should be mp4, not octet-stream
+                duration=5.0,
+                fps=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    if isinstance(artifact, ImageArtifact):
+                        return "/tmp/fake_image.png"
+                    elif isinstance(artifact, AudioArtifact):
+                        return "/tmp/fake_audio.wav"
+                    return "/tmp/fake_file"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    # Verify format is mp4, not octet-stream
+                    assert kwargs["format"] == "mp4"
+                    return mock_video_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0].format == "mp4"  # Should be mp4, not octet-stream
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_with_duration(self):
+        """Test cost estimation with known audio duration."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/avatar.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=10.0,  # 10 second audio
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # $0.115 per second * 10 seconds = $1.15
+        assert cost == pytest.approx(1.15, rel=0.01)
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_without_duration(self):
+        """Test cost estimation without known audio duration."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/avatar.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/audio.wav",
+            format="wav",
+            duration=None,  # Unknown duration
+            sample_rate=None,
+            channels=None,
+        )
+
+        input_data = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Default estimate for ~10 second video: $1.15
+        assert cost == 1.15
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = KlingVideoAiAvatarV2ProInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "image" in schema["properties"]
+        assert "audio" in schema["properties"]
+        assert "prompt" in schema["properties"]
+
+        # Check that image and audio are required
+        assert "image" in schema["required"]
+        assert "audio" in schema["required"]
+
+        # Check prompt is string type
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop["type"] == "string"
+        assert prompt_prop["default"] == "."

--- a/packages/backend/tests/generators/implementations/test_kling_video_ai_avatar_v2_pro_live.py
+++ b/packages/backend/tests/generators/implementations/test_kling_video_ai_avatar_v2_pro_live.py
@@ -1,0 +1,179 @@
+"""
+Live API tests for FalKlingVideoAiAvatarV2ProGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_kling_video_ai_avatar_v2_pro_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_kling_video_ai_avatar_v2_pro_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+
+Note: These tests use example image and audio URLs to test the avatar generation.
+Cost: ~$0.115/second of generated video.
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import AudioArtifact, ImageArtifact, VideoArtifact
+from boards.generators.implementations.fal.video.kling_video_ai_avatar_v2_pro import (
+    FalKlingVideoAiAvatarV2ProGenerator,
+    KlingVideoAiAvatarV2ProInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestKlingVideoAiAvatarV2ProGeneratorLive:
+    """Live API tests for FalKlingVideoAiAvatarV2ProGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalKlingVideoAiAvatarV2ProGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test basic avatar video generation with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses a portrait image and short audio to minimize cost.
+        """
+        # Create image artifact using a publicly accessible portrait image
+        image_artifact = ImageArtifact(
+            generation_id="example_image",
+            storage_url="https://placehold.co/512x512/222222/white.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create audio artifact using a short test audio
+        # Using a publicly accessible short audio file
+        audio_artifact = AudioArtifact(
+            generation_id="example_audio",
+            storage_url="https://v3.fal.media/files/penguin/IjB1sco-ydVA-szm3a1Rm_E_voice.mp3",
+            format="mp3",
+            duration=5.0,  # Short audio to minimize cost (~$0.575)
+            sample_rate=44100,
+            channels=2,
+        )
+
+        # Create minimal input with default prompt
+        inputs = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+
+    @pytest.mark.asyncio
+    async def test_generate_with_prompt(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test avatar video generation with custom prompt.
+
+        Verifies that the prompt parameter is correctly processed.
+        """
+        # Create image artifact
+        image_artifact = ImageArtifact(
+            generation_id="example_image",
+            storage_url="https://placehold.co/512x512/222222/white.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        # Create audio artifact
+        audio_artifact = AudioArtifact(
+            generation_id="example_audio",
+            storage_url="https://v3.fal.media/files/penguin/IjB1sco-ydVA-szm3a1Rm_E_voice.mp3",
+            format="mp3",
+            duration=5.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        # Test with custom prompt
+        inputs = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+            prompt="Generate natural, subtle facial movements",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url.startswith("https://")
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Create dummy artifacts (used for cost estimation based on audio duration)
+        image_artifact = ImageArtifact(
+            generation_id="test",
+            storage_url="https://example.com/test.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="test",
+            storage_url="https://example.com/test.wav",
+            format="wav",
+            duration=10.0,  # 10 second audio
+            sample_rate=None,
+            channels=None,
+        )
+
+        # Test cost estimation
+        inputs = KlingVideoAiAvatarV2ProInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+        estimated_cost = await self.generator.estimate_cost(inputs)
+
+        # $0.115/second * 10 seconds = $1.15
+        assert estimated_cost == pytest.approx(1.15, rel=0.01)
+        assert estimated_cost > 0.0
+        assert estimated_cost < 10.0  # Should be under $10 for 10 seconds


### PR DESCRIPTION
Adds support for the fal-ai/kling-video/ai-avatar/v2/pro model which transforms static portrait images into synchronized talking avatar videos using audio-driven facial animation.

Features:
- Takes image and audio inputs to generate talking avatar video
- Supports optional prompt for animation refinement
- Cost estimation based on audio duration ($0.115/second)

Includes:
- Generator implementation with artifact uploads
- Unit tests with mocked fal_client
- Live API tests (opt-in with FAL_KEY)
- Module exports and generators.yaml configuration