### PR TITLE
Run worker as a service with a health check

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -96,6 +96,8 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:8800/health || exit 1
 
 # Default command: API server
-# Override this command to run as worker:
+# Override this command to run as worker with health endpoint (recommended for Cloud Run):
+#   docker run ... boards-backend boards-worker-health --processes 1 --threads 50
+# Or without health endpoint (legacy):
 #   docker run ... boards-backend dramatiq-gevent boards.workers.actors:broker --processes 1 --threads 50
 CMD ["uvicorn", "boards.api.app:app", "--host", "0.0.0.0", "--port", "8800"]

--- a/packages/backend/pyproject.toml
+++ b/packages/backend/pyproject.toml
@@ -139,6 +139,7 @@ Changelog = "https://github.com/weirdfingers/boards/blob/main/CHANGELOG.md"
 [project.scripts]
 boards-server = "boards.cli:main"
 boards-worker = "boards.workers.cli:main"
+boards-worker-health = "boards.workers.worker_main:main"
 boards-migrate = "boards.database.cli:main"
 
 [tool.setuptools.packages.find]

--- a/packages/backend/src/boards/workers/health.py
+++ b/packages/backend/src/boards/workers/health.py
@@ -1,0 +1,71 @@
+"""
+Minimal HTTP health check server for Cloud Run compatibility.
+
+Cloud Run requires containers to listen on a port and respond to health checks.
+This module provides a lightweight HTTP server that runs alongside the dramatiq
+worker to satisfy Cloud Run's health check requirements.
+"""
+
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+
+from boards.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    """HTTP request handler that responds to health check probes."""
+
+    def do_GET(self) -> None:
+        """Handle GET requests - respond OK to /health or /."""
+        if self.path in ("/health", "/"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"OK")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Suppress default HTTP logging to avoid noise."""
+        pass
+
+
+def start_health_server(port: int | None = None) -> HTTPServer:
+    """
+    Start the health check HTTP server.
+
+    Args:
+        port: Port to listen on. Defaults to PORT env var or 8080.
+
+    Returns:
+        The running HTTPServer instance.
+    """
+    if port is None:
+        port = int(os.environ.get("PORT", 8080))
+
+    server = HTTPServer(("0.0.0.0", port), HealthHandler)
+    logger.info("Health check server started", port=port)
+    server.serve_forever()
+    return server
+
+
+def start_health_server_thread(port: int | None = None) -> Thread:
+    """
+    Start the health check server in a background daemon thread.
+
+    Args:
+        port: Port to listen on. Defaults to PORT env var or 8080.
+
+    Returns:
+        The daemon thread running the health server.
+    """
+    if port is None:
+        port = int(os.environ.get("PORT", 8080))
+
+    thread = Thread(target=start_health_server, args=(port,), daemon=True)
+    thread.start()
+    return thread

--- a/packages/backend/src/boards/workers/worker_main.py
+++ b/packages/backend/src/boards/workers/worker_main.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Combined worker entrypoint with health check server.
+
+This module starts both:
+1. A minimal HTTP health check server (for Cloud Run compatibility)
+2. The dramatiq-gevent worker (for job processing)
+
+Usage:
+    python -m boards.workers.worker_main [options]
+
+Or via the boards-worker-health console script.
+"""
+
+import os
+import subprocess
+import sys
+
+import click
+
+from boards import __version__
+from boards.logging import configure_logging, get_logger
+from boards.workers.health import start_health_server_thread
+
+logger = get_logger(__name__)
+
+
+@click.command()
+@click.option(
+    "--processes",
+    default=1,
+    type=int,
+    help="Number of worker processes (default: 1)",
+)
+@click.option(
+    "--threads",
+    default=50,
+    type=int,
+    help="Number of worker threads per process (default: 50)",
+)
+@click.option(
+    "--queues",
+    default="boards-jobs",
+    help="Comma-separated list of queues to process (default: boards-jobs)",
+)
+@click.option(
+    "--log-level",
+    default="info",
+    type=click.Choice(["debug", "info", "warning", "error"]),
+    help="Log level (default: info)",
+)
+@click.option(
+    "--health-port",
+    default=None,
+    type=int,
+    help="Health check server port (default: PORT env var or 8080)",
+)
+@click.version_option(version=__version__, prog_name="boards-worker-health")
+def main(
+    processes: int,
+    threads: int,
+    queues: str,
+    log_level: str,
+    health_port: int | None,
+) -> None:
+    """Start Boards worker with integrated health check server."""
+    # Configure logging
+    configure_logging(debug=(log_level == "debug"))
+
+    # Determine health port
+    if health_port is None:
+        health_port = int(os.environ.get("PORT", 8080))
+
+    queue_list = [q.strip() for q in queues.split(",")]
+
+    logger.info(
+        "Starting Boards worker with health server",
+        processes=processes,
+        threads=threads,
+        queues=queue_list,
+        health_port=health_port,
+        log_level=log_level,
+    )
+
+    # Start health server in background thread
+    start_health_server_thread(health_port)
+    logger.info("Health check server running", port=health_port)
+
+    # Build dramatiq-gevent command
+    cmd = [
+        "dramatiq-gevent",
+        "boards.workers.actors:broker",
+        f"--processes={processes}",
+        f"--threads={threads}",
+    ]
+
+    for queue in queue_list:
+        cmd.extend(["--queues", queue])
+
+    logger.info("Starting dramatiq-gevent worker", cmd=" ".join(cmd))
+
+    # Run dramatiq-gevent (blocking)
+    try:
+        result = subprocess.run(cmd)
+        sys.exit(result.returncode)
+    except KeyboardInterrupt:
+        logger.info("Worker shutdown requested")
+        sys.exit(0)
+    except Exception as e:
+        logger.error("Worker failed", error=str(e))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds a new health check server and entrypoint for worker processes to improve compatibility with Cloud Run. The main changes include introducing a minimal HTTP health server, a new combined worker entrypoint that runs both the health server and the worker, and updating documentation and scripts to support these changes.

**Cloud Run health check support:**

* Added `boards.workers.health` module with a minimal HTTP server that responds to `/health` for Cloud Run health checks.
* Introduced a new `boards-worker-health` entrypoint (`boards.workers.worker_main:main`) that runs both the health server and the dramatiq worker in the same process, with configurable ports and options. [[1]](diffhunk://#diff-f846887a7dca72a564118732bc0c147e3d8cde725580bd8f275f17e00bbc8013R1-R115) [[2]](diffhunk://#diff-d766c1fb150f99f72600176d9097c26f8f78d54751c5e6f402c78c2fd2a31d9cR142)

**Documentation and Dockerfile updates:**

* Updated `packages/backend/Dockerfile` comments to recommend using the new `boards-worker-health` entrypoint for worker containers in Cloud Run, and clarified legacy usage.
* Registered the `boards-worker-health` script in `pyproject.toml` so it is available as a CLI command.