### PR TITLE
Fix download

### DIFF
--- a/Boards default.session.sql
+++ b/Boards default.session.sql
@@ -1,2 +1,3 @@
-select storage_url
-from generations;
+select *
+from generations
+where board_id = 'df0e6376-4c52-461d-8b64-13471359a751';

--- a/apps/baseboards/src/components/boards/GenerationGrid.tsx
+++ b/apps/baseboards/src/components/boards/GenerationGrid.tsx
@@ -30,9 +30,27 @@ export function GenerationGrid({
     );
   }
 
-  const handleDownload = (generation: Generation) => {
-    if (generation.storageUrl) {
-      window.open(generation.storageUrl, "_blank");
+  const handleDownload = async (generation: Generation) => {
+    if (!generation.storageUrl) return;
+
+    try {
+      // Add download query parameter to force download instead of inline preview
+      // Also add custom filename based on generation ID
+      const url = new URL(generation.storageUrl);
+      url.searchParams.set('download', 'true');
+      url.searchParams.set('filename', `gen-${generation.id}`);
+
+      // Create temporary anchor and trigger download
+      const link = document.createElement('a');
+      link.href = url.toString();
+      link.target = '_blank';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch (error) {
+      console.error('Failed to download file:', error);
+      // Fallback to opening in new tab if download fails
+      window.open(generation.storageUrl, '_blank');
     }
   };
 


### PR DESCRIPTION
Addresses #200 

This pull request improves the file download experience for board generations by allowing users to force a file download with a custom filename, and by enhancing backend support for serving files with correct extensions and content disposition headers. The main changes include frontend logic for triggering downloads with custom filenames, and backend logic for determining file extensions and setting appropriate headers based on content type and user request.

**Frontend download improvements:**

- Updated the `handleDownload` function in `GenerationGrid.tsx` to add `download` and `filename` query parameters to the file URL, and to use a temporary anchor element to trigger a download with a custom filename. Falls back to opening in a new tab if the download fails.

**Backend file serving enhancements:**

- Added a `_get_extension_from_content_type` helper in `storage.py` to map common MIME types to file extensions, ensuring downloaded files have the correct extension.
- Modified the `serve_file` endpoint to accept `download` and `filename` query parameters, determine the correct filename and extension using storage metadata, and set appropriate `Content-Disposition` headers to either force download or suggest a filename for inline preview. [[1]](diffhunk://#diff-868dce9f3a04d17c9387b8dc9cc92f7921f81104d1f152b3361a712ba3475e0aR24-R74) [[2]](diffhunk://#diff-868dce9f3a04d17c9387b8dc9cc92f7921f81104d1f152b3361a712ba3475e0aL67-R149)

**Testing and SQL update:**

- Updated a SQL query in `Boards default.session.sql` to select all columns from the `generations` table for a specific `board_id`, likely for testing or debugging the new download logic.