### PR TITLE
fix: resolve TypeScript linting errors in auth packages

### DIFF
--- a/packages/auth-jwt/src/JWTAuthProvider.ts
+++ b/packages/auth-jwt/src/JWTAuthProvider.ts
@@ -21,7 +21,7 @@ export class JWTAuthProvider extends BaseAuthProvider {
     this.currentState = {
       user: null,
       status: "loading",
-      signIn: this.signIn.bind(this) as any,
+      signIn: this.signIn.bind(this) as AuthState["signIn"],
       signOut: this.signOut.bind(this),
       getToken: this.getToken.bind(this),
       refreshToken: this.refreshToken.bind(this),
@@ -53,8 +53,8 @@ export class JWTAuthProvider extends BaseAuthProvider {
   async signIn(
     options?: import("@weirdfingers/boards").SignInOptions
   ): Promise<void> {
-    const email = (options as any)?.email as string | undefined;
-    const password = (options as any)?.password as string | undefined;
+    const email = options?.email as string | undefined;
+    const password = options?.password as string | undefined;
     this.updateState({ status: "loading" });
 
     try {

--- a/packages/auth-jwt/src/__tests__/JWTAuthProvider.test.ts
+++ b/packages/auth-jwt/src/__tests__/JWTAuthProvider.test.ts
@@ -18,7 +18,8 @@ Object.defineProperty(window, "localStorage", {
 });
 
 // Mock fetch
-global.fetch = vi.fn();
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
 
 describe("JWTAuthProvider", () => {
   let provider: JWTAuthProvider;
@@ -117,7 +118,7 @@ describe("JWTAuthProvider", () => {
         exp: Math.floor(Date.now() / 1000) + 3600,
       });
 
-      (fetch as any).mockResolvedValueOnce({
+      mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ token: mockToken }),
       });
@@ -152,7 +153,7 @@ describe("JWTAuthProvider", () => {
     });
 
     it("should handle sign in failure", async () => {
-      (fetch as any).mockResolvedValueOnce({
+      mockFetch.mockResolvedValueOnce({
         ok: false,
         statusText: "Unauthorized",
       });
@@ -169,7 +170,7 @@ describe("JWTAuthProvider", () => {
     });
 
     it("should handle network error", async () => {
-      (fetch as any).mockRejectedValueOnce(new Error("Network error"));
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
 
       await expect(
         provider.signIn({
@@ -180,7 +181,7 @@ describe("JWTAuthProvider", () => {
     });
 
     it("should handle missing token in response", async () => {
-      (fetch as any).mockResolvedValueOnce({
+      mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({}), // No token in response
       });
@@ -255,7 +256,7 @@ describe("JWTAuthProvider", () => {
         exp: Math.floor(Date.now() / 1000) + 3600,
       });
 
-      (fetch as any).mockResolvedValueOnce({
+      mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ token: mockToken }),
       });
@@ -317,7 +318,15 @@ describe("JWTAuthProvider", () => {
 });
 
 // Helper function to create mock JWT tokens
-function createMockJWT(payload: any): string {
+interface MockJWTPayload {
+  sub: string;
+  email?: string;
+  name?: string;
+  picture?: string;
+  exp: number;
+}
+
+function createMockJWT(payload: MockJWTPayload): string {
   const header = { alg: "HS256", typ: "JWT" };
   const encodedHeader = btoa(JSON.stringify(header));
   const encodedPayload = btoa(JSON.stringify(payload));

--- a/packages/auth-supabase/src/SupabaseAuthProvider.ts
+++ b/packages/auth-supabase/src/SupabaseAuthProvider.ts
@@ -191,7 +191,7 @@ export class SupabaseAuthProvider extends BaseAuthProvider {
       } = await this.supabase.auth.refreshSession();
       if (error) throw error;
       return session?.access_token || null;
-    } catch (_err) {
+    } catch {
       return null;
     }
   }


### PR DESCRIPTION
- Replace `any` type casts with proper types in JWTAuthProvider.ts
- Use dedicated mockFetch variable instead of `(fetch as any)` in tests
- Add MockJWTPayload interface for test helper function
- Remove unused `_err` catch parameter in SupabaseAuthProvider.ts