### PR TITLE
Implement Delete Generation

### DIFF
--- a/apps/baseboards/package.json
+++ b/apps/baseboards/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-navigation-menu": "^1.2.14",
     "@radix-ui/react-slot": "^1.2.3",

--- a/apps/baseboards/src/components/boards/ArtifactPreview.tsx
+++ b/apps/baseboards/src/components/boards/ArtifactPreview.tsx
@@ -13,6 +13,7 @@ import {
   Pause,
   RotateCcw,
   GitBranch,
+  Trash2,
 } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -35,6 +36,7 @@ interface ArtifactPreviewProps {
   canAddToSlot?: boolean;
   onDownload?: () => void;
   onPreview?: () => void;
+  onDelete?: () => void;
   artifactId?: string;
   prompt?: string | null;
 }
@@ -50,6 +52,7 @@ export function ArtifactPreview({
   canAddToSlot = false,
   onDownload,
   onPreview,
+  onDelete,
   artifactId,
   prompt,
 }: ArtifactPreviewProps) {
@@ -403,6 +406,21 @@ export function ArtifactPreview({
                         <Download className="w-4 h-4 mr-2" />
                         Download
                       </DropdownMenuItem>
+                    )}
+                    {onDelete && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDelete();
+                          }}
+                          className="cursor-pointer text-destructive focus:text-destructive"
+                        >
+                          <Trash2 className="w-4 h-4 mr-2" />
+                          Delete
+                        </DropdownMenuItem>
+                      </>
                     )}
                   </DropdownMenuContent>
                 </DropdownMenu>

--- a/apps/baseboards/src/components/ui/alert-dialog.tsx
+++ b/apps/baseboards/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/apps/docs/docs/backend/graphql-api/mutations.md
+++ b/apps/docs/docs/backend/graphql-api/mutations.md
@@ -416,7 +416,7 @@ Only generations with status `PENDING` or `PROCESSING` can be cancelled. Complet
 
 ### deleteGeneration
 
-Delete a generation and its associated files.
+Delete a generation and its associated storage artifacts.
 
 ```graphql
 mutation {
@@ -434,6 +434,39 @@ mutation {
 
 `true` if deletion was successful.
 
+#### Authorization
+
+Generation deletion requires authentication and follows these rules:
+
+- **Board owner** can delete any generation on their board
+- **Board editors** can only delete their own generations (ones they created)
+- **Board viewers** cannot delete any generations
+- **Non-members** cannot delete generations
+
+:::tip Authorization Examples
+```graphql
+# Owner deletes any generation on their board
+mutation {
+  deleteGeneration(id: "gen-uuid")  # ✅ Allowed
+}
+
+# Editor deletes their own generation
+mutation {
+  deleteGeneration(id: "gen-created-by-editor")  # ✅ Allowed
+}
+
+# Editor tries to delete owner's generation
+mutation {
+  deleteGeneration(id: "gen-created-by-owner")  # ❌ Permission denied
+}
+
+# Viewer tries to delete a generation
+mutation {
+  deleteGeneration(id: "gen-uuid")  # ❌ Permission denied
+}
+```
+:::
+
 #### Example
 
 ```graphql
@@ -441,6 +474,10 @@ mutation DeleteGeneration($genId: UUID!) {
   deleteGeneration(id: $genId)
 }
 ```
+
+:::warning
+This operation is destructive and cannot be undone. The generation record and associated storage artifacts will be permanently deleted.
+:::
 
 ---
 

--- a/packages/backend/tests/graphql/test_delete_generation_auth.py
+++ b/packages/backend/tests/graphql/test_delete_generation_auth.py
@@ -1,0 +1,357 @@
+"""
+Integration tests for delete generation authorization.
+
+Tests that:
+- Board owner can delete any generation
+- Board editors can only delete their own generations
+- Non-owners/non-editors cannot delete generations
+- Non-authenticated users cannot delete generations
+"""
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import delete, select
+
+from boards.api.app import create_app
+from boards.database.seed_data import ensure_tenant
+from boards.dbmodels import BoardMembers, Boards, Generations, Tenants, Users
+
+
+def generate_auth_adapter_user_id(provider: str, subject: str, tenant_id: str) -> uuid.UUID:
+    """Generate user ID using the same algorithm as the NoAuthAdapter."""
+    import hashlib
+
+    stable_input = f"{provider}:{subject}:{tenant_id}"
+    user_id_hash = hashlib.sha256(stable_input.encode()).hexdigest()[:32]
+    formatted_uuid = (
+        f"{user_id_hash[:8]}-{user_id_hash[8:12]}-"
+        f"{user_id_hash[12:16]}-{user_id_hash[16:20]}-"
+        f"{user_id_hash[20:32]}"
+    )
+    return uuid.UUID(formatted_uuid)
+
+
+async def cleanup_test_data(session):
+    """Clean up any existing test data that might interfere with the test."""
+    try:
+        test_user_ids_stmt = select(Users.id).where(
+            Users.auth_subject.in_(["del-owner", "del-editor", "del-other"])
+        )
+
+        # Delete board members first
+        board_ids_stmt = select(Boards.id).where(Boards.owner_id.in_(test_user_ids_stmt))
+        await session.execute(delete(BoardMembers).where(BoardMembers.board_id.in_(board_ids_stmt)))
+
+        # Delete generations
+        await session.execute(delete(Generations).where(Generations.board_id.in_(board_ids_stmt)))
+
+        # Delete boards
+        await session.execute(delete(Boards).where(Boards.owner_id.in_(test_user_ids_stmt)))
+
+        # Delete users
+        await session.execute(
+            delete(Users).where(Users.auth_subject.in_(["del-owner", "del-editor", "del-other"]))
+        )
+
+        # Delete tenant
+        await session.execute(delete(Tenants).where(Tenants.slug == "del-tenant"))
+
+        await session.commit()
+    except Exception:
+        await session.rollback()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.requires_db
+async def test_delete_generation_authorization(
+    alembic_migrate, test_database, reset_shared_db_connections
+):
+    """Integration test for generation deletion authorization."""
+    dsn, _ = test_database
+
+    import os
+
+    os.environ["BOARDS_DATABASE_URL"] = dsn
+    os.environ["BOARDS_AUTH_PROVIDER"] = "none"
+    os.environ["BOARDS_AUTH_CONFIG"] = (
+        '{"default_user_id": "del-owner", "default_tenant": "del-tenant"}'
+    )
+
+    app = create_app()
+
+    from httpx import ASGITransport
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        from boards.database.connection import get_async_session
+
+        async with get_async_session() as session:
+            await cleanup_test_data(session)
+
+            # Create tenant
+            tenant_id = await ensure_tenant(session, slug="del-tenant")
+
+            # Create users
+            owner_id = generate_auth_adapter_user_id("none", "del-owner", "del-tenant")
+            owner = Users()
+            owner.id = owner_id
+            owner.tenant_id = tenant_id
+            owner.auth_provider = "none"
+            owner.auth_subject = "del-owner"
+            owner.email = "owner@example.com"
+            owner.display_name = "Board Owner"
+            owner.metadata_ = {}
+            owner.created_at = datetime.now(UTC)
+            owner.updated_at = datetime.now(UTC)
+            session.add(owner)
+
+            editor_id = generate_auth_adapter_user_id("none", "del-editor", "del-tenant")
+            editor = Users()
+            editor.id = editor_id
+            editor.tenant_id = tenant_id
+            editor.auth_provider = "none"
+            editor.auth_subject = "del-editor"
+            editor.email = "editor@example.com"
+            editor.display_name = "Board Editor"
+            editor.metadata_ = {}
+            editor.created_at = datetime.now(UTC)
+            editor.updated_at = datetime.now(UTC)
+            session.add(editor)
+
+            other_id = generate_auth_adapter_user_id("none", "del-other", "del-tenant")
+            other = Users()
+            other.id = other_id
+            other.tenant_id = tenant_id
+            other.auth_provider = "none"
+            other.auth_subject = "del-other"
+            other.email = "other@example.com"
+            other.display_name = "Other User"
+            other.metadata_ = {}
+            other.created_at = datetime.now(UTC)
+            other.updated_at = datetime.now(UTC)
+            session.add(other)
+
+            # Create board owned by owner
+            board = Boards()
+            board.id = uuid.uuid4()
+            board.tenant_id = tenant_id
+            board.owner_id = owner.id
+            board.title = "Test Board"
+            board.description = "Board for deletion testing"
+            board.is_public = False
+            board.settings = {}
+            board.metadata_ = {}
+            board.created_at = datetime.now(UTC)
+            board.updated_at = datetime.now(UTC)
+            session.add(board)
+
+            # Add editor as board member with editor role
+            member = BoardMembers()
+            member.id = uuid.uuid4()
+            member.board_id = board.id
+            member.user_id = editor.id
+            member.role = "editor"
+            member.invited_by = owner.id
+            member.joined_at = datetime.now(UTC)
+            session.add(member)
+
+            # Create generation by owner
+            gen_by_owner = Generations()
+            gen_by_owner.id = uuid.uuid4()
+            gen_by_owner.tenant_id = tenant_id
+            gen_by_owner.board_id = board.id
+            gen_by_owner.user_id = owner.id
+            gen_by_owner.generator_name = "test-generator"
+            gen_by_owner.artifact_type = "image"
+            gen_by_owner.storage_url = "https://storage.example.com/owner_gen.jpg"
+            gen_by_owner.thumbnail_url = None
+            gen_by_owner.additional_files = []
+            gen_by_owner.input_params = {"prompt": "test"}
+            gen_by_owner.output_metadata = {}
+            gen_by_owner.external_job_id = "job-owner"
+            gen_by_owner.status = "completed"
+            gen_by_owner.progress = Decimal(1.0)
+            gen_by_owner.error_message = None
+            gen_by_owner.started_at = datetime.now(UTC)
+            gen_by_owner.completed_at = datetime.now(UTC)
+            gen_by_owner.created_at = datetime.now(UTC)
+            gen_by_owner.updated_at = datetime.now(UTC)
+            session.add(gen_by_owner)
+
+            # Create generation by editor
+            gen_by_editor = Generations()
+            gen_by_editor.id = uuid.uuid4()
+            gen_by_editor.tenant_id = tenant_id
+            gen_by_editor.board_id = board.id
+            gen_by_editor.user_id = editor.id
+            gen_by_editor.generator_name = "test-generator"
+            gen_by_editor.artifact_type = "image"
+            gen_by_editor.storage_url = "https://storage.example.com/editor_gen.jpg"
+            gen_by_editor.thumbnail_url = None
+            gen_by_editor.additional_files = []
+            gen_by_editor.input_params = {"prompt": "test"}
+            gen_by_editor.output_metadata = {}
+            gen_by_editor.external_job_id = "job-editor"
+            gen_by_editor.status = "completed"
+            gen_by_editor.progress = Decimal(1.0)
+            gen_by_editor.error_message = None
+            gen_by_editor.started_at = datetime.now(UTC)
+            gen_by_editor.completed_at = datetime.now(UTC)
+            gen_by_editor.created_at = datetime.now(UTC)
+            gen_by_editor.updated_at = datetime.now(UTC)
+            session.add(gen_by_editor)
+
+            # Create another generation by owner for editor to attempt to delete
+            gen_by_owner_2 = Generations()
+            gen_by_owner_2.id = uuid.uuid4()
+            gen_by_owner_2.tenant_id = tenant_id
+            gen_by_owner_2.board_id = board.id
+            gen_by_owner_2.user_id = owner.id
+            gen_by_owner_2.generator_name = "test-generator"
+            gen_by_owner_2.artifact_type = "image"
+            gen_by_owner_2.storage_url = "https://storage.example.com/owner_gen_2.jpg"
+            gen_by_owner_2.thumbnail_url = None
+            gen_by_owner_2.additional_files = []
+            gen_by_owner_2.input_params = {"prompt": "test"}
+            gen_by_owner_2.output_metadata = {}
+            gen_by_owner_2.external_job_id = "job-owner-2"
+            gen_by_owner_2.status = "completed"
+            gen_by_owner_2.progress = Decimal(1.0)
+            gen_by_owner_2.error_message = None
+            gen_by_owner_2.started_at = datetime.now(UTC)
+            gen_by_owner_2.completed_at = datetime.now(UTC)
+            gen_by_owner_2.created_at = datetime.now(UTC)
+            gen_by_owner_2.updated_at = datetime.now(UTC)
+            session.add(gen_by_owner_2)
+
+            await session.flush()
+
+            # Store IDs
+            gen_by_owner_id = gen_by_owner.id
+            gen_by_editor_id = gen_by_editor.id
+            gen_by_owner_2_id = gen_by_owner_2.id
+
+            await session.commit()
+
+        delete_mutation = """
+        mutation DeleteGeneration($id: UUID!) {
+            deleteGeneration(id: $id)
+        }
+        """
+
+        # Test 1: Owner can delete their own generation
+        response = await client.post(
+            "/graphql",
+            json={
+                "query": delete_mutation,
+                "variables": {"id": str(gen_by_owner_id)},
+            },
+            headers={"X-Tenant": "del-tenant"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "errors" not in data
+        assert data["data"]["deleteGeneration"] is True
+
+        # Verify generation was deleted
+        async with get_async_session() as session:
+            result = await session.execute(
+                select(Generations).where(Generations.id == gen_by_owner_id)
+            )
+            assert result.scalar_one_or_none() is None
+
+        # Test 2: Editor can delete their own generation
+        os.environ["BOARDS_AUTH_CONFIG"] = (
+            '{"default_user_id": "del-editor", "default_tenant": "del-tenant"}'
+        )
+        # Force app recreation to pick up new auth config
+        app = create_app()
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/graphql",
+                json={
+                    "query": delete_mutation,
+                    "variables": {"id": str(gen_by_editor_id)},
+                },
+                headers={"X-Tenant": "del-tenant"},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "errors" not in data
+            assert data["data"]["deleteGeneration"] is True
+
+            # Verify generation was deleted
+            async with get_async_session() as session:
+                result = await session.execute(
+                    select(Generations).where(Generations.id == gen_by_editor_id)
+                )
+                assert result.scalar_one_or_none() is None
+
+            # Test 3: Editor CANNOT delete owner's generation
+            response = await client.post(
+                "/graphql",
+                json={
+                    "query": delete_mutation,
+                    "variables": {"id": str(gen_by_owner_2_id)},
+                },
+                headers={"X-Tenant": "del-tenant"},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "errors" in data
+            assert "Permission denied" in data["errors"][0]["message"]
+
+            # Verify generation still exists
+            async with get_async_session() as session:
+                result = await session.execute(
+                    select(Generations).where(Generations.id == gen_by_owner_2_id)
+                )
+                assert result.scalar_one_or_none() is not None
+
+        # Test 4: Non-member cannot delete generations
+        os.environ["BOARDS_AUTH_CONFIG"] = (
+            '{"default_user_id": "del-other", "default_tenant": "del-tenant"}'
+        )
+        app = create_app()
+        transport = ASGITransport(app=app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/graphql",
+                json={
+                    "query": delete_mutation,
+                    "variables": {"id": str(gen_by_owner_2_id)},
+                },
+                headers={"X-Tenant": "del-tenant"},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "errors" in data
+            assert "Permission denied" in data["errors"][0]["message"]
+
+            # Verify generation still exists
+            async with get_async_session() as session:
+                result = await session.execute(
+                    select(Generations).where(Generations.id == gen_by_owner_2_id)
+                )
+                assert result.scalar_one_or_none() is not None
+
+        # Test 5: Verify generation still exists after failed deletion attempts
+        async with get_async_session() as session:
+            result = await session.execute(
+                select(Generations).where(Generations.id == gen_by_owner_2_id)
+            )
+            gen = result.scalar_one_or_none()
+            assert gen is not None
+            assert gen.user_id == owner_id  # Verify it's owned by the owner

--- a/packages/frontend/src/graphql/operations.ts
+++ b/packages/frontend/src/graphql/operations.ts
@@ -322,6 +322,12 @@ export const RETRY_GENERATION = gql`
   }
 `;
 
+export const DELETE_GENERATION = gql`
+  mutation DeleteGeneration($id: UUID!) {
+    deleteGeneration(id: $id)
+  }
+`;
+
 export const UPLOAD_ARTIFACT_FROM_URL = gql`
   ${GENERATION_FRAGMENT}
   mutation UploadArtifactFromUrl($input: UploadArtifactInput!) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   apps/baseboards:
     dependencies:
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2089,6 +2092,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -2131,6 +2147,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-direction@1.1.1':
@@ -10581,6 +10610,20 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.24)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.24
+      '@types/react-dom': 18.3.7(@types/react@18.3.24)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10613,6 +10656,28 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.24
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.24)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.1(@types/react@18.3.24)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.24
+      '@types/react-dom': 18.3.7(@types/react@18.3.24)
 
   '@radix-ui/react-direction@1.1.1(@types/react@18.3.24)(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
This pull request introduces a feature to allow users to delete generations from the UI, including a confirmation dialog and updated documentation on deletion rules and authorization. The most important changes are:

**UI Feature: Generation Deletion**

* Added a delete option to the `ArtifactPreview` dropdown menu, which triggers a confirmation dialog before deleting a generation. (`apps/baseboards/src/components/boards/ArtifactPreview.tsx`, `apps/baseboards/src/components/boards/GenerationGrid.tsx`) [[1]](diffhunk://#diff-b5950d8dffeb1140dcf8195121ec3c5c0477cdf829d7eafcffe3a19d4fd0fb19R16) [[2]](diffhunk://#diff-b5950d8dffeb1140dcf8195121ec3c5c0477cdf829d7eafcffe3a19d4fd0fb19R39) [[3]](diffhunk://#diff-b5950d8dffeb1140dcf8195121ec3c5c0477cdf829d7eafcffe3a19d4fd0fb19R55) [[4]](diffhunk://#diff-b5950d8dffeb1140dcf8195121ec3c5c0477cdf829d7eafcffe3a19d4fd0fb19R410-R424) [[5]](diffhunk://#diff-265baa60ba0e9da340d019ba3ba49179b0e4ff13a706aa69c966388ad88b1285L1-R14) [[6]](diffhunk://#diff-265baa60ba0e9da340d019ba3ba49179b0e4ff13a706aa69c966388ad88b1285R36-R39) [[7]](diffhunk://#diff-265baa60ba0e9da340d019ba3ba49179b0e4ff13a706aa69c966388ad88b1285R95-R121) [[8]](diffhunk://#diff-265baa60ba0e9da340d019ba3ba49179b0e4ff13a706aa69c966388ad88b1285R141-R164)
* Implemented a reusable `AlertDialog` component for confirmation dialogs, based on Radix UI primitives. (`apps/baseboards/src/components/ui/alert-dialog.tsx`, `apps/baseboards/package.json`) [[1]](diffhunk://#diff-092a34ff640e5368393ce0df6b1ffbc17014c9112a46e89fbd3234e045c3a639R1-R157) [[2]](diffhunk://#diff-526568dfc7c6e82de9a53799707dc3d77040b54698074617bd8d086d467273d3R13)

**Backend Documentation & Authorization**

* Updated the GraphQL API documentation for the `deleteGeneration` mutation to clarify that it deletes both the generation and its storage artifacts, and added detailed authorization rules for who can delete generations. (`apps/docs/docs/backend/graphql-api/mutations.md`) [[1]](diffhunk://#diff-4393f9f138f59e3e51d1642d1785e5bdfb691a089851be07a059d629b9e59e6cL419-R419) [[2]](diffhunk://#diff-4393f9f138f59e3e51d1642d1785e5bdfb691a089851be07a059d629b9e59e6cR437-R469)
* Added a warning in the documentation that deletion is permanent and cannot be undone. (`apps/docs/docs/backend/graphql-api/mutations.md`)

These changes improve the user experience by providing a safe, clear way to delete generations and make the backend behavior and permissions explicit in the documentation.