### PR TITLE
Create FAL GPT Image edit generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -80,6 +80,9 @@ generators:
   - class: "boards.generators.implementations.fal.image.gpt_image_1_mini.FalGptImage1MiniGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.gpt_image_15_edit.FalGptImage15EditGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.image.fal_ideogram_character.FalIdeogramCharacterGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -15,6 +15,7 @@ from .gemini_25_flash_image_edit import FalGemini25FlashImageEditGenerator
 from .gpt_image_1_5 import FalGptImage15Generator
 from .gpt_image_1_edit_image import FalGptImage1EditImageGenerator
 from .gpt_image_1_mini import FalGptImage1MiniGenerator
+from .gpt_image_15_edit import FalGptImage15EditGenerator
 from .ideogram_character_edit import FalIdeogramCharacterEditGenerator
 from .ideogram_v2 import FalIdeogramV2Generator
 from .imagen4_preview import FalImagen4PreviewGenerator
@@ -41,6 +42,7 @@ __all__ = [
     "FalFluxProUltraGenerator",
     "FalGemini25FlashImageEditGenerator",
     "FalGemini25FlashImageGenerator",
+    "FalGptImage15EditGenerator",
     "FalGptImage15Generator",
     "FalGptImage1EditImageGenerator",
     "FalGptImage1MiniGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/image/gpt_image_15_edit.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/gpt_image_15_edit.py
@@ -1,0 +1,216 @@
+"""
+fal.ai GPT-Image-1.5 image editing generator.
+
+Edit images using OpenAI's GPT-Image-1.5 model via fal.ai.
+Based on Fal AI's fal-ai/gpt-image-1.5/edit model.
+See: https://fal.ai/models/fal-ai/gpt-image-1.5/edit
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class GptImage15EditInput(BaseModel):
+    """Input schema for GPT-Image-1.5 image editing.
+
+    Artifact fields are automatically detected via type introspection
+    and resolved from generation IDs to artifact objects.
+    """
+
+    prompt: str = Field(
+        description="Edit instruction for transforming the input images",
+        min_length=2,
+        max_length=32000,
+    )
+    image_urls: list[ImageArtifact] = Field(
+        description="URLs of images to use as reference for editing",
+        min_length=1,
+    )
+    mask_image_url: ImageArtifact | None = Field(
+        default=None,
+        description="Optional mask image to specify the area to edit",
+    )
+    num_images: int = Field(
+        default=1,
+        ge=1,
+        le=4,
+        description="Number of edited images to generate (1-4)",
+    )
+    image_size: Literal["auto", "1024x1024", "1536x1024", "1024x1536"] = Field(
+        default="auto",
+        description="Size of the output images",
+    )
+    quality: Literal["low", "medium", "high"] = Field(
+        default="high",
+        description="Quality level of the output images",
+    )
+    input_fidelity: Literal["low", "high"] = Field(
+        default="high",
+        description="How closely to follow the input image",
+    )
+    output_format: Literal["jpeg", "png", "webp"] = Field(
+        default="png",
+        description="Output image format",
+    )
+    background: Literal["auto", "transparent", "opaque"] = Field(
+        default="auto",
+        description="Background handling for the output images",
+    )
+
+
+class FalGptImage15EditGenerator(BaseGenerator):
+    """Generator for OpenAI's GPT-Image-1.5 image editing via fal.ai."""
+
+    name = "fal-gpt-image-15-edit"
+    description = "Fal: GPT-Image-1.5 Edit - OpenAI's latest image editing model"
+    artifact_type = "image"
+
+    def get_input_schema(self) -> type[GptImage15EditInput]:
+        """Return the input schema for this generator."""
+        return GptImage15EditInput
+
+    async def generate(
+        self, inputs: GptImage15EditInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate edited images using fal.ai GPT-Image-1.5."""
+        # Check for API key
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalGptImage15EditGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifacts to Fal's public storage
+        # Fal API requires publicly accessible URLs
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal(inputs.image_urls, context)
+
+        # Upload mask image if provided
+        mask_image_url = None
+        if inputs.mask_image_url is not None:
+            mask_urls = await upload_artifacts_to_fal([inputs.mask_image_url], context)
+            mask_image_url = mask_urls[0] if mask_urls else None
+
+        # Prepare arguments for fal.ai API
+        arguments: dict = {
+            "prompt": inputs.prompt,
+            "image_urls": image_urls,
+            "num_images": inputs.num_images,
+            "image_size": inputs.image_size,
+            "quality": inputs.quality,
+            "input_fidelity": inputs.input_fidelity,
+            "output_format": inputs.output_format,
+            "background": inputs.background,
+        }
+
+        # Add mask image if provided
+        if mask_image_url is not None:
+            arguments["mask_image_url"] = mask_image_url
+
+        # Submit async job
+        handler = await fal_client.submit_async(
+            "fal-ai/gpt-image-1.5/edit",
+            arguments=arguments,
+        )
+
+        # Store external job ID
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+            # Sample every 3rd event to avoid spam
+            if event_count % 3 == 0:
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract images from result
+        # Response structure: {"images": [{"url": "...", "width": 1024, "height": 1024, ...}, ...]}
+        images = result.get("images", [])
+
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url = image_data.get("url")
+            width = image_data.get("width", 1024)
+            height = image_data.get("height", 1024)
+
+            if not image_url:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Determine format from content_type if available, otherwise use input format
+            format = inputs.output_format
+            if "content_type" in image_data:
+                content_type = image_data["content_type"]
+                if "jpeg" in content_type:
+                    format = "jpeg"
+                elif "webp" in content_type:
+                    format = "webp"
+                elif "png" in content_type:
+                    format = "png"
+
+            artifact = await context.store_image_result(
+                storage_url=image_url,
+                format=format,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: GptImage15EditInput) -> float:
+        """Estimate cost for GPT-Image-1.5 edit generation.
+
+        Pricing varies by quality and image size:
+        - Low Quality: $0.009-$0.013 per image
+        - Medium Quality: $0.034-$0.051 per image
+        - High Quality: $0.133-$0.200 per image
+        """
+        # Base costs by quality (using 1024x1024 as reference)
+        quality_costs = {
+            "low": 0.011,  # Average of $0.009-$0.013
+            "medium": 0.045,  # Average of $0.034-$0.051
+            "high": 0.177,  # Average of $0.133-$0.200
+        }
+
+        per_image_cost = quality_costs.get(inputs.quality, 0.177)
+        return per_image_cost * inputs.num_images

--- a/packages/backend/tests/generators/implementations/test_gpt_image_15_edit.py
+++ b/packages/backend/tests/generators/implementations/test_gpt_image_15_edit.py
@@ -1,0 +1,878 @@
+"""
+Tests for FalGptImage15EditGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.gpt_image_15_edit import (
+    FalGptImage15EditGenerator,
+    GptImage15EditInput,
+)
+
+
+class TestGptImage15EditInput:
+    """Tests for GptImage15EditInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image_artifact_1 = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image1.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+        image_artifact_2 = ImageArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/image2.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="Make the image look vintage",
+            image_urls=[image_artifact_1, image_artifact_2],
+            num_images=2,
+            output_format="jpeg",
+            quality="medium",
+        )
+
+        assert input_data.prompt == "Make the image look vintage"
+        assert len(input_data.image_urls) == 2
+        assert input_data.num_images == 2
+        assert input_data.output_format == "jpeg"
+        assert input_data.quality == "medium"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="Test prompt",
+            image_urls=[image_artifact],
+        )
+
+        assert input_data.num_images == 1
+        assert input_data.output_format == "png"
+        assert input_data.quality == "high"
+        assert input_data.input_fidelity == "high"
+        assert input_data.image_size == "auto"
+        assert input_data.background == "auto"
+        assert input_data.mask_image_url is None
+
+    def test_invalid_output_format(self):
+        """Test validation fails for invalid output format."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            GptImage15EditInput(
+                prompt="Test",
+                image_urls=[image_artifact],
+                output_format="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_quality(self):
+        """Test validation fails for invalid quality."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            GptImage15EditInput(
+                prompt="Test",
+                image_urls=[image_artifact],
+                quality="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_image_size(self):
+        """Test validation fails for invalid image size."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            GptImage15EditInput(
+                prompt="Test",
+                image_urls=[image_artifact],
+                image_size="512x512",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_background(self):
+        """Test validation fails for invalid background."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            GptImage15EditInput(
+                prompt="Test",
+                image_urls=[image_artifact],
+                background="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_empty_image_urls(self):
+        """Test validation fails for empty image_urls."""
+        with pytest.raises(ValidationError):
+            GptImage15EditInput(
+                prompt="Test",
+                image_urls=[],  # Empty list should fail min_length=1
+            )
+
+    def test_prompt_too_short(self):
+        """Test validation fails for prompt less than 2 characters."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            GptImage15EditInput(
+                prompt="X",  # Too short - min_length is 2
+                image_urls=[image_artifact],
+            )
+
+    def test_num_images_validation(self):
+        """Test validation for num_images constraints."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            GptImage15EditInput(
+                prompt="Test",
+                image_urls=[image_artifact],
+                num_images=0,
+            )
+
+        # Test above maximum (4)
+        with pytest.raises(ValidationError):
+            GptImage15EditInput(
+                prompt="Test",
+                image_urls=[image_artifact],
+                num_images=5,
+            )
+
+    def test_with_mask_image(self):
+        """Test input with mask image."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+        mask_artifact = ImageArtifact(
+            generation_id="gen_mask",
+            storage_url="https://example.com/mask.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="Change the background",
+            image_urls=[image_artifact],
+            mask_image_url=mask_artifact,
+        )
+
+        assert input_data.mask_image_url is not None
+        assert input_data.mask_image_url.generation_id == "gen_mask"
+
+    def test_quality_options(self):
+        """Test all valid quality options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_qualities = ["low", "medium", "high"]
+
+        for quality in valid_qualities:
+            input_data = GptImage15EditInput(
+                prompt="Test",
+                image_urls=[image_artifact],
+                quality=quality,  # type: ignore[arg-type]
+            )
+            assert input_data.quality == quality
+
+    def test_image_size_options(self):
+        """Test all valid image size options."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_sizes = ["auto", "1024x1024", "1536x1024", "1024x1536"]
+
+        for size in valid_sizes:
+            input_data = GptImage15EditInput(
+                prompt="Test",
+                image_urls=[image_artifact],
+                image_size=size,  # type: ignore[arg-type]
+            )
+            assert input_data.image_size == size
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalGptImage15EditGenerator:
+    """Tests for FalGptImage15EditGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalGptImage15EditGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-gpt-image-15-edit"
+        assert self.generator.artifact_type == "image"
+        assert "GPT-Image-1.5" in self.generator.description
+        assert "Edit" in self.generator.description
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == GptImage15EditInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/image.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+
+            input_data = GptImage15EditInput(
+                prompt="Test prompt",
+                image_urls=[image_artifact],
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation with single image output."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="Make the sky more dramatic",
+            image_urls=[input_image],
+            num_images=1,
+            output_format="jpeg",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 1024,
+                            "height": 768,
+                        }
+                    ],
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=768,
+                format="jpeg",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    # Return a fake local file path
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            mock_fal_client.upload_file_async.assert_called_once_with("/tmp/fake_image.png")
+
+            # Verify API calls with uploaded URL
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/gpt-image-1.5/edit",
+                arguments={
+                    "prompt": "Make the sky more dramatic",
+                    "image_urls": [fake_uploaded_url],
+                    "num_images": 1,
+                    "image_size": "auto",
+                    "quality": "high",
+                    "input_fidelity": "high",
+                    "output_format": "jpeg",
+                    "background": "auto",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_multiple_images(self):
+        """Test successful generation with multiple image outputs."""
+        input_image_1 = ImageArtifact(
+            generation_id="gen_input1",
+            storage_url="https://example.com/input1.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+        input_image_2 = ImageArtifact(
+            generation_id="gen_input2",
+            storage_url="https://example.com/input2.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="Enhance the colors",
+            image_urls=[input_image_1, input_image_2],
+            num_images=2,
+            output_format="png",
+            quality="medium",
+        )
+
+        fake_output_urls = [
+            "https://storage.googleapis.com/falserverless/output1.png",
+            "https://storage.googleapis.com/falserverless/output2.png",
+        ]
+        fake_uploaded_urls = [
+            "https://fal.media/files/uploaded-input1.png",
+            "https://fal.media/files/uploaded-input2.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {"url": fake_output_urls[0], "width": 1920, "height": 1080},
+                        {"url": fake_output_urls[1], "width": 1920, "height": 1080},
+                    ],
+                }
+            )
+
+            # Mock file uploads to return different URLs for each file
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_urls[upload_call_count]
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage results
+            mock_artifacts = [
+                ImageArtifact(
+                    generation_id="test_gen",
+                    storage_url=url,
+                    width=1920,
+                    height=1080,
+                    format="png",
+                )
+                for url in fake_output_urls
+            ]
+
+            artifact_idx = 0
+            resolve_call_count = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    nonlocal resolve_call_count
+                    # Return different fake paths for each artifact
+                    path = f"/tmp/fake_image_{resolve_call_count}.png"
+                    resolve_call_count += 1
+                    return path
+
+                async def store_image_result(self, **kwargs):
+                    nonlocal artifact_idx
+                    result = mock_artifacts[artifact_idx]
+                    artifact_idx += 1
+                    return result
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 2
+
+            # Verify file uploads were called for both images
+            assert mock_fal_client.upload_file_async.call_count == 2
+
+            # Verify API call included quality and uploaded URLs
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["quality"] == "medium"
+            assert call_args[1]["arguments"]["image_urls"] == fake_uploaded_urls
+
+    @pytest.mark.asyncio
+    async def test_generate_with_mask_image(self):
+        """Test generation with mask image."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=1024,
+        )
+        mask_image = ImageArtifact(
+            generation_id="gen_mask",
+            storage_url="https://example.com/mask.png",
+            format="png",
+            width=1024,
+            height=1024,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="Change the background to a beach",
+            image_urls=[input_image],
+            mask_image_url=mask_image,
+            num_images=1,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_image_url = "https://fal.media/files/uploaded-input.png"
+        fake_uploaded_mask_url = "https://fal.media/files/uploaded-mask.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-mask"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [{"url": fake_output_url, "width": 1024, "height": 1024}],
+                }
+            )
+
+            # Track which file is being uploaded
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                upload_call_count += 1
+                if "mask" in file_path:
+                    return fake_uploaded_mask_url
+                return fake_uploaded_image_url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1024,
+                height=1024,
+                format="png",
+            )
+
+            resolve_count = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    nonlocal resolve_count
+                    resolve_count += 1
+                    if artifact.generation_id == "gen_mask":
+                        return "/tmp/fake_mask.png"
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify API call included mask_image_url
+            call_args = mock_fal_client.submit_async.call_args
+            assert "mask_image_url" in call_args[1]["arguments"]
+            assert call_args[1]["arguments"]["mask_image_url"] == fake_uploaded_mask_url
+
+    @pytest.mark.asyncio
+    async def test_generate_no_images_returned(self):
+        """Test generation fails when API returns no images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="test prompt",
+            image_urls=[input_image],
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"images": []})
+
+            fake_uploaded_url = "https://fal.media/files/uploaded.png"
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No images returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_low_quality(self):
+        """Test cost estimation for low quality."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="Test prompt",
+            image_urls=[input_image],
+            num_images=1,
+            quality="low",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Low quality cost (0.011 * 1)
+        assert cost == 0.011
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_medium_quality(self):
+        """Test cost estimation for medium quality."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="Test prompt",
+            image_urls=[input_image],
+            num_images=1,
+            quality="medium",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # Medium quality cost (0.045 * 1)
+        assert cost == 0.045
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_high_quality(self):
+        """Test cost estimation for high quality (default)."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="Test prompt",
+            image_urls=[input_image],
+            num_images=1,
+            quality="high",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # High quality cost (0.177 * 1)
+        assert cost == 0.177
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_multiple_images(self):
+        """Test cost estimation for multiple images."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = GptImage15EditInput(
+            prompt="Test prompt",
+            image_urls=[input_image],
+            num_images=4,
+            quality="high",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # High quality cost (0.177 * 4)
+        assert cost == 0.708
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = GptImage15EditInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "image_urls" in schema["properties"]
+        assert "mask_image_url" in schema["properties"]
+        assert "num_images" in schema["properties"]
+        assert "output_format" in schema["properties"]
+        assert "quality" in schema["properties"]
+        assert "image_size" in schema["properties"]
+        assert "background" in schema["properties"]
+        assert "input_fidelity" in schema["properties"]
+
+        # Check that image_urls is an array
+        image_urls_prop = schema["properties"]["image_urls"]
+        assert image_urls_prop["type"] == "array"
+        assert "minItems" in image_urls_prop
+
+        # Check that num_images has constraints
+        num_images_prop = schema["properties"]["num_images"]
+        assert num_images_prop["minimum"] == 1
+        assert num_images_prop["maximum"] == 4
+        assert num_images_prop["default"] == 1
+
+        # Check that prompt has min_length constraint
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop["minLength"] == 2

--- a/packages/backend/tests/generators/implementations/test_gpt_image_15_edit_live.py
+++ b/packages/backend/tests/generators/implementations/test_gpt_image_15_edit_live.py
@@ -1,0 +1,368 @@
+"""
+Live API tests for FalGptImage15EditGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_gpt_image_15_edit_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_gpt_image_15_edit_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.implementations.fal.image.gpt_image_15_edit import (
+    FalGptImage15EditGenerator,
+    GptImage15EditInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestGptImage15EditGeneratorLive:
+    """Live API tests for FalGptImage15EditGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalGptImage15EditGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test basic image editing with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses a small publicly accessible test image to minimize cost.
+        """
+        # Use a small publicly accessible test image (256x256 solid color)
+        # This is a simple red square that's small and cheap to process
+        test_image_url = "https://placehold.co/256x256/ff0000/ff0000.png"
+
+        # Create test image artifact
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create minimal input to reduce cost
+        inputs = GptImage15EditInput(
+            prompt="Make this image pixel-art style",
+            image_urls=[test_artifact],
+            num_images=1,  # Single image to minimize cost
+            image_size="auto",  # Auto size to avoid upscaling
+            quality="low",  # Low quality to minimize cost
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+        assert artifact.format in ["png", "jpeg", "webp"]
+
+    @pytest.mark.asyncio
+    async def test_generate_with_image_size(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with specific image size.
+
+        Verifies that image_size parameter is correctly processed.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/256x256/00ff00/00ff00.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input2",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input with specific image size
+        inputs = GptImage15EditInput(
+            prompt="Make it blue",
+            image_urls=[test_artifact],
+            image_size="1024x1024",
+            num_images=1,
+            quality="low",  # Keep cost down
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url.startswith("https://")
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+
+        # When image_size is 1024x1024, expect square output
+        if artifact.width is not None and artifact.height is not None:
+            assert artifact.width == artifact.height
+
+    @pytest.mark.asyncio
+    async def test_generate_with_high_fidelity(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with high input fidelity.
+
+        Verifies that input_fidelity parameter is correctly processed.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/256x256/0000ff/0000ff.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input3",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input with high fidelity to closely follow input image
+        inputs = GptImage15EditInput(
+            prompt="Add a white circle in the center",
+            image_urls=[test_artifact],
+            input_fidelity="high",  # High fidelity to closely follow input
+            num_images=1,
+            quality="low",  # Keep cost down
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result (fidelity doesn't affect output structure, just quality)
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+        assert result.outputs[0].storage_url.startswith("https://")
+
+    @pytest.mark.asyncio
+    async def test_generate_multiple_images(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation of multiple images (2 images to minimize cost).
+
+        Verifies that num_images parameter works correctly.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/256x256/ff00ff/ff00ff.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input4",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input requesting 2 images
+        inputs = GptImage15EditInput(
+            prompt="Make it artistic",
+            image_urls=[test_artifact],
+            num_images=2,  # Generate 2 variations (keep low to minimize cost)
+            quality="low",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result has 2 outputs
+        assert result.outputs is not None
+        assert len(result.outputs) == 2
+
+        # Verify both artifacts are valid
+        for artifact in result.outputs:
+            assert isinstance(artifact, ImageArtifact)
+            assert artifact.storage_url.startswith("https://")
+            if artifact.width is not None:
+                assert artifact.width > 0
+            if artifact.height is not None:
+                assert artifact.height > 0
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Create dummy input (artifact won't be used for estimation)
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url="https://example.com/test.png",
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Single image, low quality
+        inputs_low = GptImage15EditInput(
+            prompt="test", image_urls=[test_artifact], num_images=1, quality="low"
+        )
+        cost_low = await self.generator.estimate_cost(inputs_low)
+
+        # Single image, high quality
+        inputs_high = GptImage15EditInput(
+            prompt="test", image_urls=[test_artifact], num_images=1, quality="high"
+        )
+        cost_high = await self.generator.estimate_cost(inputs_high)
+
+        # Multiple images, high quality
+        inputs_4 = GptImage15EditInput(
+            prompt="test", image_urls=[test_artifact], num_images=4, quality="high"
+        )
+        cost_4 = await self.generator.estimate_cost(inputs_4)
+
+        # High quality should cost more than low quality
+        assert cost_high > cost_low
+
+        # Cost should scale linearly with number of images
+        assert cost_4 == cost_high * 4
+
+        # Sanity check on absolute costs
+        assert cost_low > 0.0
+        assert cost_low < 0.05  # Low quality should be under $0.05
+        assert cost_high > 0.1  # High quality should be over $0.10
+        assert cost_high < 0.30  # But under $0.30
+
+    @pytest.mark.asyncio
+    async def test_generate_with_multiple_input_images(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with multiple input images.
+
+        Verifies that the generator can handle multiple reference images.
+        """
+        # Create multiple small test images
+        test_image_1 = ImageArtifact(
+            generation_id="test_input5a",
+            storage_url="https://placehold.co/256x256/ff0000/ff0000.png",
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        test_image_2 = ImageArtifact(
+            generation_id="test_input5b",
+            storage_url="https://placehold.co/256x256/00ff00/00ff00.png",
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input with multiple reference images
+        inputs = GptImage15EditInput(
+            prompt="Combine these into a gradient",
+            image_urls=[test_image_1, test_image_2],
+            num_images=1,
+            quality="low",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+        assert result.outputs[0].storage_url.startswith("https://")
+
+    @pytest.mark.asyncio
+    async def test_generate_with_output_format(
+        self, skip_if_no_fal_key, image_resolving_context, cost_logger
+    ):
+        """
+        Test generation with different output formats.
+
+        Verifies that output_format parameter is correctly processed.
+        """
+        # Use small test image
+        test_image_url = "https://placehold.co/256x256/ffff00/ffff00.png"
+
+        test_artifact = ImageArtifact(
+            generation_id="test_input6",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create input with webp output format
+        inputs = GptImage15EditInput(
+            prompt="Make it grayscale",
+            image_urls=[test_artifact],
+            output_format="webp",
+            num_images=1,
+            quality="low",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+        artifact = result.outputs[0]
+        assert artifact.storage_url.startswith("https://")
+        # Format should be webp (or determined by content_type)
+        assert artifact.format in ["webp", "png", "jpeg"]


### PR DESCRIPTION
Add support for OpenAI's GPT-Image-1.5 image editing model via fal.ai:
- Generator implementation with mask image support
- Quality-based pricing (low/medium/high)
- Comprehensive unit and live API tests