### PR TITLE
Create FAL AI avatar video generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -101,6 +101,9 @@ generators:
   - class: "boards.generators.implementations.fal.video.kling_video_ai_avatar_v2_pro.FalKlingVideoAiAvatarV2ProGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.video.kling_video_ai_avatar_v2_standard.FalKlingVideoAiAvatarV2StandardGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.video.kling_video_v2_5_turbo_pro_image_to_video.FalKlingVideoV25TurboProImageToVideoGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
@@ -14,6 +14,9 @@ from .fal_pixverse_lipsync import FalPixverseLipsyncGenerator
 from .fal_sora_2_text_to_video import FalSora2TextToVideoGenerator
 from .infinitalk import FalInfinitalkGenerator
 from .kling_video_ai_avatar_v2_pro import FalKlingVideoAiAvatarV2ProGenerator
+from .kling_video_ai_avatar_v2_standard import (
+    FalKlingVideoAiAvatarV2StandardGenerator,
+)
 from .kling_video_v2_5_turbo_pro_image_to_video import (
     FalKlingVideoV25TurboProImageToVideoGenerator,
 )
@@ -47,6 +50,7 @@ __all__ = [
     "FalBytedanceSeedanceV1ProImageToVideoGenerator",
     "FalBytedanceSeedanceV1ProTextToVideoGenerator",
     "FalKlingVideoAiAvatarV2ProGenerator",
+    "FalKlingVideoAiAvatarV2StandardGenerator",
     "FalKlingVideoV25TurboProImageToVideoGenerator",
     "FalKlingVideoV25TurboProTextToVideoGenerator",
     "FalPixverseLipsyncGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/video/kling_video_ai_avatar_v2_standard.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/kling_video_ai_avatar_v2_standard.py
@@ -1,0 +1,159 @@
+"""
+fal.ai Kling Video AI Avatar v2 Standard generator.
+
+Generates avatar videos by synthesizing realistic humans, animals, cartoons, or
+stylized characters. Takes an image and audio as inputs to create synchronized
+video output.
+
+Based on Fal AI's fal-ai/kling-video/ai-avatar/v2/standard model.
+See: https://fal.ai/models/fal-ai/kling-video/ai-avatar/v2/standard
+"""
+
+import os
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import AudioArtifact, ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class KlingVideoAiAvatarV2StandardInput(BaseModel):
+    """Input schema for Kling Video AI Avatar v2 Standard.
+
+    Artifact fields are automatically detected via type introspection
+    and resolved from generation IDs to artifact objects.
+    """
+
+    image: ImageArtifact = Field(description="The image to use as your avatar")
+    audio: AudioArtifact = Field(description="The audio file for lip-sync animation")
+    prompt: str | None = Field(
+        default=".", description="The prompt to use for the video generation"
+    )
+
+
+class FalKlingVideoAiAvatarV2StandardGenerator(BaseGenerator):
+    """Generator for AI-powered avatar video synthesis."""
+
+    name = "fal-kling-video-ai-avatar-v2-standard"
+    description = "Fal: Kling Video AI Avatar v2 Standard - Avatar video from image and audio"
+    artifact_type = "video"
+
+    def get_input_schema(self) -> type[KlingVideoAiAvatarV2StandardInput]:
+        """Return the input schema for this generator."""
+        return KlingVideoAiAvatarV2StandardInput
+
+    async def generate(
+        self, inputs: KlingVideoAiAvatarV2StandardInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate avatar video using fal.ai kling-video/ai-avatar/v2/standard."""
+        # Check for API key
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalKlingVideoAiAvatarV2StandardGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image and audio artifacts to Fal's public storage
+        # Fal API requires publicly accessible URLs
+        from ..utils import upload_artifacts_to_fal
+
+        # Upload image and audio separately
+        image_urls = await upload_artifacts_to_fal([inputs.image], context)
+        audio_urls = await upload_artifacts_to_fal([inputs.audio], context)
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "image_url": image_urls[0],
+            "audio_url": audio_urls[0],
+        }
+
+        # Add prompt only if provided and not the default empty value
+        if inputs.prompt and inputs.prompt != ".":
+            arguments["prompt"] = inputs.prompt
+
+        # Submit async job
+        handler = await fal_client.submit_async(
+            "fal-ai/kling-video/ai-avatar/v2/standard",
+            arguments=arguments,
+        )
+
+        # Store external job ID
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+            # Sample every 3rd event to avoid spam
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract video from result
+        # fal.ai returns: {"video": {"url": ..., "content_type": ...}, "duration": ...}
+        video_data = result.get("video")
+
+        if not video_data:
+            raise ValueError("No video returned from fal.ai API")
+
+        video_url = video_data.get("url")
+        if not video_url:
+            raise ValueError("Video missing URL in fal.ai response")
+
+        # Extract format from content_type (e.g., "video/mp4" -> "mp4")
+        content_type = video_data.get("content_type", "video/mp4")
+        video_format = content_type.split("/")[-1] if "/" in content_type else "mp4"
+
+        # Extract duration from response (available in API response)
+        duration = result.get("duration")
+
+        # Store the video result
+        # Use input image dimensions as base dimensions (avatar video maintains aspect ratio)
+        artifact = await context.store_video_result(
+            storage_url=video_url,
+            format=video_format,
+            width=inputs.image.width,
+            height=inputs.image.height,
+            duration=duration,
+            fps=None,  # Not provided by API
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: KlingVideoAiAvatarV2StandardInput) -> float:
+        """Estimate cost for Kling Video AI Avatar v2 Standard generation in USD.
+
+        Pricing not specified in documentation, using estimate based on
+        typical Kling video generation costs.
+        """
+        # Estimate per generation based on typical Kling pricing
+        return 0.10

--- a/packages/backend/tests/generators/implementations/test_kling_video_ai_avatar_v2_standard.py
+++ b/packages/backend/tests/generators/implementations/test_kling_video_ai_avatar_v2_standard.py
@@ -1,0 +1,591 @@
+"""
+Tests for FalKlingVideoAiAvatarV2StandardGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import AudioArtifact, ImageArtifact, VideoArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.video.kling_video_ai_avatar_v2_standard import (
+    FalKlingVideoAiAvatarV2StandardGenerator,
+    KlingVideoAiAvatarV2StandardInput,
+)
+
+
+class TestKlingVideoAiAvatarV2StandardInput:
+    """Tests for KlingVideoAiAvatarV2StandardInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/avatar.jpg",
+            format="jpg",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/speech.mp3",
+            format="mp3",
+            duration=10.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = KlingVideoAiAvatarV2StandardInput(
+            image=image_artifact,
+            audio=audio_artifact,
+            prompt="A person speaking clearly",
+        )
+
+        assert input_data.image == image_artifact
+        assert input_data.audio == audio_artifact
+        assert input_data.prompt == "A person speaking clearly"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/avatar.jpg",
+            format="jpg",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/speech.mp3",
+            format="mp3",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        input_data = KlingVideoAiAvatarV2StandardInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        assert input_data.prompt == "."
+
+    def test_missing_image(self):
+        """Test validation fails when image is missing."""
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/speech.mp3",
+            format="mp3",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        with pytest.raises(ValidationError):
+            KlingVideoAiAvatarV2StandardInput(
+                audio=audio_artifact,  # type: ignore[call-arg]
+            )
+
+    def test_missing_audio(self):
+        """Test validation fails when audio is missing."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/avatar.jpg",
+            format="jpg",
+            width=512,
+            height=512,
+        )
+
+        with pytest.raises(ValidationError):
+            KlingVideoAiAvatarV2StandardInput(
+                image=image_artifact,  # type: ignore[call-arg]
+            )
+
+    def test_custom_prompt(self):
+        """Test custom prompt is accepted."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/avatar.jpg",
+            format="jpg",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/speech.mp3",
+            format="mp3",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        input_data = KlingVideoAiAvatarV2StandardInput(
+            image=image_artifact,
+            audio=audio_artifact,
+            prompt="A cartoon character speaking enthusiastically",
+        )
+
+        assert input_data.prompt == "A cartoon character speaking enthusiastically"
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalKlingVideoAiAvatarV2StandardGenerator:
+    """Tests for FalKlingVideoAiAvatarV2StandardGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalKlingVideoAiAvatarV2StandardGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-kling-video-ai-avatar-v2-standard"
+        assert self.generator.artifact_type == "video"
+        assert "avatar" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == KlingVideoAiAvatarV2StandardInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/avatar.jpg",
+                format="jpg",
+                width=512,
+                height=512,
+            )
+            audio_artifact = AudioArtifact(
+                generation_id="gen2",
+                storage_url="https://example.com/speech.mp3",
+                format="mp3",
+                duration=None,
+                sample_rate=None,
+                channels=None,
+            )
+
+            input_data = KlingVideoAiAvatarV2StandardInput(
+                image=image_artifact,
+                audio=audio_artifact,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    return VideoArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="mp4",
+                        duration=None,
+                        fps=None,
+                    )
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful(self):
+        """Test successful generation with default parameters."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/avatar.jpg",
+            format="jpg",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/speech.mp3",
+            format="mp3",
+            duration=10.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        input_data = KlingVideoAiAvatarV2StandardInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        fake_output_url = "https://v3.fal.media/files/penguin/output.mp4"
+        fake_uploaded_image_url = "https://fal.media/files/uploaded-image.jpg"
+        fake_uploaded_audio_url = "https://fal.media/files/uploaded-audio.mp3"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                        "file_name": "output.mp4",
+                        "file_size": 4404019,
+                    },
+                    "duration": 10.0,
+                }
+            )
+
+            # Track upload calls to return different URLs for image and audio
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+                upload_call_count += 1
+                return url
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_video_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=512,
+                height=512,
+                format="mp4",
+                duration=10.0,
+                fps=None,
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    # Return different fake paths for image and audio
+                    if isinstance(artifact, ImageArtifact):
+                        return "/tmp/fake_image.jpg"
+                    elif isinstance(artifact, AudioArtifact):
+                        return "/tmp/fake_audio.mp3"
+                    return "/tmp/fake_file"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_video_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_video_artifact
+
+            # Verify file uploads were called for both image and audio
+            assert mock_fal_client.upload_file_async.call_count == 2
+
+            # Verify API calls with uploaded URLs (default prompt is not sent)
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/kling-video/ai-avatar/v2/standard",
+                arguments={
+                    "image_url": fake_uploaded_image_url,
+                    "audio_url": fake_uploaded_audio_url,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_with_prompt(self):
+        """Test successful generation with custom prompt."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/avatar.jpg",
+            format="jpg",
+            width=1024,
+            height=1024,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/speech.mp3",
+            format="mp3",
+            duration=15.0,
+            sample_rate=48000,
+            channels=1,
+        )
+
+        input_data = KlingVideoAiAvatarV2StandardInput(
+            image=image_artifact,
+            audio=audio_artifact,
+            prompt="A cartoon character speaking with enthusiasm",
+        )
+
+        fake_output_url = "https://v3.fal.media/files/penguin/output-with-prompt.mp4"
+        fake_uploaded_image_url = "https://fal.media/files/uploaded-image-prompt.jpg"
+        fake_uploaded_audio_url = "https://fal.media/files/uploaded-audio-prompt.mp3"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                        "file_name": "output-with-prompt.mp4",
+                        "file_size": 8808038,
+                    },
+                    "duration": 15.0,
+                }
+            )
+
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_video_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=1024,
+                format="mp4",
+                duration=15.0,
+                fps=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    if isinstance(artifact, ImageArtifact):
+                        return "/tmp/fake_image_prompt.jpg"
+                    elif isinstance(artifact, AudioArtifact):
+                        return "/tmp/fake_audio_prompt.mp3"
+                    return "/tmp/fake_file"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_video_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_video_artifact
+
+            # Verify API call includes the custom prompt
+            call_args = mock_fal_client.submit_async.call_args
+            expected_prompt = "A cartoon character speaking with enthusiasm"
+            assert call_args[1]["arguments"]["prompt"] == expected_prompt
+
+    @pytest.mark.asyncio
+    async def test_generate_no_video_returned(self):
+        """Test generation fails when API returns no video."""
+        image_artifact = ImageArtifact(
+            generation_id="gen_input_image",
+            storage_url="https://example.com/avatar.jpg",
+            format="jpg",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen_input_audio",
+            storage_url="https://example.com/speech.mp3",
+            format="mp3",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        input_data = KlingVideoAiAvatarV2StandardInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})  # No video in response
+
+            fake_uploaded_image_url = "https://fal.media/files/uploaded-image.jpg"
+            fake_uploaded_audio_url = "https://fal.media/files/uploaded-audio.mp3"
+
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_image_url if upload_call_count == 0 else fake_uploaded_audio_url
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    if isinstance(artifact, ImageArtifact):
+                        return "/tmp/fake_image.jpg"
+                    elif isinstance(artifact, AudioArtifact):
+                        return "/tmp/fake_audio.mp3"
+                    return "/tmp/fake_file"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No video returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/avatar.jpg",
+            format="jpg",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/speech.mp3",
+            format="mp3",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        input_data = KlingVideoAiAvatarV2StandardInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Estimated cost (0.10)
+        assert cost == 0.10
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = KlingVideoAiAvatarV2StandardInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "image" in schema["properties"]
+        assert "audio" in schema["properties"]
+        assert "prompt" in schema["properties"]
+
+        # Check that image and audio are required
+        assert "image" in schema["required"]
+        assert "audio" in schema["required"]
+
+        # Check prompt has default
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop.get("default") == "."

--- a/packages/backend/tests/generators/implementations/test_kling_video_ai_avatar_v2_standard_live.py
+++ b/packages/backend/tests/generators/implementations/test_kling_video_ai_avatar_v2_standard_live.py
@@ -1,0 +1,130 @@
+"""
+Live API tests for FalKlingVideoAiAvatarV2StandardGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/.../test_kling_video_ai_avatar_v2_standard_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/.../test_kling_video_ai_avatar_v2_standard_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+
+Note: These tests use example image and audio URLs from Fal.ai's documentation
+since the generator requires artifact inputs.
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import AudioArtifact, ImageArtifact, VideoArtifact
+from boards.generators.implementations.fal.video.kling_video_ai_avatar_v2_standard import (
+    FalKlingVideoAiAvatarV2StandardGenerator,
+    KlingVideoAiAvatarV2StandardInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestKlingVideoAiAvatarV2StandardGeneratorLive:
+    """Live API tests for FalKlingVideoAiAvatarV2StandardGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalKlingVideoAiAvatarV2StandardGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test basic avatar video generation.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses example image and audio from Fal.ai documentation.
+        """
+        # Create image and audio artifacts using example URLs from Fal.ai docs
+        # These are publicly accessible example files from the API documentation
+        image_artifact = ImageArtifact(
+            generation_id="example_image",
+            storage_url="https://storage.googleapis.com/falserverless/example_inputs/kling_ai_avatar_input.jpg",
+            format="jpg",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="example_audio",
+            storage_url="https://v3.fal.media/files/rabbit/9_0ZG_geiWjZOmn9yscO6_output.mp3",
+            format="mp3",
+            duration=5.0,
+            sample_rate=44100,
+            channels=2,
+        )
+
+        # Create minimal input
+        inputs = KlingVideoAiAvatarV2StandardInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        # Dimensions are optional, but if present should be valid
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+        assert artifact.format == "mp4"
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Create dummy artifacts (not actually used for cost estimation)
+        image_artifact = ImageArtifact(
+            generation_id="test",
+            storage_url="https://example.com/test.jpg",
+            format="jpg",
+            width=512,
+            height=512,
+        )
+        audio_artifact = AudioArtifact(
+            generation_id="test",
+            storage_url="https://example.com/test.mp3",
+            format="mp3",
+            duration=None,
+            sample_rate=None,
+            channels=None,
+        )
+
+        inputs = KlingVideoAiAvatarV2StandardInput(
+            image=image_artifact,
+            audio=audio_artifact,
+        )
+        estimated_cost = await self.generator.estimate_cost(inputs)
+
+        # Verify estimate is in reasonable range
+        assert estimated_cost > 0.0
+        assert estimated_cost < 1.0  # Should be well under $1 per generation


### PR DESCRIPTION
Adds a new generator for fal-ai/kling-video/ai-avatar/v2/standard that creates avatar videos from image and audio inputs. The model synthesizes realistic humans, animals, cartoons, or stylized characters with synchronized lip movements.

Features:
- Image and audio artifact inputs for avatar synthesis
- Optional prompt parameter for guiding generation
- Automatic artifact upload to Fal storage
- Progress streaming during video generation
- Cost estimation ($0.10 per generation)

Includes comprehensive unit tests and live API tests.