### PR TITLE
Implement Bria background remover generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -17,6 +17,9 @@ generators:
   - class: "boards.generators.implementations.fal.audio.beatoven_sound_effect_generation.FalBeatovenSoundEffectGenerationGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.bria_background_remove.FalBriaBackgroundRemoveGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.audio.chatterbox_text_to_speech.FalChatterboxTextToSpeechGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -1,5 +1,6 @@
 """Fal.ai image generators."""
 
+from .bria_background_remove import FalBriaBackgroundRemoveGenerator
 from .bytedance_seedream_v45_edit import FalBytedanceSeedreamV45EditGenerator
 from .clarity_upscaler import FalClarityUpscalerGenerator
 from .crystal_upscaler import FalCrystalUpscalerGenerator
@@ -31,6 +32,7 @@ from .reve_text_to_image import FalReveTextToImageGenerator
 from .seedream_v45_text_to_image import FalSeedreamV45TextToImageGenerator
 
 __all__ = [
+    "FalBriaBackgroundRemoveGenerator",
     "FalBytedanceSeedreamV45EditGenerator",
     "FalClarityUpscalerGenerator",
     "FalCrystalUpscalerGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/image/bria_background_remove.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/bria_background_remove.py
@@ -1,0 +1,154 @@
+"""
+Bria RMBG 2.0 - Background Removal Generator.
+
+Seamless removal of backgrounds from images, ideal for professional editing tasks.
+Trained exclusively on licensed data for safe and risk-free commercial use.
+
+Based on Fal AI's fal-ai/bria/background/remove model.
+See: https://fal.ai/models/fal-ai/bria/background/remove
+"""
+
+import os
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class BriaBackgroundRemoveInput(BaseModel):
+    """Input schema for Bria background removal.
+
+    Artifact fields (like image_url) are automatically detected via type
+    introspection and resolved from generation IDs to ImageArtifact objects.
+    """
+
+    image_url: ImageArtifact = Field(description="Input image to remove background from")
+
+
+class FalBriaBackgroundRemoveGenerator(BaseGenerator):
+    """Bria RMBG 2.0 background removal generator using fal.ai."""
+
+    name = "fal-bria-background-remove"
+    artifact_type = "image"
+    description = "Fal: Bria RMBG 2.0 - Seamless background removal from images"
+
+    def get_input_schema(self) -> type[BriaBackgroundRemoveInput]:
+        return BriaBackgroundRemoveInput
+
+    async def generate(
+        self, inputs: BriaBackgroundRemoveInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Remove background from image using fal.ai bria/background/remove model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalBriaBackgroundRemoveGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifact to Fal's public storage
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal([inputs.image_url], context)
+        image_url = image_urls[0]
+
+        # Prepare arguments for fal.ai API
+        arguments = {
+            "image_url": image_url,
+        }
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/bria/background/remove",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image from result
+        # fal.ai returns: {
+        #   "image": {"url": "...", "width": ..., "height": ..., "content_type": ...}
+        # }
+        image_data = result.get("image")
+
+        if not image_data:
+            raise ValueError("No image returned from fal.ai API")
+
+        output_url = image_data.get("url")
+        if not output_url:
+            raise ValueError("Image missing URL in fal.ai response")
+
+        # Extract dimensions if available
+        width = image_data.get("width")
+        height = image_data.get("height")
+
+        # If dimensions are not in the response, use original image dimensions
+        if width is None or height is None:
+            original_width = inputs.image_url.width
+            original_height = inputs.image_url.height
+            if original_width and original_height:
+                width = original_width
+                height = original_height
+            else:
+                # Fallback to reasonable defaults
+                width = 1024
+                height = 1024
+
+        # Store the result image (background removal outputs PNG with transparency)
+        artifact = await context.store_image_result(
+            storage_url=output_url,
+            format="png",
+            width=width,
+            height=height,
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: BriaBackgroundRemoveInput) -> float:
+        """Estimate cost for background removal.
+
+        Based on typical Fal background removal model pricing.
+        """
+        # Estimated cost per background removal operation
+        return 0.02

--- a/packages/backend/tests/generators/implementations/test_bria_background_remove.py
+++ b/packages/backend/tests/generators/implementations/test_bria_background_remove.py
@@ -1,0 +1,382 @@
+"""
+Tests for FalBriaBackgroundRemoveGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.bria_background_remove import (
+    BriaBackgroundRemoveInput,
+    FalBriaBackgroundRemoveGenerator,
+)
+
+
+class TestBriaBackgroundRemoveInput:
+    """Tests for BriaBackgroundRemoveInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image_artifact = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        input_data = BriaBackgroundRemoveInput(
+            image_url=image_artifact,
+        )
+
+        assert input_data.image_url == image_artifact
+
+    def test_input_requires_image(self):
+        """Test that image_url is required."""
+        with pytest.raises(ValidationError):
+            BriaBackgroundRemoveInput()  # type: ignore[call-arg]
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalBriaBackgroundRemoveGenerator:
+    """Tests for FalBriaBackgroundRemoveGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalBriaBackgroundRemoveGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-bria-background-remove"
+        assert self.generator.artifact_type == "image"
+        assert "background" in self.generator.description.lower()
+        assert "Bria" in self.generator.description
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == BriaBackgroundRemoveInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image_artifact = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/image.png",
+                format="png",
+                width=512,
+                height=512,
+            )
+
+            input_data = BriaBackgroundRemoveInput(image_url=image_artifact)
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful(self):
+        """Test successful background removal generation."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        input_data = BriaBackgroundRemoveInput(
+            image_url=input_image,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            # Mock fal_client module
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "image": {
+                        "url": fake_output_url,
+                        "width": 512,
+                        "height": 512,
+                        "content_type": "image/png",
+                    },
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=512,
+                height=512,
+                format="png",
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    # Return a fake local file path
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            mock_fal_client.upload_file_async.assert_called_once_with("/tmp/fake_image.png")
+
+            # Verify API calls with uploaded URL
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[0][0] == "fal-ai/bria/background/remove"
+            assert call_args[1]["arguments"]["image_url"] == fake_uploaded_url
+
+    @pytest.mark.asyncio
+    async def test_generate_no_image_returned(self):
+        """Test generation fails when API returns no image."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        input_data = BriaBackgroundRemoveInput(image_url=input_image)
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})
+
+            fake_uploaded_url = "https://fal.media/files/uploaded.png"
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No image returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_uses_original_dimensions_when_not_in_response(self):
+        """Test that original image dimensions are used when API doesn't return them."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=800,
+            height=600,
+        )
+
+        input_data = BriaBackgroundRemoveInput(image_url=input_image)
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+        fake_uploaded_url = "https://fal.media/files/uploaded-input.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            # API response without width/height
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "image": {
+                        "url": fake_output_url,
+                    },
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_url)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            stored_kwargs = {}
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    stored_kwargs.update(kwargs)
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url=fake_output_url,
+                        width=kwargs.get("width", 1024),
+                        height=kwargs.get("height", 1024),
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            await self.generator.generate(input_data, DummyCtx())
+
+            # Verify that original dimensions were used
+            assert stored_kwargs["width"] == 800
+            assert stored_kwargs["height"] == 600
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_image = ImageArtifact(
+            generation_id="gen_input",
+            storage_url="https://example.com/input.png",
+            format="png",
+            width=512,
+            height=512,
+        )
+
+        input_data = BriaBackgroundRemoveInput(image_url=input_image)
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        assert cost == 0.02
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = BriaBackgroundRemoveInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "image_url" in schema["properties"]
+        # Only image_url should be required
+        assert "image_url" in schema.get("required", [])

--- a/packages/backend/tests/generators/implementations/test_bria_background_remove_live.py
+++ b/packages/backend/tests/generators/implementations/test_bria_background_remove_live.py
@@ -1,0 +1,107 @@
+"""
+Live API tests for FalBriaBackgroundRemoveGenerator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_bria_background_remove_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_bria_background_remove_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.implementations.fal.image.bria_background_remove import (
+    BriaBackgroundRemoveInput,
+    FalBriaBackgroundRemoveGenerator,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestBriaBackgroundRemoveGeneratorLive:
+    """Live API tests for FalBriaBackgroundRemoveGenerator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalBriaBackgroundRemoveGenerator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, image_resolving_context, cost_logger):
+        """
+        Test basic background removal with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses a small publicly accessible test image to minimize cost.
+        """
+        # Use a small publicly accessible test image (256x256 solid color from placeholder services)
+        test_image_url = "https://placehold.co/256x256/ff0000/ff0000.png"
+
+        # Create test image artifact
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url=test_image_url,
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        # Create minimal input
+        inputs = BriaBackgroundRemoveInput(
+            image_url=test_artifact,
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, image_resolving_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) == 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.width is not None and artifact.width > 0
+        assert artifact.height is not None and artifact.height > 0
+        assert artifact.format == "png"
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Create dummy input (artifact won't be used for estimation)
+        test_artifact = ImageArtifact(
+            generation_id="test_input",
+            storage_url="https://example.com/test.png",
+            format="png",
+            width=256,
+            height=256,
+        )
+
+        inputs = BriaBackgroundRemoveInput(image_url=test_artifact)
+        estimated_cost = await self.generator.estimate_cost(inputs)
+
+        # Verify estimate is in reasonable range
+        assert estimated_cost > 0.0
+        assert estimated_cost < 0.1  # Sanity check - should be under $0.10


### PR DESCRIPTION
## Summary
- Adds Bria Background Remove generator integration via Fal.ai
- Removes backgrounds from images using Bria AI
- Includes comprehensive unit tests and live integration tests

Cherry-picked from https://github.com/cdiddy77/angie-tryon/pull/3

## Test plan
- [x] Pre-commit hooks pass (lint, typecheck, tests)
- [ ] Manual testing with Fal.ai API credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new external fal.ai integration that uploads user-provided images and stores returned URLs; behavior depends on third-party API responses and credentials, with potential for runtime failures or unexpected outputs.
> 
> **Overview**
> Adds a new Fal.ai image generator, `FalBriaBackgroundRemoveGenerator`, to remove image backgrounds via the `fal-ai/bria/background/remove` model, including artifact upload to Fal temporary storage, external job tracking, and basic progress/log streaming.
> 
> Enables the generator in `baseline-config/generators.yaml` and exports it from the Fal image package, and adds comprehensive unit tests plus opt-in live API tests to validate success/error paths and dimension handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3cc2e5e866b7d76c34effb58ad4715d5643a36d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->