### PR TITLE
feat: add fal-nano-banana-2 generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -131,6 +131,9 @@ generators:
   - class: "boards.generators.implementations.fal.audio.minimax_speech_2_6_turbo.FalMinimaxSpeech26TurboGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.image.nano_banana_2.FalNanoBanana2Generator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.image.nano_banana_edit.FalNanoBananaEditGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/__init__.py
@@ -21,6 +21,7 @@ from .ideogram_v2 import FalIdeogramV2Generator
 from .imagen4_preview import FalImagen4PreviewGenerator
 from .imagen4_preview_fast import FalImagen4PreviewFastGenerator
 from .nano_banana import FalNanoBananaGenerator
+from .nano_banana_2 import FalNanoBanana2Generator
 from .nano_banana_edit import FalNanoBananaEditGenerator
 from .nano_banana_pro import FalNanoBananaProGenerator
 from .nano_banana_pro_edit import FalNanoBananaProEditGenerator
@@ -51,6 +52,7 @@ __all__ = [
     "FalIdeogramV2Generator",
     "FalImagen4PreviewGenerator",
     "FalImagen4PreviewFastGenerator",
+    "FalNanoBanana2Generator",
     "FalNanoBananaGenerator",
     "FalNanoBananaEditGenerator",
     "FalNanoBananaProGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/image/nano_banana_2.py
+++ b/packages/backend/src/boards/generators/implementations/fal/image/nano_banana_2.py
@@ -1,0 +1,218 @@
+"""
+fal.ai nano-banana-2 text-to-image generator.
+
+Google's state-of-the-art fast image generation model with support for
+multiple resolutions, aspect ratios, and optional web search integration.
+
+Based on Fal AI's fal-ai/nano-banana-2 model.
+See: https://fal.ai/models/fal-ai/nano-banana-2
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class NanoBanana2Input(BaseModel):
+    """Input schema for nano-banana-2 image generation."""
+
+    prompt: str = Field(
+        min_length=3,
+        max_length=50000,
+        description="The text prompt to generate an image from",
+    )
+    num_images: int = Field(
+        default=1,
+        ge=1,
+        le=4,
+        description="Number of images to generate in batch",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Random seed for reproducibility (optional)",
+    )
+    aspect_ratio: Literal[
+        "auto",
+        "21:9",
+        "16:9",
+        "3:2",
+        "4:3",
+        "5:4",
+        "1:1",
+        "4:5",
+        "3:4",
+        "2:3",
+        "9:16",
+    ] = Field(
+        default="auto",
+        description="Image aspect ratio",
+    )
+    output_format: Literal["jpeg", "png", "webp"] = Field(
+        default="png",
+        description="Output image format",
+    )
+    safety_tolerance: Literal["1", "2", "3", "4", "5", "6"] = Field(
+        default="4",
+        description="Safety tolerance level (1 = strictest, 6 = most permissive)",
+    )
+    resolution: Literal["0.5K", "1K", "2K", "4K"] = Field(
+        default="1K",
+        description="Image resolution",
+    )
+    limit_generations: bool = Field(
+        default=True,
+        description="Experimental: restrict to 1 generation per round",
+    )
+    enable_web_search: bool = Field(
+        default=False,
+        description="Allow web data to inform generation",
+    )
+    sync_mode: bool = Field(
+        default=True,
+        description="Use synchronous mode (wait for completion)",
+    )
+
+
+class FalNanoBanana2Generator(BaseGenerator):
+    """nano-banana-2 image generator using fal.ai.
+
+    Google's state-of-the-art fast image generation model with support for
+    multiple resolutions, aspect ratios, and optional web search.
+    """
+
+    name = "fal-nano-banana-2"
+    artifact_type = "image"
+    description = (
+        "Fal: nano-banana-2 - Google's fast image generation "
+        "with web search and multiple resolutions"
+    )
+
+    def get_input_schema(self) -> type[NanoBanana2Input]:
+        return NanoBanana2Input
+
+    async def generate(
+        self, inputs: NanoBanana2Input, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate images using fal.ai nano-banana-2 model."""
+        # Check for API key (fal-client uses FAL_KEY environment variable)
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalNanoBanana2Generator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Prepare arguments for fal.ai API
+        arguments: dict[str, object] = {
+            "prompt": inputs.prompt,
+            "num_images": inputs.num_images,
+            "aspect_ratio": inputs.aspect_ratio,
+            "output_format": inputs.output_format,
+            "safety_tolerance": inputs.safety_tolerance,
+            "resolution": inputs.resolution,
+            "limit_generations": inputs.limit_generations,
+            "enable_web_search": inputs.enable_web_search,
+            "sync_mode": inputs.sync_mode,
+        }
+
+        # Add seed if provided
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+
+        # Submit async job and get handler
+        handler = await fal_client.submit_async(
+            "fal-ai/nano-banana-2",
+            arguments=arguments,
+        )
+
+        # Store the external job ID for tracking
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates (sample every 3rd event to avoid spam)
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+
+            # Process every 3rd event to provide feedback without overwhelming
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,  # Approximate mid-point progress
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract image URLs from result
+        # fal.ai returns: {"images": [{"url": "...", "width": ..., "height": ...}, ...]}
+        images = result.get("images", [])
+        if not images:
+            raise ValueError("No images returned from fal.ai API")
+
+        # Store each image using output_index
+        artifacts = []
+        for idx, image_data in enumerate(images):
+            image_url = image_data.get("url")
+            width = image_data.get("width")
+            height = image_data.get("height")
+
+            if not image_url:
+                raise ValueError(f"Image {idx} missing URL in fal.ai response")
+
+            # Store with appropriate output_index
+            artifact = await context.store_image_result(
+                storage_url=image_url,
+                format=inputs.output_format,
+                width=width,
+                height=height,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: NanoBanana2Input) -> float:
+        """Estimate cost for nano-banana-2 generation.
+
+        Base cost is $0.08 per image at 1K resolution.
+        Resolution multipliers: 0.5K=0.75x, 2K=1.5x, 4K=2x.
+        Web search adds $0.015 per request.
+        """
+        resolution_multipliers = {
+            "0.5K": 0.75,
+            "1K": 1.0,
+            "2K": 1.5,
+            "4K": 2.0,
+        }
+        multiplier = resolution_multipliers.get(inputs.resolution, 1.0)
+        cost = 0.08 * multiplier * inputs.num_images
+
+        if inputs.enable_web_search:
+            cost += 0.015
+
+        return cost

--- a/packages/backend/tests/generators/implementations/test_nano_banana_2.py
+++ b/packages/backend/tests/generators/implementations/test_nano_banana_2.py
@@ -1,0 +1,703 @@
+"""
+Tests for FalNanoBanana2Generator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.image.nano_banana_2 import (
+    FalNanoBanana2Generator,
+    NanoBanana2Input,
+)
+
+
+class TestNanoBanana2Input:
+    """Tests for NanoBanana2Input schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        input_data = NanoBanana2Input(
+            prompt="A beautiful sunset over the ocean",
+            aspect_ratio="16:9",
+            num_images=2,
+            resolution="2K",
+            output_format="jpeg",
+        )
+
+        assert input_data.prompt == "A beautiful sunset over the ocean"
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.num_images == 2
+        assert input_data.resolution == "2K"
+        assert input_data.output_format == "jpeg"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = NanoBanana2Input(
+            prompt="Test prompt",
+        )
+
+        assert input_data.aspect_ratio == "auto"
+        assert input_data.num_images == 1
+        assert input_data.resolution == "1K"
+        assert input_data.output_format == "png"
+        assert input_data.safety_tolerance == "4"
+        assert input_data.limit_generations is True
+        assert input_data.enable_web_search is False
+        assert input_data.sync_mode is True
+        assert input_data.seed is None
+
+    def test_prompt_min_length(self):
+        """Test validation fails for prompt below minimum length."""
+        with pytest.raises(ValidationError):
+            NanoBanana2Input(
+                prompt="ab",  # 2 chars, minimum is 3
+            )
+
+    def test_invalid_output_format(self):
+        """Test validation fails for invalid output format."""
+        with pytest.raises(ValidationError):
+            NanoBanana2Input(
+                prompt="Test prompt",
+                output_format="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_aspect_ratio(self):
+        """Test validation fails for invalid aspect ratio."""
+        with pytest.raises(ValidationError):
+            NanoBanana2Input(
+                prompt="Test prompt",
+                aspect_ratio="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_resolution(self):
+        """Test validation fails for invalid resolution."""
+        with pytest.raises(ValidationError):
+            NanoBanana2Input(
+                prompt="Test prompt",
+                resolution="8K",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_safety_tolerance(self):
+        """Test validation fails for invalid safety tolerance."""
+        with pytest.raises(ValidationError):
+            NanoBanana2Input(
+                prompt="Test prompt",
+                safety_tolerance="7",  # type: ignore[arg-type]
+            )
+
+    def test_num_images_validation(self):
+        """Test validation for num_images constraints."""
+        # Test below minimum
+        with pytest.raises(ValidationError):
+            NanoBanana2Input(
+                prompt="Test prompt",
+                num_images=0,
+            )
+
+        # Test above maximum
+        with pytest.raises(ValidationError):
+            NanoBanana2Input(
+                prompt="Test prompt",
+                num_images=5,
+            )
+
+    def test_aspect_ratio_options(self):
+        """Test all valid aspect ratio options."""
+        valid_ratios = [
+            "auto",
+            "21:9",
+            "16:9",
+            "3:2",
+            "4:3",
+            "5:4",
+            "1:1",
+            "4:5",
+            "3:4",
+            "2:3",
+            "9:16",
+        ]
+
+        for ratio in valid_ratios:
+            input_data = NanoBanana2Input(
+                prompt="Test prompt",
+                aspect_ratio=ratio,  # type: ignore[arg-type]
+            )
+            assert input_data.aspect_ratio == ratio
+
+    def test_resolution_options(self):
+        """Test all valid resolution options."""
+        valid_resolutions = ["0.5K", "1K", "2K", "4K"]
+
+        for resolution in valid_resolutions:
+            input_data = NanoBanana2Input(
+                prompt="Test prompt",
+                resolution=resolution,  # type: ignore[arg-type]
+            )
+            assert input_data.resolution == resolution
+
+    def test_output_format_options(self):
+        """Test all valid output format options."""
+        valid_formats = ["jpeg", "png", "webp"]
+
+        for fmt in valid_formats:
+            input_data = NanoBanana2Input(
+                prompt="Test prompt",
+                output_format=fmt,  # type: ignore[arg-type]
+            )
+            assert input_data.output_format == fmt
+
+    def test_safety_tolerance_options(self):
+        """Test all valid safety tolerance options."""
+        valid_tolerances = ["1", "2", "3", "4", "5", "6"]
+
+        for tolerance in valid_tolerances:
+            input_data = NanoBanana2Input(
+                prompt="Test prompt",
+                safety_tolerance=tolerance,  # type: ignore[arg-type]
+            )
+            assert input_data.safety_tolerance == tolerance
+
+    def test_seed_optional(self):
+        """Test that seed can be set or left as None."""
+        input_with_seed = NanoBanana2Input(prompt="Test prompt", seed=42)
+        assert input_with_seed.seed == 42
+
+        input_without_seed = NanoBanana2Input(prompt="Test prompt")
+        assert input_without_seed.seed is None
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalNanoBanana2Generator:
+    """Tests for FalNanoBanana2Generator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalNanoBanana2Generator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-nano-banana-2"
+        assert self.generator.artifact_type == "image"
+        assert "nano-banana-2" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == NanoBanana2Input
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = NanoBanana2Input(
+                prompt="Test prompt",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return ImageArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        format="png",
+                    )
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_single_image(self):
+        """Test successful generation with single image output."""
+        input_data = NanoBanana2Input(
+            prompt="A beautiful landscape",
+            aspect_ratio="16:9",
+            num_images=1,
+            resolution="1K",
+            output_format="jpeg",
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": fake_output_url,
+                            "width": 1920,
+                            "height": 1080,
+                        }
+                    ],
+                    "description": "A beautiful landscape image.",
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1920,
+                height=1080,
+                format="jpeg",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify API calls
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/nano-banana-2",
+                arguments={
+                    "prompt": "A beautiful landscape",
+                    "num_images": 1,
+                    "aspect_ratio": "16:9",
+                    "output_format": "jpeg",
+                    "safety_tolerance": "4",
+                    "resolution": "1K",
+                    "limit_generations": True,
+                    "enable_web_search": False,
+                    "sync_mode": True,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_multiple_images(self):
+        """Test successful generation with multiple image outputs."""
+        input_data = NanoBanana2Input(
+            prompt="Abstract art",
+            aspect_ratio="1:1",
+            num_images=3,
+            resolution="2K",
+            output_format="png",
+        )
+
+        fake_output_urls = [
+            "https://storage.googleapis.com/falserverless/output1.png",
+            "https://storage.googleapis.com/falserverless/output2.png",
+            "https://storage.googleapis.com/falserverless/output3.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {"url": fake_output_urls[0], "width": 2048, "height": 2048},
+                        {"url": fake_output_urls[1], "width": 2048, "height": 2048},
+                        {"url": fake_output_urls[2], "width": 2048, "height": 2048},
+                    ],
+                    "description": "Abstract art images.",
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifacts = [
+                ImageArtifact(
+                    generation_id="test_gen",
+                    storage_url=url,
+                    width=2048,
+                    height=2048,
+                    format="png",
+                )
+                for url in fake_output_urls
+            ]
+
+            artifact_idx = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    nonlocal artifact_idx
+                    result = mock_artifacts[artifact_idx]
+                    artifact_idx += 1
+                    return result
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 3
+
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["num_images"] == 3
+            assert call_args[1]["arguments"]["resolution"] == "2K"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_seed(self):
+        """Test that seed is passed to API when provided."""
+        input_data = NanoBanana2Input(
+            prompt="Test prompt",
+            seed=42,
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-seed"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [
+                        {
+                            "url": "https://example.com/img.png",
+                            "width": 1024,
+                            "height": 1024,
+                        }
+                    ],
+                    "description": "",
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = ImageArtifact(
+                generation_id="test_gen",
+                storage_url="https://example.com/img.png",
+                width=1024,
+                height=1024,
+                format="png",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            await self.generator.generate(input_data, DummyCtx())
+
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["seed"] == 42
+
+    @pytest.mark.asyncio
+    async def test_generate_no_images_returned(self):
+        """Test generation fails when API returns no images."""
+        input_data = NanoBanana2Input(
+            prompt="Test prompt",
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={"images": [], "description": ""})
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No images returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_url_in_response(self):
+        """Test generation fails when image data is missing URL."""
+        input_data = NanoBanana2Input(
+            prompt="Test prompt",
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-000"
+
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "images": [{"width": 1024, "height": 1024}],  # Missing url
+                    "description": "",
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="missing URL"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation at default resolution."""
+        input_data = NanoBanana2Input(
+            prompt="Test prompt",
+            num_images=1,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # $0.08 per image at 1K resolution
+        assert cost == pytest.approx(0.08)
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_multiple_images(self):
+        """Test cost estimation for multiple images."""
+        input_data = NanoBanana2Input(
+            prompt="Test prompt",
+            num_images=4,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # $0.08 * 4 = $0.32
+        assert cost == pytest.approx(0.32)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_resolution_multipliers(self):
+        """Test cost estimation with resolution multipliers."""
+        # 0.5K = 0.75x
+        cost_05k = await self.generator.estimate_cost(
+            NanoBanana2Input(prompt="test", resolution="0.5K")
+        )
+        assert cost_05k == pytest.approx(0.08 * 0.75)
+
+        # 2K = 1.5x
+        cost_2k = await self.generator.estimate_cost(
+            NanoBanana2Input(prompt="test", resolution="2K")
+        )
+        assert cost_2k == pytest.approx(0.08 * 1.5)
+
+        # 4K = 2x
+        cost_4k = await self.generator.estimate_cost(
+            NanoBanana2Input(prompt="test", resolution="4K")
+        )
+        assert cost_4k == pytest.approx(0.08 * 2.0)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_web_search(self):
+        """Test cost estimation with web search enabled."""
+        cost = await self.generator.estimate_cost(
+            NanoBanana2Input(prompt="test", enable_web_search=True)
+        )
+
+        # $0.08 + $0.015 for web search
+        assert cost == pytest.approx(0.095)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_combined(self):
+        """Test cost estimation with multiple factors."""
+        cost = await self.generator.estimate_cost(
+            NanoBanana2Input(
+                prompt="test",
+                num_images=2,
+                resolution="4K",
+                enable_web_search=True,
+            )
+        )
+
+        # ($0.08 * 2.0 * 2) + $0.015 = $0.335
+        assert cost == pytest.approx(0.335)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = NanoBanana2Input.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "aspect_ratio" in schema["properties"]
+        assert "num_images" in schema["properties"]
+        assert "resolution" in schema["properties"]
+        assert "output_format" in schema["properties"]
+        assert "safety_tolerance" in schema["properties"]
+        assert "enable_web_search" in schema["properties"]
+        assert "limit_generations" in schema["properties"]
+
+        # Check that num_images has constraints
+        num_images_prop = schema["properties"]["num_images"]
+        assert num_images_prop["minimum"] == 1
+        assert num_images_prop["maximum"] == 4
+        assert num_images_prop["default"] == 1
+
+        # Check that prompt has length constraints
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop["minLength"] == 3
+        assert prompt_prop["maxLength"] == 50000

--- a/packages/backend/tests/generators/implementations/test_nano_banana_2_live.py
+++ b/packages/backend/tests/generators/implementations/test_nano_banana_2_live.py
@@ -1,0 +1,99 @@
+"""
+Live API tests for FalNanoBanana2Generator.
+
+These tests make actual API calls to the Fal.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_fal to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"FAL_KEY": "..."}'
+    pytest tests/generators/implementations/test_nano_banana_2_live.py -v -m live_api
+
+Or using direct environment variable:
+    export FAL_KEY="..."
+    pytest tests/generators/implementations/test_nano_banana_2_live.py -v -m live_fal
+
+Or run all Fal live tests:
+    pytest -m live_fal -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.implementations.fal.image.nano_banana_2 import (
+    FalNanoBanana2Generator,
+    NanoBanana2Input,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_fal]
+
+
+class TestNanoBanana2GeneratorLive:
+    """Live API tests for FalNanoBanana2Generator using real Fal.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = FalNanoBanana2Generator()
+        # Sync API keys from settings to os.environ for third-party SDKs
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_fal_key, dummy_context, cost_logger):
+        """
+        Test basic image generation with minimal parameters.
+
+        This test makes a real API call to Fal.ai and will consume credits.
+        Uses minimal/cheap settings to reduce cost.
+        """
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(NanoBanana2Input(prompt="test"))
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Create minimal input to reduce cost
+        inputs = NanoBanana2Input(
+            prompt="A simple red circle on white background",
+            aspect_ratio="1:1",
+            num_images=1,
+            resolution="0.5K",  # Cheapest resolution
+        )
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) >= 1
+
+        # Verify artifact properties
+        from boards.generators.artifacts import ImageArtifact
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, ImageArtifact)
+        assert artifact.storage_url is not None
+        if artifact.width is not None:
+            assert artifact.width > 0
+        if artifact.height is not None:
+            assert artifact.height > 0
+        assert artifact.format in ["jpeg", "png", "webp"]
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_batch_size(self, skip_if_no_fal_key):
+        """
+        Test that cost estimation scales with batch size.
+
+        This doesn't make an API call, just verifies the cost logic.
+        """
+        # Single image
+        inputs_1 = NanoBanana2Input(prompt="test", num_images=1)
+        cost_1 = await self.generator.estimate_cost(inputs_1)
+
+        # Four images (max)
+        inputs_4 = NanoBanana2Input(prompt="test", num_images=4)
+        cost_4 = await self.generator.estimate_cost(inputs_4)
+
+        # Cost should scale linearly with number of images
+        assert cost_4 == cost_1 * 4
+
+        # Sanity check on absolute costs
+        assert cost_1 > 0.0
+        assert cost_1 < 0.50  # Should be well under $0.50 per image


### PR DESCRIPTION
## Summary
- Add text-to-image generator for `fal-ai/nano-banana-2` (Google's fast image generation model)
- Supports: prompt, num_images (1-4), aspect_ratio (incl. auto), resolution (0.5K-4K), output_format (jpeg/png/webp), safety_tolerance (1-6), seed, web search, and limit_generations
- Cost estimation with resolution multipliers (0.5K=0.75x, 2K=1.5x, 4K=2x) and web search surcharge ($0.015)
- 27 unit tests covering input validation, generation mocking, error handling, and cost estimation
- Live API test suite for real API verification

## Files changed
- `packages/backend/src/boards/generators/implementations/fal/image/nano_banana_2.py` - Generator implementation
- `packages/backend/src/boards/generators/implementations/fal/image/__init__.py` - Module exports
- `packages/backend/baseline-config/generators.yaml` - Configuration
- `packages/backend/tests/generators/implementations/test_nano_banana_2.py` - Unit tests (27 tests)
- `packages/backend/tests/generators/implementations/test_nano_banana_2_live.py` - Live API tests

## Test plan
- [x] Typecheck passes (pyright: 0 errors)
- [x] Lint passes (ruff: 0 errors)
- [x] All 27 unit tests pass
- [ ] Live API test (requires FAL_KEY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new third-party (fal.ai) image generation integration with new request parameters and result handling; main risk is runtime failures/cost changes if fal API/SDK behavior differs from assumptions.
> 
> **Overview**
> Adds a new fal.ai image generator `FalNanoBanana2Generator` for the `fal-ai/nano-banana-2` model, including a typed `NanoBanana2Input` schema (aspect ratio, resolution, safety tolerance, web search, batching, etc.), progress streaming, and per-image artifact storage.
> 
> Registers the generator for discovery by exporting it in `fal/image/__init__.py` and enabling it in `baseline-config/generators.yaml`, and adds both mocked unit tests plus opt-in live API tests to validate integration and cost estimation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24d4626df5068f6500cc35049c15afd68c535221. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->