### PR TITLE
various prep template fixes

### DIFF
--- a/apps/baseboards/next.config.js
+++ b/apps/baseboards/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   reactStrictMode: true,
   transpilePackages: ["@weirdfingers/boards"],
   images: {

--- a/packages/cli-launcher/basic-template/docker/env.example
+++ b/packages/cli-launcher/basic-template/docker/env.example
@@ -2,12 +2,12 @@
 
 # PostgreSQL Database
 POSTGRES_USER=boards
-POSTGRES_PASSWORD=boards_dev
+POSTGRES_PASSWORD=REPLACE_WITH_GENERATED_PASSWORD
 POSTGRES_DB=boards_dev
 
 # Backend API
-BOARDS_DATABASE_URL=postgresql://boards:boards_dev@postgres:5432/boards_dev
-BOARDS_REDIS_URL=redis://redis:6379/0
+BOARDS_DATABASE_URL=postgresql://boards:REPLACE_WITH_GENERATED_PASSWORD@db:5432/boards_dev
+BOARDS_REDIS_URL=redis://cache:6379/0
 BOARDS_STORAGE_CONFIG_PATH=/app/config/storage_config.yaml
 BOARDS_GENERATORS_CONFIG_PATH=/app/config/generators.yaml
 

--- a/packages/cli-launcher/src/commands/up.ts
+++ b/packages/cli-launcher/src/commands/up.ts
@@ -818,18 +818,24 @@ async function runMigrations(ctx: ProjectContext): Promise<void> {
       );
     } else {
       console.log(
+        chalk.red(
+          "\n❌ Database migrations failed"
+        )
+      );
+      console.log(chalk.gray("\n   Error details:"));
+      console.log(chalk.gray("   " + errorMessage));
+      console.log(
         chalk.yellow(
-          "\n⚠️  Database migrations failed. You may need to run them manually:"
+          "\n   You can try running migrations manually:"
         )
       );
       console.log(
         chalk.cyan("   docker compose exec api alembic upgrade head")
       );
-      console.log(chalk.gray("\n   Error details:"));
-      console.log(chalk.gray("   " + errorMessage));
     }
 
-    // Don't throw - app can still start
+    // Migrations are critical - throw to fail the initialization
+    throw new Error("Database migrations failed");
   }
 }
 

--- a/packages/cli-launcher/template-sources/compose.yaml
+++ b/packages/cli-launcher/template-sources/compose.yaml
@@ -36,7 +36,8 @@ services:
       - api/.env
     environment:
       # Enable loading custom generators and plugins from /app/extensions
-      - PYTHONPATH=/app:/app/extensions
+      # Include /app/src for the boards module (from Docker image)
+      - PYTHONPATH=/app/src:/app/extensions
       # Explicit paths to configuration files
       - BOARDS_GENERATORS_CONFIG_PATH=/app/config/generators.yaml
       - BOARDS_STORAGE_CONFIG_PATH=/app/config/storage_config.yaml
@@ -83,7 +84,8 @@ services:
       - api/.env
     environment:
       # Enable loading custom generators and plugins from /app/extensions
-      - PYTHONPATH=/app:/app/extensions
+      # Include /app/src for the boards module (from Docker image)
+      - PYTHONPATH=/app/src:/app/extensions
       # Explicit paths to configuration files
       - BOARDS_GENERATORS_CONFIG_PATH=/app/config/generators.yaml
       - BOARDS_STORAGE_CONFIG_PATH=/app/config/storage_config.yaml

--- a/scripts/prepare-release-templates.sh
+++ b/scripts/prepare-release-templates.sh
@@ -156,6 +156,7 @@ copy_template_structure() {
     # Base exclusions (common to all types)
     local base_excludes=(
         --exclude='.DS_Store'
+        --exclude='._*'
         --exclude='.env'
         --exclude='.env.local'
     )
@@ -213,6 +214,12 @@ prepare_baseboards_template() {
 
     # Copy baseboards app to web/ directory
     copy_template_structure "$PROJECT_ROOT/apps/baseboards" "$web_dir" "baseboards"
+
+    # Copy web environment file
+    if [[ -f "$PROJECT_ROOT/packages/cli-launcher/template-sources/web-env.example" ]]; then
+        cp "$PROJECT_ROOT/packages/cli-launcher/template-sources/web-env.example" "$web_dir/.env.example"
+        log_success "  Copied web/.env.example"
+    fi
 
     # Transform workspace dependencies
     transform_package_json "$web_dir/package.json" "$VERSION"
@@ -275,12 +282,12 @@ This is **not recommended** for most users. The pre-built images are the support
 EOF
     log_success "  Created api/README.md"
 
-    # Copy shared template files from basic-template
+    # Copy shared template files from template-sources
     log_info "  Copying shared template files..."
-    cp "$PROJECT_ROOT/packages/cli-launcher/basic-template/compose.yaml" "$template_dir/"
-    cp "$PROJECT_ROOT/packages/cli-launcher/basic-template/compose.web.yaml" "$template_dir/"
-    cp "$PROJECT_ROOT/packages/cli-launcher/basic-template/Dockerfile.web" "$template_dir/"
-    cp "$PROJECT_ROOT/packages/cli-launcher/basic-template/README.md" "$template_dir/"
+    cp "$PROJECT_ROOT/packages/cli-launcher/template-sources/compose.yaml" "$template_dir/"
+    cp "$PROJECT_ROOT/packages/cli-launcher/template-sources/compose.web.yaml" "$template_dir/"
+    cp "$PROJECT_ROOT/packages/cli-launcher/template-sources/Dockerfile.web" "$template_dir/"
+    cp "$PROJECT_ROOT/packages/cli-launcher/template-sources/README.md" "$template_dir/"
 
     # Copy config directory
     mkdir -p "$template_dir/config"
@@ -491,6 +498,9 @@ create_tarballs() {
 
     cd "$TEMPLATES_DIR"
 
+    # Set COPYFILE_DISABLE to prevent macOS from including ._* (AppleDouble) files
+    export COPYFILE_DISABLE=1
+
     # Create baseboards tarball
     log_info "  Creating template-baseboards-v${VERSION}.tar.gz..."
     tar -czf "$DIST_DIR/template-baseboards-v${VERSION}.tar.gz" baseboards/
@@ -501,6 +511,7 @@ create_tarballs() {
     tar -czf "$DIST_DIR/template-basic-v${VERSION}.tar.gz" basic/
     log_success "  Created template-basic-v${VERSION}.tar.gz"
 
+    unset COPYFILE_DISABLE
     cd "$PROJECT_ROOT"
 }
 


### PR DESCRIPTION
This pull request makes several improvements to template handling, environment configuration, and error reporting for the project. Key changes include stricter database migration error handling, updates to Docker and environment templates for clarity and compatibility, and improvements to the release packaging process to avoid macOS-specific artifacts.

**Template and Environment Improvements:**

* Updated the example environment file for the basic template to use placeholder values for sensitive credentials, and renamed the file for clarity. Also updated database and cache hostnames to match Docker Compose service names.
* Updated the Docker Compose template to set `PYTHONPATH` to include `/app/src` for proper module resolution in the boards Docker image. [[1]](diffhunk://#diff-ced1045cd088a687de847906c275cfd850158d481fe139cc327315006892e245L39-R40) [[2]](diffhunk://#diff-ced1045cd088a687de847906c275cfd850158d481fe139cc327315006892e245L86-R88)
* The Next.js configuration for the baseboards app now uses standalone output mode, improving deployment flexibility.

**Release Packaging and Template Scripts:**

* The release template preparation script now excludes macOS AppleDouble files (e.g., `._*`), sets `COPYFILE_DISABLE` during tarball creation to prevent macOS metadata files from being included, and ensures the web environment example is copied if present. [[1]](diffhunk://#diff-1085a7a53947170d15288098df6acedf58bfff2a876057eb67da6b3835c15b85R159) [[2]](diffhunk://#diff-1085a7a53947170d15288098df6acedf58bfff2a876057eb67da6b3835c15b85R501-R503) [[3]](diffhunk://#diff-1085a7a53947170d15288098df6acedf58bfff2a876057eb67da6b3835c15b85R514) [[4]](diffhunk://#diff-1085a7a53947170d15288098df6acedf58bfff2a876057eb67da6b3835c15b85R218-R223)
* Shared template files are now copied from a new `template-sources` directory instead of `basic-template`, streamlining template management.

**Error Handling:**

* Database migration failures in the CLI launcher now cause the process to exit with an error, rather than allowing the app to start with failed migrations. Error messages are clearer and more prominently displayed.