### PR TITLE
Add audio and video recording to baseboards

### DIFF
--- a/apps/baseboards/src/app/boards/[boardId]/page.tsx
+++ b/apps/baseboards/src/app/boards/[boardId]/page.tsx
@@ -11,6 +11,7 @@ import {
 import { GenerationGrid } from "@/components/boards/GenerationGrid";
 import { GenerationInput } from "@/components/boards/GenerationInput";
 import { UploadArtifact } from "@/components/boards/UploadArtifact";
+import { RecordMedia } from "@/components/boards/RecordMedia";
 import { Button } from "@/components/ui/button";
 import { Pencil, Check, X } from "lucide-react";
 
@@ -308,12 +309,20 @@ export default function BoardPage() {
                 </p>
               )}
             </div>
-            <UploadArtifact
-              boardId={boardId}
-              onUploadComplete={() => {
-                refreshBoard();
-              }}
-            />
+            <div className="flex items-center gap-2">
+              <RecordMedia
+                boardId={boardId}
+                onRecordingComplete={() => {
+                  refreshBoard();
+                }}
+              />
+              <UploadArtifact
+                boardId={boardId}
+                onUploadComplete={() => {
+                  refreshBoard();
+                }}
+              />
+            </div>
           </div>
 
           {/* Generation Grid */}

--- a/apps/baseboards/src/components/boards/RecordMedia.tsx
+++ b/apps/baseboards/src/components/boards/RecordMedia.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import React, { useCallback, useState, useRef, useEffect } from "react";
+import {
+  useMediaRecorder,
+  useMultiUpload,
+  mediaResultToFile,
+  ArtifactType,
+  MediaRecordingType,
+} from "@weirdfingers/boards";
+import { toast } from "@/components/ui/use-toast";
+
+interface RecordMediaProps {
+  boardId: string;
+  onRecordingComplete?: (generationId: string) => void;
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export function RecordMedia({
+  boardId,
+  onRecordingComplete,
+}: RecordMediaProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [recordingType, setRecordingType] = useState<MediaRecordingType | null>(
+    null
+  );
+  const videoPreviewRef = useRef<HTMLVideoElement>(null);
+
+  const {
+    status,
+    error,
+    previewStream,
+    duration,
+    initialize,
+    startRecording,
+    pauseRecording,
+    resumeRecording,
+    stopRecording,
+    cancelRecording,
+    reset,
+  } = useMediaRecorder({ maxDuration: 5 * 60 * 1000 }); // 5 minute max
+
+  const { uploadMultiple, isUploading } = useMultiUpload();
+
+  // Connect preview stream to video element
+  useEffect(() => {
+    if (videoPreviewRef.current && previewStream) {
+      videoPreviewRef.current.srcObject = previewStream;
+    }
+  }, [previewStream]);
+
+  const handleStartRecording = useCallback(
+    async (type: MediaRecordingType) => {
+      setRecordingType(type);
+      setIsOpen(true);
+      await initialize(type);
+    },
+    [initialize]
+  );
+
+  const handleRecord = useCallback(() => {
+    startRecording();
+  }, [startRecording]);
+
+  const handlePause = useCallback(() => {
+    pauseRecording();
+  }, [pauseRecording]);
+
+  const handleResume = useCallback(() => {
+    resumeRecording();
+  }, [resumeRecording]);
+
+  const handleStop = useCallback(async () => {
+    try {
+      const result = await stopRecording();
+      const file = mediaResultToFile(result, recordingType!);
+
+      // Upload the recorded file
+      const artifactType =
+        recordingType === "audio" ? ArtifactType.AUDIO : ArtifactType.VIDEO;
+
+      const uploadResults = await uploadMultiple([
+        {
+          boardId,
+          artifactType,
+          source: file,
+        },
+      ]);
+
+      if (uploadResults.length > 0) {
+        onRecordingComplete?.(uploadResults[0].id);
+        toast({
+          title: "Recording uploaded",
+          description: `Your ${recordingType} recording has been uploaded successfully.`,
+        });
+      }
+
+      handleClose();
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Recording failed",
+        description:
+          err instanceof Error ? err.message : "An unknown error occurred",
+      });
+    }
+  }, [
+    stopRecording,
+    recordingType,
+    uploadMultiple,
+    boardId,
+    onRecordingComplete,
+  ]);
+
+  const handleCancel = useCallback(() => {
+    cancelRecording();
+    handleClose();
+  }, [cancelRecording]);
+
+  const handleClose = useCallback(() => {
+    reset();
+    setIsOpen(false);
+    setRecordingType(null);
+  }, [reset]);
+
+  const handleRetry = useCallback(() => {
+    if (recordingType) {
+      initialize(recordingType);
+    }
+  }, [recordingType, initialize]);
+
+  const isRecordingActive = status === "recording" || status === "paused";
+
+  return (
+    <div className="relative inline-flex gap-1">
+      {/* Record Audio Button */}
+      <button
+        onClick={() => handleStartRecording("audio")}
+        className="inline-flex items-center gap-2 px-3 py-2 bg-secondary text-secondary-foreground rounded-lg hover:bg-secondary/80 transition-colors"
+        title="Record audio"
+      >
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"
+          />
+        </svg>
+        <span className="hidden sm:inline">Audio</span>
+      </button>
+
+      {/* Record Video Button */}
+      <button
+        onClick={() => handleStartRecording("video")}
+        className="inline-flex items-center gap-2 px-3 py-2 bg-secondary text-secondary-foreground rounded-lg hover:bg-secondary/80 transition-colors"
+        title="Record video"
+      >
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
+          />
+        </svg>
+        <span className="hidden sm:inline">Video</span>
+      </button>
+
+      {/* Recording Modal */}
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-full max-w-md bg-background rounded-lg shadow-xl p-6 mx-4">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-foreground">
+                Record {recordingType === "audio" ? "Audio" : "Video"}
+              </h3>
+              <button
+                onClick={handleCancel}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Close recording dialog"
+                disabled={isUploading}
+              >
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            {/* Error State */}
+            {status === "error" && error && (
+              <div className="text-center py-8">
+                <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+                  <svg
+                    className="w-8 h-8 text-red-600 dark:text-red-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                    />
+                  </svg>
+                </div>
+                <p className="text-foreground font-medium mb-2">
+                  {error.type === "permission"
+                    ? "Permission Required"
+                    : error.type === "not-supported"
+                      ? "Not Supported"
+                      : "Error"}
+                </p>
+                <p className="text-muted-foreground text-sm mb-4">
+                  {error.message}
+                </p>
+                {error.type === "permission" && (
+                  <p className="text-muted-foreground text-xs mb-4">
+                    Please allow access to your{" "}
+                    {recordingType === "audio"
+                      ? "microphone"
+                      : "camera and microphone"}{" "}
+                    in your browser settings.
+                  </p>
+                )}
+                <button
+                  onClick={handleRetry}
+                  className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+                >
+                  Try Again
+                </button>
+              </div>
+            )}
+
+            {/* Requesting Permission State */}
+            {status === "requesting" && (
+              <div className="text-center py-8">
+                <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-muted flex items-center justify-center animate-pulse">
+                  {recordingType === "audio" ? (
+                    <svg
+                      className="w-8 h-8 text-muted-foreground"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"
+                      />
+                    </svg>
+                  ) : (
+                    <svg
+                      className="w-8 h-8 text-muted-foreground"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
+                      />
+                    </svg>
+                  )}
+                </div>
+                <p className="text-foreground font-medium">
+                  Requesting Permission
+                </p>
+                <p className="text-muted-foreground text-sm mt-2">
+                  Please allow access to your{" "}
+                  {recordingType === "audio"
+                    ? "microphone"
+                    : "camera and microphone"}
+                </p>
+              </div>
+            )}
+
+            {/* Preview and Recording State */}
+            {(status === "ready" || isRecordingActive || status === "stopped") && (
+              <div>
+                {/* Video Preview */}
+                {recordingType === "video" && previewStream && (
+                  <div className="relative mb-4 rounded-lg overflow-hidden bg-black aspect-video">
+                    <video
+                      ref={videoPreviewRef}
+                      autoPlay
+                      muted
+                      playsInline
+                      className="w-full h-full object-cover"
+                    />
+                    {isRecordingActive && (
+                      <div className="absolute top-3 left-3 flex items-center gap-2 px-2 py-1 bg-red-600 text-white text-sm rounded">
+                        <span className="w-2 h-2 bg-white rounded-full animate-pulse" />
+                        REC
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Audio Waveform Placeholder */}
+                {recordingType === "audio" && (
+                  <div className="relative mb-4 rounded-lg bg-muted aspect-[2/1] flex items-center justify-center">
+                    {isRecordingActive ? (
+                      <div className="flex items-center gap-1">
+                        {[...Array(5)].map((_, i) => (
+                          <div
+                            key={i}
+                            className="w-2 bg-primary rounded-full animate-pulse"
+                            style={{
+                              height: `${20 + Math.random() * 40}px`,
+                              animationDelay: `${i * 0.1}s`,
+                            }}
+                          />
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="text-center">
+                        <svg
+                          className="w-12 h-12 mx-auto text-muted-foreground mb-2"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"
+                          />
+                        </svg>
+                        <p className="text-muted-foreground text-sm">
+                          Ready to record
+                        </p>
+                      </div>
+                    )}
+                    {isRecordingActive && (
+                      <div className="absolute top-3 left-3 flex items-center gap-2 px-2 py-1 bg-red-600 text-white text-sm rounded">
+                        <span className="w-2 h-2 bg-white rounded-full animate-pulse" />
+                        REC
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Duration Display */}
+                <div className="text-center mb-4">
+                  <span className="text-2xl font-mono text-foreground">
+                    {formatDuration(duration)}
+                  </span>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Max: 5:00
+                  </p>
+                </div>
+
+                {/* Controls */}
+                <div className="flex items-center justify-center gap-3">
+                  {status === "ready" && (
+                    <button
+                      onClick={handleRecord}
+                      className="flex items-center justify-center w-14 h-14 rounded-full bg-red-600 text-white hover:bg-red-700 transition-colors"
+                      title="Start recording"
+                    >
+                      <span className="w-5 h-5 rounded-full bg-white" />
+                    </button>
+                  )}
+
+                  {status === "recording" && (
+                    <>
+                      <button
+                        onClick={handlePause}
+                        className="flex items-center justify-center w-12 h-12 rounded-full bg-muted text-foreground hover:bg-muted/80 transition-colors"
+                        title="Pause recording"
+                      >
+                        <svg
+                          className="w-6 h-6"
+                          fill="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <rect x="6" y="4" width="4" height="16" rx="1" />
+                          <rect x="14" y="4" width="4" height="16" rx="1" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={handleStop}
+                        disabled={isUploading}
+                        className="flex items-center justify-center w-14 h-14 rounded-full bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        title="Stop and save"
+                      >
+                        <span className="w-5 h-5 rounded bg-white" />
+                      </button>
+                    </>
+                  )}
+
+                  {status === "paused" && (
+                    <>
+                      <button
+                        onClick={handleResume}
+                        className="flex items-center justify-center w-12 h-12 rounded-full bg-muted text-foreground hover:bg-muted/80 transition-colors"
+                        title="Resume recording"
+                      >
+                        <svg
+                          className="w-6 h-6"
+                          fill="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path d="M8 5v14l11-7z" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={handleStop}
+                        disabled={isUploading}
+                        className="flex items-center justify-center w-14 h-14 rounded-full bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        title="Stop and save"
+                      >
+                        <span className="w-5 h-5 rounded bg-white" />
+                      </button>
+                    </>
+                  )}
+                </div>
+
+                {/* Uploading indicator */}
+                {isUploading && (
+                  <div className="mt-4 text-center">
+                    <p className="text-sm text-muted-foreground">
+                      Uploading recording...
+                    </p>
+                  </div>
+                )}
+
+                {/* Instructions */}
+                {status === "ready" && (
+                  <p className="text-center text-muted-foreground text-sm mt-4">
+                    Click the red button to start recording
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/hooks/useMediaRecorder.ts
+++ b/packages/frontend/src/hooks/useMediaRecorder.ts
@@ -1,0 +1,432 @@
+/**
+ * Hook for recording audio and video using browser MediaRecorder API.
+ */
+
+import { useCallback, useState, useRef, useEffect } from "react";
+
+export type MediaRecordingType = "audio" | "video";
+export type MediaRecorderStatus =
+  | "idle"
+  | "requesting"
+  | "ready"
+  | "recording"
+  | "paused"
+  | "stopped"
+  | "error";
+
+export interface MediaRecorderError {
+  type: "permission" | "not-supported" | "stream" | "recording" | "unknown";
+  message: string;
+}
+
+export interface UseMediaRecorderOptions {
+  /**
+   * Maximum recording duration in milliseconds.
+   * Default: 5 minutes (300000ms)
+   */
+  maxDuration?: number;
+  /**
+   * Preferred MIME type for the recording.
+   * Will fall back to supported types if not available.
+   */
+  mimeType?: string;
+  /**
+   * Audio bitrate in bits per second.
+   * Default: 128000 (128 kbps)
+   */
+  audioBitsPerSecond?: number;
+  /**
+   * Video bitrate in bits per second.
+   * Default: 2500000 (2.5 Mbps)
+   */
+  videoBitsPerSecond?: number;
+}
+
+export interface MediaRecorderResult {
+  blob: Blob;
+  mimeType: string;
+  duration: number;
+}
+
+export interface MediaRecorderHook {
+  /** Current status of the recorder */
+  status: MediaRecorderStatus;
+  /** Error if status is 'error' */
+  error: MediaRecorderError | null;
+  /** Preview stream for displaying live video/audio feedback */
+  previewStream: MediaStream | null;
+  /** Recording duration in milliseconds */
+  duration: number;
+  /** Start requesting media permissions and initialize recorder */
+  initialize: (type: MediaRecordingType) => Promise<void>;
+  /** Start recording */
+  startRecording: () => void;
+  /** Pause recording */
+  pauseRecording: () => void;
+  /** Resume recording */
+  resumeRecording: () => void;
+  /** Stop recording and return the recorded blob */
+  stopRecording: () => Promise<MediaRecorderResult>;
+  /** Cancel recording and release resources */
+  cancelRecording: () => void;
+  /** Reset to idle state */
+  reset: () => void;
+}
+
+const PREFERRED_AUDIO_MIME_TYPES = [
+  "audio/webm;codecs=opus",
+  "audio/webm",
+  "audio/ogg;codecs=opus",
+  "audio/mp4",
+];
+
+const PREFERRED_VIDEO_MIME_TYPES = [
+  "video/webm;codecs=vp9,opus",
+  "video/webm;codecs=vp8,opus",
+  "video/webm",
+  "video/mp4",
+];
+
+function getSupportedMimeType(type: MediaRecordingType): string | undefined {
+  const mimeTypes =
+    type === "audio" ? PREFERRED_AUDIO_MIME_TYPES : PREFERRED_VIDEO_MIME_TYPES;
+
+  for (const mimeType of mimeTypes) {
+    if (MediaRecorder.isTypeSupported(mimeType)) {
+      return mimeType;
+    }
+  }
+  return undefined;
+}
+
+function getFileExtension(mimeType: string): string {
+  if (mimeType.includes("webm")) return "webm";
+  if (mimeType.includes("mp4")) return "mp4";
+  if (mimeType.includes("ogg")) return "ogg";
+  return "bin";
+}
+
+export function useMediaRecorder(
+  options: UseMediaRecorderOptions = {}
+): MediaRecorderHook {
+  const {
+    maxDuration = 5 * 60 * 1000, // 5 minutes default
+    mimeType: preferredMimeType,
+    audioBitsPerSecond = 128000,
+    videoBitsPerSecond = 2500000,
+  } = options;
+
+  const [status, setStatus] = useState<MediaRecorderStatus>("idle");
+  const [error, setError] = useState<MediaRecorderError | null>(null);
+  const [previewStream, setPreviewStream] = useState<MediaStream | null>(null);
+  const [duration, setDuration] = useState(0);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const startTimeRef = useRef<number>(0);
+  const durationIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
+    null
+  );
+  const maxDurationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const recordingTypeRef = useRef<MediaRecordingType>("audio");
+  const resolveStopRef = useRef<
+    ((result: MediaRecorderResult) => void) | null
+  >(null);
+  const mimeTypeRef = useRef<string>("");
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (durationIntervalRef.current) {
+        clearInterval(durationIntervalRef.current);
+      }
+      if (maxDurationTimeoutRef.current) {
+        clearTimeout(maxDurationTimeoutRef.current);
+      }
+      if (previewStream) {
+        previewStream.getTracks().forEach((track) => track.stop());
+      }
+    };
+  }, [previewStream]);
+
+  const cleanup = useCallback(() => {
+    if (durationIntervalRef.current) {
+      clearInterval(durationIntervalRef.current);
+      durationIntervalRef.current = null;
+    }
+    if (maxDurationTimeoutRef.current) {
+      clearTimeout(maxDurationTimeoutRef.current);
+      maxDurationTimeoutRef.current = null;
+    }
+    if (previewStream) {
+      previewStream.getTracks().forEach((track) => track.stop());
+      setPreviewStream(null);
+    }
+    mediaRecorderRef.current = null;
+    chunksRef.current = [];
+    resolveStopRef.current = null;
+  }, [previewStream]);
+
+  const reset = useCallback(() => {
+    cleanup();
+    setStatus("idle");
+    setError(null);
+    setDuration(0);
+  }, [cleanup]);
+
+  const initialize = useCallback(
+    async (type: MediaRecordingType) => {
+      // Check if MediaRecorder is supported
+      if (typeof MediaRecorder === "undefined") {
+        setStatus("error");
+        setError({
+          type: "not-supported",
+          message: "MediaRecorder is not supported in this browser",
+        });
+        return;
+      }
+
+      setStatus("requesting");
+      setError(null);
+      recordingTypeRef.current = type;
+
+      try {
+        const constraints: MediaStreamConstraints =
+          type === "audio"
+            ? { audio: true, video: false }
+            : { audio: true, video: { facingMode: "user" } };
+
+        const stream = await navigator.mediaDevices.getUserMedia(constraints);
+        setPreviewStream(stream);
+
+        // Determine MIME type
+        let selectedMimeType = preferredMimeType;
+        if (!selectedMimeType || !MediaRecorder.isTypeSupported(selectedMimeType)) {
+          selectedMimeType = getSupportedMimeType(type);
+        }
+
+        if (!selectedMimeType) {
+          stream.getTracks().forEach((track) => track.stop());
+          setStatus("error");
+          setError({
+            type: "not-supported",
+            message: `No supported MIME type found for ${type} recording`,
+          });
+          return;
+        }
+
+        mimeTypeRef.current = selectedMimeType;
+
+        // Create MediaRecorder
+        const recorderOptions: MediaRecorderOptions = {
+          mimeType: selectedMimeType,
+          audioBitsPerSecond,
+        };
+        if (type === "video") {
+          recorderOptions.videoBitsPerSecond = videoBitsPerSecond;
+        }
+
+        const recorder = new MediaRecorder(stream, recorderOptions);
+
+        recorder.ondataavailable = (event) => {
+          if (event.data.size > 0) {
+            chunksRef.current.push(event.data);
+          }
+        };
+
+        recorder.onstop = () => {
+          const recordedDuration = Date.now() - startTimeRef.current;
+          const blob = new Blob(chunksRef.current, {
+            type: mimeTypeRef.current,
+          });
+
+          if (resolveStopRef.current) {
+            resolveStopRef.current({
+              blob,
+              mimeType: mimeTypeRef.current,
+              duration: recordedDuration,
+            });
+            resolveStopRef.current = null;
+          }
+        };
+
+        recorder.onerror = () => {
+          setStatus("error");
+          setError({
+            type: "recording",
+            message: "An error occurred during recording",
+          });
+        };
+
+        mediaRecorderRef.current = recorder;
+        setStatus("ready");
+      } catch (err) {
+        let errorType: MediaRecorderError["type"] = "unknown";
+        let errorMessage = "Failed to access media devices";
+
+        if (err instanceof Error) {
+          if (
+            err.name === "NotAllowedError" ||
+            err.name === "PermissionDeniedError"
+          ) {
+            errorType = "permission";
+            errorMessage = `Permission denied to access ${type === "audio" ? "microphone" : "camera and microphone"}`;
+          } else if (err.name === "NotFoundError") {
+            errorType = "stream";
+            errorMessage = `No ${type === "audio" ? "microphone" : "camera"} found`;
+          } else if (err.name === "NotReadableError") {
+            errorType = "stream";
+            errorMessage = `${type === "audio" ? "Microphone" : "Camera"} is already in use`;
+          } else {
+            errorMessage = err.message;
+          }
+        }
+
+        setStatus("error");
+        setError({ type: errorType, message: errorMessage });
+      }
+    },
+    [preferredMimeType, audioBitsPerSecond, videoBitsPerSecond]
+  );
+
+  const startRecording = useCallback(() => {
+    if (!mediaRecorderRef.current || status !== "ready") {
+      return;
+    }
+
+    chunksRef.current = [];
+    startTimeRef.current = Date.now();
+    setDuration(0);
+
+    // Start duration tracking
+    durationIntervalRef.current = setInterval(() => {
+      setDuration(Date.now() - startTimeRef.current);
+    }, 100);
+
+    // Set max duration timeout
+    maxDurationTimeoutRef.current = setTimeout(() => {
+      if (
+        mediaRecorderRef.current &&
+        mediaRecorderRef.current.state === "recording"
+      ) {
+        mediaRecorderRef.current.stop();
+      }
+    }, maxDuration);
+
+    mediaRecorderRef.current.start(1000); // Collect data every second
+    setStatus("recording");
+  }, [status, maxDuration]);
+
+  const pauseRecording = useCallback(() => {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state === "recording"
+    ) {
+      mediaRecorderRef.current.pause();
+      if (durationIntervalRef.current) {
+        clearInterval(durationIntervalRef.current);
+        durationIntervalRef.current = null;
+      }
+      setStatus("paused");
+    }
+  }, []);
+
+  const resumeRecording = useCallback(() => {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state === "paused"
+    ) {
+      const pausedDuration = duration;
+      startTimeRef.current = Date.now() - pausedDuration;
+
+      durationIntervalRef.current = setInterval(() => {
+        setDuration(Date.now() - startTimeRef.current);
+      }, 100);
+
+      mediaRecorderRef.current.resume();
+      setStatus("recording");
+    }
+  }, [duration]);
+
+  const stopRecording = useCallback((): Promise<MediaRecorderResult> => {
+    return new Promise((resolve, reject) => {
+      if (!mediaRecorderRef.current) {
+        reject(new Error("No active recording"));
+        return;
+      }
+
+      if (
+        mediaRecorderRef.current.state !== "recording" &&
+        mediaRecorderRef.current.state !== "paused"
+      ) {
+        reject(new Error("Recording is not active"));
+        return;
+      }
+
+      resolveStopRef.current = resolve;
+
+      if (durationIntervalRef.current) {
+        clearInterval(durationIntervalRef.current);
+        durationIntervalRef.current = null;
+      }
+      if (maxDurationTimeoutRef.current) {
+        clearTimeout(maxDurationTimeoutRef.current);
+        maxDurationTimeoutRef.current = null;
+      }
+
+      mediaRecorderRef.current.stop();
+      setStatus("stopped");
+
+      // Stop the stream tracks
+      if (previewStream) {
+        previewStream.getTracks().forEach((track) => track.stop());
+        setPreviewStream(null);
+      }
+    });
+  }, [previewStream]);
+
+  const cancelRecording = useCallback(() => {
+    if (mediaRecorderRef.current) {
+      if (
+        mediaRecorderRef.current.state === "recording" ||
+        mediaRecorderRef.current.state === "paused"
+      ) {
+        mediaRecorderRef.current.stop();
+      }
+    }
+    cleanup();
+    setStatus("idle");
+    setDuration(0);
+  }, [cleanup]);
+
+  return {
+    status,
+    error,
+    previewStream,
+    duration,
+    initialize,
+    startRecording,
+    pauseRecording,
+    resumeRecording,
+    stopRecording,
+    cancelRecording,
+    reset,
+  };
+}
+
+/**
+ * Helper function to convert a MediaRecorderResult to a File object
+ * suitable for uploading.
+ */
+export function mediaResultToFile(
+  result: MediaRecorderResult,
+  type: MediaRecordingType
+): File {
+  const extension = getFileExtension(result.mimeType);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `${type}-recording-${timestamp}.${extension}`;
+
+  return new File([result.blob], filename, { type: result.mimeType });
+}

--- a/packages/frontend/src/index.ts
+++ b/packages/frontend/src/index.ts
@@ -33,6 +33,7 @@ export { useBoard } from "./hooks/useBoard";
 export { useGeneration } from "./hooks/useGeneration";
 export { useGenerators } from "./hooks/useGenerators";
 export { useMultiUpload } from "./hooks/useMultiUpload";
+export { useMediaRecorder, mediaResultToFile } from "./hooks/useMediaRecorder";
 export type { Generator, JSONSchema7 } from "./hooks/useGenerators";
 export {
   useAncestry,
@@ -52,6 +53,14 @@ export type {
   UploadItem,
   UploadStatus,
 } from "./hooks/useMultiUpload";
+export type {
+  MediaRecordingType,
+  MediaRecorderStatus,
+  MediaRecorderError,
+  UseMediaRecorderOptions,
+  MediaRecorderResult,
+  MediaRecorderHook,
+} from "./hooks/useMediaRecorder";
 
 // Generator schema utilities
 export * from "./types/generatorSchema";


### PR DESCRIPTION
Implement browser-based audio/video recording using MediaRecorder API:

- Add useMediaRecorder hook in packages/frontend with support for:
  - Audio and video recording
  - Permission handling
  - Pause/resume functionality
  - Max duration limits (5 minutes default)
  - Preview stream for live feedback

- Add RecordMedia component in baseboards app with:
  - Audio and Video recording buttons
  - Recording modal with video preview/audio visualization
  - Duration display and controls
  - Automatic upload on recording completion

- Integrate RecordMedia next to Upload button on board page