### PR TITLE
Create FAL GPT Image 1.5 generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -71,6 +71,9 @@ generators:
   - class: "boards.generators.implementations.fal.image.gemini_25_flash_image_edit.FalGemini25FlashImageEditGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.gpt_image_1_5.FalGptImage15Generator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.image.gpt_image_1_edit_image.FalGptImage1EditImageGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -12,6 +12,7 @@ from .flux_pro_kontext import FalFluxProKontextGenerator
 from .flux_pro_ultra import FalFluxProUltraGenerator
 from .gemini_25_flash_image import FalGemini25FlashImageGenerator
 from .gemini_25_flash_image_edit import FalGemini25FlashImageEditGenerator
+from .gpt_image_1_5 import FalGptImage15Generator
 from .gpt_image_1_edit_image import FalGptImage1EditImageGenerator
 from .gpt_image_1_mini import FalGptImage1MiniGenerator
 from .ideogram_character_edit import FalIdeogramCharacterEditGenerator
@@ -40,6 +41,7 @@ __all__ = [
     "FalFluxProUltraGenerator",
     "FalGemini25FlashImageEditGenerator",
     "FalGemini25FlashImageGenerator",
+    "FalGptImage15Generator",
     "FalGptImage1EditImageGenerator",
     "FalGptImage1MiniGenerator",
     "FalIdeogramCharacterGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/image/gpt_image_1_5.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/gpt_image_1_5.py
@@ -1,0 +1,177 @@
+"""
+fal.ai GPT Image 1.5 text-to-image generator.
+
+Generate high-fidelity images using GPT Image 1.5 with strong prompt adherence,
+preserving composition, lighting, and fine-grained detail.
+
+Based on Fal AI's fal-ai/gpt-image-1.5 model.
+See: https://fal.ai/models/fal-ai/gpt-image-1.5
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class GptImage15Input(BaseModel):
+    """Input schema for GPT Image 1.5.
+
+    Artifact fields are automatically detected via type introspection
+    and resolved from generation IDs to artifact objects.
+    """
+
+    prompt: str = Field(
+        description="The prompt for image generation",
+        min_length=2,
+    )
+    num_images: int = Field(
+        default=1,
+        ge=1,
+        le=4,
+        description="Number of images to generate",
+    )
+    image_size: Literal["1024x1024", "1536x1024", "1024x1536"] = Field(
+        default="1024x1024",
+        description="Aspect ratio for the generated image",
+    )
+    background: Literal["auto", "transparent", "opaque"] = Field(
+        default="auto",
+        description="Background for the generated image",
+    )
+    quality: Literal["low", "medium", "high"] = Field(
+        default="high",
+        description="Quality for the generated image",
+    )
+    output_format: Literal["jpeg", "png", "webp"] = Field(
+        default="png",
+        description="Output format for the images",
+    )
+
+
+class FalGptImage15Generator(BaseGenerator):
+    """GPT Image 1.5 text-to-image generator using fal.ai."""
+
+    name = "fal-gpt-image-1-5"
+    artifact_type = "image"
+    description = "Fal: GPT Image 1.5 - High-fidelity image generation with strong prompt adherence"
+
+    def get_input_schema(self) -> type[GptImage15Input]:
+        return GptImage15Input
+
+    async def generate(
+        self, inputs: GptImage15Input, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate images using fal.ai gpt-image-1.5 model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalGptImage15Generator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "prompt": inputs.prompt,
+            "num_images": inputs.num_images,
+            "image_size": inputs.image_size,
+            "background": inputs.background,
+            "quality": inputs.quality,
+            "output_format": inputs.output_format,
+        }
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/gpt-image-1.5",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image URLs from result
+        # fal.ai returns: {
+        #   "images": [{"url": "...", "content_type": "...", "width": ..., "height": ...}, ...]
+        # }
+        images = result.get("images", [])
+
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Parse target dimensions from image_size
+        size_parts = inputs.image_size.split("x")
+        target_width = int(size_parts[0])
+        target_height = int(size_parts[1])
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url = image_data.get("url")
+            # Extract dimensions if available, otherwise use target dimensions from input
+            width = image_data.get("width") or target_width
+            height = image_data.get("height") or target_height
+
+            if not image_url:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Store with appropriate output_index
+            artifact = await context.store_image_result(
+                storage_url=image_url,
+                format=inputs.output_format,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: GptImage15Input) -> float:
+        """Estimate cost for GPT Image 1.5 generation.
+
+        Using estimated cost per image (pricing not documented).
+        GPT Image 1.5 is a higher-quality model compared to mini version.
+        """
+        # Estimated cost per image
+        per_image_cost = 0.04
+        return per_image_cost * inputs.num_images

--- a/packages/backend/tests/generators/implementations/test_gpt_image_1_5.py
+++ b/packages/backend/tests/generators/implementations/test_gpt_image_1_5.py
@@ -1,0 +1,617 @@
+"""
+Tests for FalGptImage15Generator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.gpt_image_1_5 import (
+    FalGptImage15Generator,
+    GptImage15Input,
+)
+
+
+class TestGptImage15Input:
+    """Tests for GptImage15Input schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        prompt = (
+            "A serene landscape with mountains reflecting in a "
+            "crystal-clear lake at sunset, photorealistic style"
+        )
+        input_data = GptImage15Input(
+            prompt=prompt,
+            num_images=2,
+            image_size="1536x1024",
+            background="opaque",
+            quality="high",
+            output_format="png",
+        )
+
+        assert input_data.prompt == prompt
+        assert input_data.num_images == 2
+        assert input_data.image_size == "1536x1024"
+        assert input_data.background == "opaque"
+        assert input_data.quality == "high"
+        assert input_data.output_format == "png"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = GptImage15Input(
+            prompt="Test prompt for image generation",
+        )
+
+        assert input_data.num_images == 1
+        assert input_data.image_size == "1024x1024"
+        assert input_data.background == "auto"
+        assert input_data.quality == "high"
+        assert input_data.output_format == "png"
+
+    def test_invalid_output_format(self):
+        """Test validation fails for invalid output format."""
+        with pytest.raises(ValidationError):
+            GptImage15Input(
+                prompt="Test",
+                output_format="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_image_size(self):
+        """Test validation fails for invalid image size."""
+        with pytest.raises(ValidationError):
+            GptImage15Input(
+                prompt="Test",
+                image_size="512x512",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_background(self):
+        """Test validation fails for invalid background."""
+        with pytest.raises(ValidationError):
+            GptImage15Input(
+                prompt="Test",
+                background="blur",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_quality(self):
+        """Test validation fails for invalid quality."""
+        with pytest.raises(ValidationError):
+            GptImage15Input(
+                prompt="Test",
+                quality="ultra",  # type: ignore[arg-type]
+            )
+
+    def test_prompt_min_length(self):
+        """Test validation fails for prompt too short."""
+        with pytest.raises(ValidationError):
+            GptImage15Input(
+                prompt="a",  # Only 1 character, minimum is 2
+            )
+
+    def test_num_images_validation(self):
+        """Test validation for num_images constraints."""
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            GptImage15Input(
+                prompt="Test prompt",
+                num_images=0,
+            )
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            GptImage15Input(
+                prompt="Test prompt",
+                num_images=5,  # Maximum is 4
+            )
+
+    def test_output_format_options(self):
+        """Test all valid output format options."""
+        valid_formats = ["jpeg", "png", "webp"]
+
+        for fmt in valid_formats:
+            input_data = GptImage15Input(
+                prompt="Test",
+                output_format=fmt,  # type: ignore[arg-type]
+            )
+            assert input_data.output_format == fmt
+
+    def test_image_size_options(self):
+        """Test all valid image size options."""
+        valid_sizes = ["1024x1024", "1536x1024", "1024x1536"]
+
+        for size in valid_sizes:
+            input_data = GptImage15Input(
+                prompt="Test",
+                image_size=size,  # type: ignore[arg-type]
+            )
+            assert input_data.image_size == size
+
+    def test_background_options(self):
+        """Test all valid background options."""
+        valid_backgrounds = ["auto", "transparent", "opaque"]
+
+        for bg in valid_backgrounds:
+            input_data = GptImage15Input(
+                prompt="Test",
+                background=bg,  # type: ignore[arg-type]
+            )
+            assert input_data.background == bg
+
+    def test_quality_options(self):
+        """Test all valid quality options."""
+        valid_qualities = ["low", "medium", "high"]
+
+        for quality in valid_qualities:
+            input_data = GptImage15Input(
+                prompt="Test",
+                quality=quality,  # type: ignore[arg-type]
+            )
+            assert input_data.quality == quality
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalGptImage15Generator:
+    """Tests for FalGptImage15Generator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalGptImage15Generator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-gpt-image-1-5"
+        assert self.generator.artifact_type == "image"
+        assert "GPT Image 1.5" in self.generator.description
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == GptImage15Input
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = GptImage15Input(
+                prompt="Test prompt for generation",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation with single image output."""
+        input_data = GptImage15Input(
+            prompt="A beautiful sunset over the ocean",
+            num_images=1,
+            output_format="jpeg",
+        )
+
+        fake_output_url = "https://v3b.fal.media/files/b/elephant/generated_image.jpg"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 1024,
+                            "height": 1024,
+                        }
+                    ],
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=1024,
+                format="jpeg",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify API calls
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/gpt-image-1.5",
+                arguments={
+                    "prompt": "A beautiful sunset over the ocean",
+                    "num_images": 1,
+                    "image_size": "1024x1024",
+                    "background": "auto",
+                    "quality": "high",
+                    "output_format": "jpeg",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_multiple_images(self):
+        """Test successful generation with multiple image outputs."""
+        input_data = GptImage15Input(
+            prompt="A futuristic cityscape at night",
+            num_images=3,
+            output_format="png",
+            image_size="1536x1024",
+            quality="medium",
+            background="opaque",
+        )
+
+        fake_output_urls = [
+            "https://v3b.fal.media/files/b/elephant/output1.png",
+            "https://v3b.fal.media/files/b/elephant/output2.png",
+            "https://v3b.fal.media/files/b/elephant/output3.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {"url": fake_output_urls[0], "width": 1536, "height": 1024},
+                        {"url": fake_output_urls[1], "width": 1536, "height": 1024},
+                        {"url": fake_output_urls[2], "width": 1536, "height": 1024},
+                    ],
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage results
+            mock_artifacts = [
+                ImageArtifact(
+                    generation_id="test_gen",
+                    storage_url=url,
+                    width=1536,
+                    height=1024,
+                    format="png",
+                )
+                for url in fake_output_urls
+            ]
+
+            artifact_idx = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    nonlocal artifact_idx
+                    result = mock_artifacts[artifact_idx]
+                    artifact_idx += 1
+                    return result
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 3
+
+            # Verify API call included all parameters
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["num_images"] == 3
+            assert call_args[1]["arguments"]["image_size"] == "1536x1024"
+            assert call_args[1]["arguments"]["quality"] == "medium"
+            assert call_args[1]["arguments"]["background"] == "opaque"
+
+    @pytest.mark.asyncio
+    async def test_generate_no_images_returned(self):
+        """Test generation fails when API returns no images."""
+        input_data = GptImage15Input(
+            prompt="test prompt",
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"images": []})
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No images returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_with_transparent_background(self):
+        """Test generation with transparent background."""
+        input_data = GptImage15Input(
+            prompt="A logo with transparent background",
+            background="transparent",
+            output_format="png",
+        )
+
+        fake_output_url = "https://v3b.fal.media/files/b/elephant/logo.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-transparent"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 1024,
+                            "height": 1024,
+                        }
+                    ],
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=1024,
+                format="png",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify API call included background parameter
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["background"] == "transparent"
+
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_data = GptImage15Input(
+            prompt="Test prompt",
+            num_images=1,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.04 * 1)
+        assert cost == 0.04
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_multiple_images(self):
+        """Test cost estimation for multiple images."""
+        input_data = GptImage15Input(
+            prompt="Test prompt",
+            num_images=4,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Per-image cost (0.04 * 4)
+        assert cost == 0.16
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = GptImage15Input.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "num_images" in schema["properties"]
+        assert "image_size" in schema["properties"]
+        assert "background" in schema["properties"]
+        assert "quality" in schema["properties"]
+        assert "output_format" in schema["properties"]
+
+        # Check that prompt has string constraints
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop["type"] == "string"
+        assert prompt_prop["minLength"] == 2
+
+        # Check that num_images has constraints
+        num_images_prop = schema["properties"]["num_images"]
+        assert num_images_prop["minimum"] == 1
+        assert num_images_prop["maximum"] == 4
+        assert num_images_prop["default"] == 1
+
+        # Check that image_size is an enum
+        image_size_prop = schema["properties"]["image_size"]
+        assert "enum" in image_size_prop
+        assert set(image_size_prop["enum"]) == {"1024x1024", "1536x1024", "1024x1536"}
+
+        # Check that output_format is an enum
+        output_format_prop = schema["properties"]["output_format"]
+        assert "enum" in output_format_prop
+        assert set(output_format_prop["enum"]) == {"jpeg", "png", "webp"}
+
+        # Check that background is an enum
+        background_prop = schema["properties"]["background"]
+        assert "enum" in background_prop
+        assert set(background_prop["enum"]) == {"auto", "transparent", "opaque"}
+
+        # Check that quality is an enum
+        quality_prop = schema["properties"]["quality"]
+        assert "enum" in quality_prop
+        assert set(quality_prop["enum"]) == {"low", "medium", "high"}

--- a/packages/backend/tests/generators/implementations/test_gpt_image_1_5_live.py
+++ b/packages/backend/tests/generators/implementations/test_gpt_image_1_5_live.py
@@ -1,0 +1,175 @@
+"""
+Live API tests for FalGptImage15Generator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_gpt_image_1_5_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_gpt_image_1_5_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.implementations.fal.image.gpt_image_1_5 import (
+    FalGptImage15Generator,
+    GptImage15Input,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestGptImage15GeneratorLive:
+    """Live API tests for FalGptImage15Generator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalGptImage15Generator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, dummy_context, cost_logger):
+        """
+        Test basic image generation with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses minimal/cheap settings to reduce cost.
+        """
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(GptImage15Input(prompt="test"))
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Create minimal input to reduce cost
+        inputs = GptImage15Input(
+            prompt="A simple red circle on white background",
+            num_images=1,  # Single image
+            quality="low",  # Use low quality to reduce cost
+            output_format="jpeg",  # Use JPEG for smaller files
+        )
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        from boards.generators.artifacts import ImageArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.width is not None and artifact.width > 0
+        assert artifact.height is not None and artifact.height > 0
+        assert artifact.format in ["jpeg", "png", "webp"]
+
+    @pytest.mark.asyncio
+    async def test_generate_with_different_sizes(
+        self, skip_if_no_fal_key, dummy_context, cost_logger
+    ):
+        """
+        Test generation with landscape aspect ratio.
+
+        Verifies that image_size parameter is correctly processed.
+        """
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(
+            GptImage15Input(prompt="test", image_size="1536x1024")
+        )
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Create input with landscape size
+        inputs = GptImage15Input(
+            prompt="A wide landscape view of mountains",
+            image_size="1536x1024",  # Wide/landscape
+            quality="low",  # Use low quality to reduce cost
+            num_images=1,
+        )
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        from boards.generators.artifacts import ImageArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url.startswith("https://")
+        # Verify dimensions match requested size (or close to it)
+        assert artifact.width is not None and artifact.width > 0
+        assert artifact.height is not None and artifact.height > 0
+
+    @pytest.mark.asyncio
+    async def test_generate_with_transparent_background(
+        self, skip_if_no_fal_key, dummy_context, cost_logger
+    ):
+        """
+        Test generation with transparent background.
+
+        Verifies that background parameter is correctly processed.
+        """
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(
+            GptImage15Input(prompt="test", background="transparent")
+        )
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Create input with transparent background (use PNG for transparency support)
+        inputs = GptImage15Input(
+            prompt="A simple icon of a star",
+            background="transparent",
+            output_format="png",  # PNG supports transparency
+            quality="low",  # Use low quality to reduce cost
+            num_images=1,
+        )
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        from boards.generators.artifacts import ImageArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.format == "png"
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_batch_size(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation scales with batch size.
+
+        This doesn't make an API call, just verifies the cost logic.
+        """
+        # Single image
+        inputs_1 = GptImage15Input(prompt="test", num_images=1)
+        cost_1 = await self.generator.estimate_cost(inputs_1)
+
+        # Four images (maximum)
+        inputs_4 = GptImage15Input(prompt="test", num_images=4)
+        cost_4 = await self.generator.estimate_cost(inputs_4)
+
+        # Cost should scale linearly with number of images
+        assert cost_4 == cost_1 * 4
+
+        # Sanity check on absolute costs
+        assert cost_1 > 0.0
+        assert cost_1 < 0.20  # Should be well under $0.20 per image


### PR DESCRIPTION
Adds a new generator for fal-ai/gpt-image-1.5, a high-fidelity image generation model with strong prompt adherence.

Features:
- Supports image sizes: 1024x1024, 1536x1024, 1024x1536
- Quality levels: low, medium, high
- Background options: auto, transparent, opaque
- Output formats: jpeg, png, webp
- Batch generation up to 4 images