### PR TITLE
Turn ascii art into mermaid

### DIFF
--- a/apps/docs/docs/deployment/cloud/cloud-run.md
+++ b/apps/docs/docs/deployment/cloud/cloud-run.md
@@ -10,20 +10,17 @@ sidebar_position: 1
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────────────┐
-│                  Cloud Run                       │
-│  ┌─────────────┐         ┌─────────────────┐    │
-│  │  API Service │         │  Worker Service │    │
-│  │  (auto-scale)│         │  (min 1 replica)│    │
-│  └──────┬──────┘         └────────┬────────┘    │
-└─────────┼─────────────────────────┼─────────────┘
-          │                         │
-          ▼                         ▼
-    ┌──────────┐             ┌───────────┐
-    │Cloud SQL │             │ Memorystore│
-    │(Postgres)│             │  (Redis)   │
-    └──────────┘             └───────────┘
+```mermaid
+flowchart TB
+    subgraph CloudRun["Cloud Run"]
+        APIService["API Service<br/>(auto-scale)"]
+        WorkerService["Worker Service<br/>(min 1 replica)"]
+    end
+
+    APIService --> CloudSQL["Cloud SQL<br/>(Postgres)"]
+    APIService --> Memorystore["Memorystore<br/>(Redis)"]
+    WorkerService --> CloudSQL
+    WorkerService --> Memorystore
 ```
 
 ## Prerequisites

--- a/apps/docs/docs/deployment/cloud/elastic-beanstalk.md
+++ b/apps/docs/docs/deployment/cloud/elastic-beanstalk.md
@@ -10,28 +10,23 @@ sidebar_position: 2
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                   Elastic Beanstalk                      │
-│  ┌─────────────────────────────────────────────────┐    │
-│  │              Application Load Balancer           │    │
-│  └────────────────────────┬────────────────────────┘    │
-│                           │                              │
-│  ┌────────────────────────┼────────────────────────┐    │
-│  │                   Auto Scaling Group             │    │
-│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐       │    │
-│  │  │   EC2    │  │   EC2    │  │   EC2    │       │    │
-│  │  │ API+Worker│  │ API+Worker│  │ API+Worker│     │    │
-│  │  └──────────┘  └──────────┘  └──────────┘       │    │
-│  └──────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────┘
-                           │
-          ┌────────────────┼────────────────┐
-          ▼                ▼                ▼
-     ┌─────────┐     ┌──────────┐    ┌───────────┐
-     │   RDS   │     │ElastiCache│    │    S3     │
-     │(Postgres)│     │ (Redis)  │    │ (Storage) │
-     └─────────┘     └──────────┘    └───────────┘
+```mermaid
+flowchart TB
+    subgraph EB["Elastic Beanstalk"]
+        ALB["Application Load Balancer"]
+
+        subgraph ASG["Auto Scaling Group"]
+            EC2_1["EC2<br/>API+Worker"]
+            EC2_2["EC2<br/>API+Worker"]
+            EC2_3["EC2<br/>API+Worker"]
+        end
+
+        ALB --> ASG
+    end
+
+    ASG --> RDS["RDS<br/>(Postgres)"]
+    ASG --> ElastiCache["ElastiCache<br/>(Redis)"]
+    ASG --> S3["S3<br/>(Storage)"]
 ```
 
 ## Prerequisites

--- a/apps/docs/docs/deployment/cloud/fly-io.md
+++ b/apps/docs/docs/deployment/cloud/fly-io.md
@@ -17,34 +17,31 @@ sidebar_position: 5
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────┐
-│              Fly.io Organization         │
-│                                          │
-│  ┌─────────────────────────────────┐    │
-│  │           Fly Proxy             │    │
-│  │    (Global Load Balancing)      │    │
-│  └──────────────┬──────────────────┘    │
-│                 │                        │
-│  ┌──────────────┼──────────────────┐    │
-│  │         API Machines             │    │
-│  │  ┌────┐  ┌────┐  ┌────┐         │    │
-│  │  │ VM │  │ VM │  │ VM │         │    │
-│  │  └────┘  └────┘  └────┘         │    │
-│  └──────────────────────────────────┘   │
-│                 │                        │
-│  ┌──────────────┼──────────────────┐    │
-│  │        Worker Machines           │    │
-│  │  ┌────┐  ┌────┐                 │    │
-│  │  │ VM │  │ VM │                 │    │
-│  │  └────┘  └────┘                 │    │
-│  └──────────────────────────────────┘   │
-│                 │                        │
-│  ┌──────────────┴──────────────────┐    │
-│  │     Fly Postgres    Upstash     │    │
-│  │      (Cluster)      (Redis)     │    │
-│  └─────────────────────────────────┘    │
-└─────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph Fly["Fly.io Organization"]
+        FlyProxy["Fly Proxy<br/>(Global Load Balancing)"]
+
+        subgraph APIMachines["API Machines"]
+            VM1["VM"]
+            VM2["VM"]
+            VM3["VM"]
+        end
+
+        subgraph WorkerMachines["Worker Machines"]
+            WVM1["VM"]
+            WVM2["VM"]
+        end
+
+        subgraph Data["Data Services"]
+            FlyPostgres["Fly Postgres<br/>(Cluster)"]
+            Upstash["Upstash<br/>(Redis)"]
+        end
+
+        FlyProxy --> APIMachines
+        APIMachines --> Data
+        WorkerMachines --> Data
+    end
 ```
 
 ## Prerequisites

--- a/apps/docs/docs/deployment/cloud/railway.md
+++ b/apps/docs/docs/deployment/cloud/railway.md
@@ -19,21 +19,20 @@ sidebar_position: 3
 
 Railway deploys each service as a separate container:
 
-```
-┌─────────────────────────────────────────┐
-│              Railway Project             │
-│  ┌─────────────┐  ┌─────────────────┐   │
-│  │  API Service │  │  Worker Service │   │
-│  └──────┬──────┘  └────────┬────────┘   │
-│         │                   │            │
-│  ┌──────┴───────────────────┴──────┐    │
-│  │         Internal Network         │    │
-│  └──────┬───────────────────┬──────┘    │
-│         │                   │            │
-│  ┌──────┴──────┐    ┌──────┴──────┐     │
-│  │  PostgreSQL  │    │    Redis    │     │
-│  └─────────────┘    └─────────────┘     │
-└─────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph Railway["Railway Project"]
+        APIService["API Service"]
+        WorkerService["Worker Service"]
+
+        subgraph Network["Internal Network"]
+            PostgreSQL["PostgreSQL"]
+            Redis["Redis"]
+        end
+
+        APIService --> Network
+        WorkerService --> Network
+    end
 ```
 
 ## Quick Start

--- a/apps/docs/docs/deployment/cloud/render.md
+++ b/apps/docs/docs/deployment/cloud/render.md
@@ -17,23 +17,20 @@ sidebar_position: 4
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────┐
-│              Render Account              │
-│                                          │
-│  ┌─────────────┐  ┌─────────────────┐   │
-│  │ Web Service │  │Background Worker│   │
-│  │   (API)     │  │   (Worker)      │   │
-│  └──────┬──────┘  └────────┬────────┘   │
-│         │                   │            │
-│  ┌──────┴───────────────────┴──────┐    │
-│  │         Private Network          │    │
-│  └──────┬───────────────────┬──────┘    │
-│         │                   │            │
-│  ┌──────┴──────┐    ┌──────┴──────┐     │
-│  │  PostgreSQL  │    │    Redis    │     │
-│  └─────────────┘    └─────────────┘     │
-└─────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph Render["Render Account"]
+        WebService["Web Service<br/>(API)"]
+        BGWorker["Background Worker<br/>(Worker)"]
+
+        subgraph Network["Private Network"]
+            PostgreSQL["PostgreSQL"]
+            Redis["Redis"]
+        end
+
+        WebService --> Network
+        BGWorker --> Network
+    end
 ```
 
 ## Quick Start

--- a/apps/docs/docs/deployment/overview.md
+++ b/apps/docs/docs/deployment/overview.md
@@ -109,29 +109,25 @@ See [Configuration Reference](./configuration.md) for all variables.
 
 ## Architecture Diagram
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                       Your Application                       │
-│  ┌─────────────────┐         ┌─────────────────────────┐    │
-│  │    Frontend     │         │     Load Balancer       │    │
-│  │   (Next.js)     │────────▶│    (nginx/Caddy/ALB)    │    │
-│  └─────────────────┘         └───────────┬─────────────┘    │
-│                                          │                   │
-│                              ┌───────────┴───────────┐      │
-│                              │                       │      │
-│                        ┌─────▼─────┐          ┌──────▼─────┐│
-│                        │    API    │          │   Worker   ││
-│                        │ (uvicorn) │          │  (boards-  ││
-│                        │           │          │   worker)  ││
-│                        └─────┬─────┘          └──────┬─────┘│
-│                              │                       │      │
-│          ┌───────────────────┼───────────────────────┤      │
-│          │                   │                       │      │
-│    ┌─────▼─────┐       ┌─────▼─────┐          ┌─────▼─────┐ │
-│    │ PostgreSQL │       │   Redis   │          │  Storage  │ │
-│    │           │       │           │          │ (S3/GCS)  │ │
-│    └───────────┘       └───────────┘          └───────────┘ │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph App["Your Application"]
+        Frontend["Frontend<br/>(Next.js)"]
+        LB["Load Balancer<br/>(nginx/Caddy/ALB)"]
+        API["API<br/>(uvicorn)"]
+        Worker["Worker<br/>(boards-worker)"]
+
+        Frontend --> LB
+        LB --> API
+        LB --> Worker
+    end
+
+    API --> PostgreSQL["PostgreSQL"]
+    API --> Redis["Redis"]
+    API --> Storage["Storage<br/>(S3/GCS)"]
+    Worker --> PostgreSQL
+    Worker --> Redis
+    Worker --> Storage
 ```
 
 ## Pre-built Images


### PR DESCRIPTION
This pull request updates the architecture diagrams in the deployment documentation to use Mermaid diagrams instead of ASCII art. This change makes the diagrams more visually appealing, easier to maintain, and compatible with modern documentation tooling.

**Documentation improvements:**

* Replaced all ASCII art architecture diagrams with equivalent Mermaid diagrams in the following deployment guides: `cloud-run.md`, `elastic-beanstalk.md`, `railway.md`, `render.md`, `fly-io.md`, `kubernetes.md`, and `overview.md`. [[1]](diffhunk://#diff-e7578ecfa1166c7c3a8f73fe11892a611d7355a251f222a7103bf2fbcb52c44bL13-R23) [[2]](diffhunk://#diff-191c0987441f1fa30d761e7c6368b868c1b94104249528a2ba602878cc19bcdaL13-R29) [[3]](diffhunk://#diff-2f937b906e7a70d501394d2b26ad8b138b7d3e222bca7c345b05f3a25386e222L22-R35) [[4]](diffhunk://#diff-d8cef3e272e3c3949ff7fc53908660ddfcdd2341ab7d88ae37da4b24384a21cfL20-R33) [[5]](diffhunk://#diff-0cf245458268b910eeddc0ad84f005dd5842c786f85ba7c8696de6ffebb6e924L20-R44) [[6]](diffhunk://#diff-463b954e65e626716ba862cde7ec51acf24be9a11b489e8e2e131d9e06dff619L19-R47) [[7]](diffhunk://#diff-5f5981c9333e17ddb4b4a42b8f1b3ac6adf0aec893d1560551717d9f08a702f6L112-R130)