### PR TITLE
Seedance 1.5 generators

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -35,6 +35,12 @@ generators:
   - class: "boards.generators.implementations.fal.video.creatify_lipsync.FalCreatifyLipsyncGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.fal.video.fal_bytedance_seedance_v1_5_pro_image_to_video.FalBytedanceSeedanceV15ProImageToVideoGenerator"
+    enabled: true
+
+  - class: "boards.generators.implementations.fal.video.fal_bytedance_seedance_v1_5_pro_text_to_video.FalBytedanceSeedanceV15ProTextToVideoGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.fal.video.fal_bytedance_seedance_v1_pro_image_to_video.FalBytedanceSeedanceV1ProImageToVideoGenerator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/__init__.py
@@ -4,6 +4,12 @@ from .bytedance_seedance_v1_pro_text_to_video import (
     FalBytedanceSeedanceV1ProTextToVideoGenerator,
 )
 from .creatify_lipsync import FalCreatifyLipsyncGenerator
+from .fal_bytedance_seedance_v1_5_pro_image_to_video import (
+    FalBytedanceSeedanceV15ProImageToVideoGenerator,
+)
+from .fal_bytedance_seedance_v1_5_pro_text_to_video import (
+    FalBytedanceSeedanceV15ProTextToVideoGenerator,
+)
 from .fal_bytedance_seedance_v1_pro_image_to_video import (
     FalBytedanceSeedanceV1ProImageToVideoGenerator,
 )
@@ -51,6 +57,8 @@ from .wan_pro_image_to_video import FalWanProImageToVideoGenerator
 __all__ = [
     "FalInfinitalkGenerator",
     "FalCreatifyLipsyncGenerator",
+    "FalBytedanceSeedanceV15ProImageToVideoGenerator",
+    "FalBytedanceSeedanceV15ProTextToVideoGenerator",
     "FalBytedanceSeedanceV1ProImageToVideoGenerator",
     "FalBytedanceSeedanceV1ProTextToVideoGenerator",
     "FalKlingVideoAiAvatarV2ProGenerator",

--- a/packages/backend/src/boards/generators/implementations/fal/video/fal_bytedance_seedance_v1_5_pro_image_to_video.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/fal_bytedance_seedance_v1_5_pro_image_to_video.py
@@ -1,0 +1,214 @@
+"""
+ByteDance SeedDance v1.5 Pro image-to-video generator.
+
+A high quality video generation model developed by ByteDance that converts static
+images into dynamic videos based on textual descriptions, with native audio generation.
+
+Based on Fal AI's fal-ai/bytedance/seedance/v1.5/pro/image-to-video model.
+See: https://fal.ai/models/fal-ai/bytedance/seedance/v1.5/pro/image-to-video
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import ImageArtifact
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class BytedanceSeedanceV15ProImageToVideoInput(BaseModel):
+    """Input schema for ByteDance SeedDance v1.5 Pro image-to-video generation.
+
+    Artifact fields (image, end_image) are automatically detected via type
+    introspection and resolved from generation IDs to ImageArtifact objects.
+    """
+
+    prompt: str = Field(description="Text description for video generation")
+    image: ImageArtifact = Field(description="Source image for conversion to video")
+    aspect_ratio: Literal["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"] = Field(
+        default="16:9",
+        description="Aspect ratio of the generated video",
+    )
+    resolution: Literal["480p", "720p"] = Field(
+        default="720p",
+        description="Resolution of the generated video",
+    )
+    duration: int = Field(
+        default=5,
+        ge=4,
+        le=12,
+        description="Duration of the generated video in seconds (4-12)",
+    )
+    end_image: ImageArtifact | None = Field(
+        default=None,
+        description="Optional ending frame image for directional guidance",
+    )
+    generate_audio: bool = Field(
+        default=True,
+        description="Enable native audio generation for the video",
+    )
+    camera_fixed: bool = Field(
+        default=False,
+        description="Lock camera position to prevent camera movement",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Random seed for reproducible results. Use -1 for random seed",
+    )
+
+
+class FalBytedanceSeedanceV15ProImageToVideoGenerator(BaseGenerator):
+    """Generator for converting images to videos using ByteDance SeedDance v1.5 Pro."""
+
+    name = "fal-bytedance-seedance-v1-5-pro-image-to-video"
+    description = (
+        "Fal: SeedDance v1.5 Pro - High quality image-to-video generation with audio by ByteDance"
+    )
+    artifact_type = "video"
+
+    def get_input_schema(self) -> type[BytedanceSeedanceV15ProImageToVideoInput]:
+        """Return the input schema for this generator."""
+        return BytedanceSeedanceV15ProImageToVideoInput
+
+    async def generate(
+        self, inputs: BytedanceSeedanceV15ProImageToVideoInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate video using fal.ai bytedance/seedance/v1.5/pro/image-to-video."""
+        # Check for API key
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalBytedanceSeedanceV15ProImageToVideoGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Upload image artifacts to Fal's public storage
+        # Fal API requires publicly accessible URLs
+        from ..utils import upload_artifacts_to_fal
+
+        image_urls = await upload_artifacts_to_fal([inputs.image], context)
+
+        # Prepare arguments for fal.ai API
+        arguments: dict = {
+            "prompt": inputs.prompt,
+            "image_url": image_urls[0],
+            "aspect_ratio": inputs.aspect_ratio,
+            "resolution": inputs.resolution,
+            "duration": inputs.duration,
+            "generate_audio": inputs.generate_audio,
+            "camera_fixed": inputs.camera_fixed,
+        }
+
+        # Upload end image if provided
+        if inputs.end_image is not None:
+            end_image_urls = await upload_artifacts_to_fal([inputs.end_image], context)
+            arguments["end_image_url"] = end_image_urls[0]
+
+        # Add seed if provided
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+
+        # Submit async job
+        handler = await fal_client.submit_async(
+            "fal-ai/bytedance/seedance/v1.5/pro/image-to-video",
+            arguments=arguments,
+        )
+
+        # Store external job ID
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+            # Sample every 3rd event to avoid spam
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract video from result
+        # Expected structure: {"video": {"url": "...", "content_type": "...", ...}, "seed": 123}
+        video_data = result.get("video")
+        if not video_data:
+            raise ValueError("No video returned from fal.ai API")
+
+        video_url = video_data.get("url")
+        if not video_url:
+            raise ValueError("Video missing URL in fal.ai response")
+
+        # Determine video dimensions based on resolution
+        resolution_map = {
+            "480p": (854, 480),
+            "720p": (1280, 720),
+        }
+        width, height = resolution_map.get(inputs.resolution, (1280, 720))
+
+        # Store video result
+        artifact = await context.store_video_result(
+            storage_url=video_url,
+            format="mp4",
+            width=width,
+            height=height,
+            duration=inputs.duration,
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    async def estimate_cost(self, inputs: BytedanceSeedanceV15ProImageToVideoInput) -> float:
+        """Estimate cost for this generation in USD.
+
+        Based on fal.ai pricing for Seedance v1.5 Pro:
+        - With audio: $2.4 per 1M video tokens
+        - Without audio: $1.2 per 1M video tokens
+
+        Formula: tokens(video) = (height x width x FPS x duration) / 1024
+        """
+        # Resolution mapping
+        resolution_map = {
+            "480p": (854, 480),
+            "720p": (1280, 720),
+        }
+        width, height = resolution_map.get(inputs.resolution, (1280, 720))
+
+        # Assume 30 FPS for video generation
+        fps = 30
+
+        # Calculate video tokens
+        tokens = (height * width * fps * inputs.duration) / 1024
+
+        # Price per million tokens depends on audio
+        price_per_million_tokens = 2.4 if inputs.generate_audio else 1.2
+
+        # Calculate cost
+        cost = (tokens / 1_000_000) * price_per_million_tokens
+
+        return cost

--- a/packages/backend/src/boards/generators/implementations/fal/video/fal_bytedance_seedance_v1_5_pro_text_to_video.py
+++ b/packages/backend/src/boards/generators/implementations/fal/video/fal_bytedance_seedance_v1_5_pro_text_to_video.py
@@ -1,0 +1,220 @@
+"""
+ByteDance SeedDance v1.5 Pro text-to-video generator.
+
+A high quality video generation model developed by ByteDance that transforms
+text prompts into professional-grade videos with native audio generation.
+
+Based on Fal AI's fal-ai/bytedance/seedance/v1.5/pro/text-to-video model.
+See: https://fal.ai/models/fal-ai/bytedance/seedance/v1.5/pro/text-to-video
+"""
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....base import BaseGenerator, GeneratorExecutionContext, GeneratorResult
+
+
+class BytedanceSeedanceV15ProTextToVideoInput(BaseModel):
+    """Input schema for ByteDance SeedDance v1.5 Pro text-to-video generation."""
+
+    prompt: str = Field(
+        description="Text description of the desired video content",
+    )
+    aspect_ratio: Literal["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"] = Field(
+        default="16:9",
+        description="Video aspect ratio",
+    )
+    resolution: Literal["480p", "720p", "1080p"] = Field(
+        default="720p",
+        description="Video resolution quality",
+    )
+    duration: int = Field(
+        default=5,
+        ge=4,
+        le=12,
+        description="Video length in seconds (4-12)",
+    )
+    generate_audio: bool = Field(
+        default=True,
+        description="Enable native audio generation for the video",
+    )
+    enable_safety_checker: bool = Field(
+        default=True,
+        description="Enable safety checker to filter unsafe content",
+    )
+    camera_fixed: bool = Field(
+        default=False,
+        description="Lock camera position to prevent camera movement",
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Random seed for reproducibility; use -1 for randomization",
+    )
+
+
+class FalBytedanceSeedanceV15ProTextToVideoGenerator(BaseGenerator):
+    """Generator for text-to-video using ByteDance SeedDance v1.5 Pro."""
+
+    name = "fal-bytedance-seedance-v1-5-pro-text-to-video"
+    description = (
+        "Fal: SeedDance v1.5 Pro - High quality text-to-video generation with audio by ByteDance"
+    )
+    artifact_type = "video"
+
+    def get_input_schema(self) -> type[BytedanceSeedanceV15ProTextToVideoInput]:
+        """Return the input schema for this generator."""
+        return BytedanceSeedanceV15ProTextToVideoInput
+
+    async def generate(
+        self, inputs: BytedanceSeedanceV15ProTextToVideoInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate video using fal.ai bytedance/seedance/v1.5/pro/text-to-video."""
+        # Check for API key
+        if not os.getenv("FAL_KEY"):
+            raise ValueError("API configuration invalid. Missing FAL_KEY environment variable")
+
+        # Import fal_client
+        try:
+            import fal_client
+        except ImportError as e:
+            raise ImportError(
+                "fal.ai SDK is required for FalBytedanceSeedanceV15ProTextToVideoGenerator. "
+                "Install with: pip install weirdfingers-boards[generators-fal]"
+            ) from e
+
+        # Prepare arguments for fal.ai API
+        arguments: dict = {
+            "prompt": inputs.prompt,
+            "aspect_ratio": inputs.aspect_ratio,
+            "resolution": inputs.resolution,
+            "duration": inputs.duration,
+            "generate_audio": inputs.generate_audio,
+            "enable_safety_checker": inputs.enable_safety_checker,
+            "camera_fixed": inputs.camera_fixed,
+        }
+
+        # Add seed if provided
+        if inputs.seed is not None:
+            arguments["seed"] = inputs.seed
+
+        # Submit async job
+        handler = await fal_client.submit_async(
+            "fal-ai/bytedance/seedance/v1.5/pro/text-to-video",
+            arguments=arguments,
+        )
+
+        # Store external job ID
+        await context.set_external_job_id(handler.request_id)
+
+        # Stream progress updates
+        from .....progress.models import ProgressUpdate
+
+        event_count = 0
+        async for event in handler.iter_events(with_logs=True):
+            event_count += 1
+            # Sample every 3rd event to avoid spam
+            if event_count % 3 == 0:
+                # Extract logs if available
+                logs = getattr(event, "logs", None)
+                if logs:
+                    # Join log entries into a single message
+                    if isinstance(logs, list):
+                        message = " | ".join(str(log) for log in logs if log)
+                    else:
+                        message = str(logs)
+
+                    if message:
+                        await context.publish_progress(
+                            ProgressUpdate(
+                                job_id=handler.request_id,
+                                status="processing",
+                                progress=50.0,
+                                phase="processing",
+                                message=message,
+                            )
+                        )
+
+        # Get final result
+        result = await handler.get()
+
+        # Extract video from result
+        # Expected structure: {"video": {"url": "...", "content_type": "...", ...}, "seed": 123}
+        video_data = result.get("video")
+        if not video_data:
+            raise ValueError("No video returned from fal.ai API")
+
+        video_url = video_data.get("url")
+        if not video_url:
+            raise ValueError("Video missing URL in fal.ai response")
+
+        # Calculate video dimensions based on aspect ratio and resolution
+        width, height = self._calculate_dimensions(inputs.aspect_ratio, inputs.resolution)
+
+        # Store video result
+        artifact = await context.store_video_result(
+            storage_url=video_url,
+            format="mp4",
+            width=width,
+            height=height,
+            duration=float(inputs.duration),
+            output_index=0,
+        )
+
+        return GeneratorResult(outputs=[artifact])
+
+    def _calculate_dimensions(self, aspect_ratio: str, resolution: str) -> tuple[int, int]:
+        """Calculate video dimensions based on aspect ratio and resolution.
+
+        Args:
+            aspect_ratio: Video aspect ratio (e.g., "16:9", "21:9")
+            resolution: Video resolution (e.g., "1080p", "720p", "480p")
+
+        Returns:
+            Tuple of (width, height) in pixels
+        """
+        # Base heights for each resolution
+        resolution_heights = {
+            "1080p": 1080,
+            "720p": 720,
+            "480p": 480,
+        }
+
+        # Parse aspect ratio
+        aspect_parts = aspect_ratio.split(":")
+        aspect_width = int(aspect_parts[0])
+        aspect_height = int(aspect_parts[1])
+
+        # Get base height for resolution
+        height = resolution_heights[resolution]
+
+        # Calculate width based on aspect ratio
+        width = int((height * aspect_width) / aspect_height)
+
+        return width, height
+
+    async def estimate_cost(self, inputs: BytedanceSeedanceV15ProTextToVideoInput) -> float:
+        """Estimate cost for this generation in USD.
+
+        Based on fal.ai pricing for Seedance v1.5 Pro:
+        - With audio: $2.4 per 1M video tokens
+        - Without audio: $1.2 per 1M video tokens
+
+        Formula: tokens(video) = (height x width x FPS x duration) / 1024
+        """
+        width, height = self._calculate_dimensions(inputs.aspect_ratio, inputs.resolution)
+
+        # Assume 30 FPS for video generation
+        fps = 30
+
+        # Calculate video tokens
+        tokens = (height * width * fps * inputs.duration) / 1024
+
+        # Price per million tokens depends on audio
+        price_per_million_tokens = 2.4 if inputs.generate_audio else 1.2
+
+        # Calculate cost
+        cost = (tokens / 1_000_000) * price_per_million_tokens
+
+        return cost

--- a/packages/backend/tests/generators/implementations/test_fal_bytedance_seedance_v1_5_pro_image_to_video.py
+++ b/packages/backend/tests/generators/implementations/test_fal_bytedance_seedance_v1_5_pro_image_to_video.py
@@ -1,0 +1,796 @@
+"""
+Tests for FalBytedanceSeedanceV15ProImageToVideoGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import ImageArtifact, VideoArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.video.fal_bytedance_seedance_v1_5_pro_image_to_video import (  # noqa: E501
+    BytedanceSeedanceV15ProImageToVideoInput,
+    FalBytedanceSeedanceV15ProImageToVideoGenerator,
+)
+
+
+class TestBytedanceSeedanceV15ProImageToVideoInput:
+    """Tests for BytedanceSeedanceV15ProImageToVideoInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1920,
+            height=1080,
+        )
+
+        input_data = BytedanceSeedanceV15ProImageToVideoInput(
+            prompt="A skier glides over fresh snow",
+            image=image,
+            aspect_ratio="16:9",
+            resolution="720p",
+            duration=5,
+            generate_audio=True,
+            camera_fixed=False,
+            seed=42,
+        )
+
+        assert input_data.prompt == "A skier glides over fresh snow"
+        assert input_data.image == image
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.resolution == "720p"
+        assert input_data.duration == 5
+        assert input_data.generate_audio is True
+        assert input_data.camera_fixed is False
+        assert input_data.seed == 42
+        assert input_data.end_image is None
+
+    def test_input_defaults(self):
+        """Test default values."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedanceV15ProImageToVideoInput(
+            prompt="Test prompt",
+            image=image,
+        )
+
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.resolution == "720p"
+        assert input_data.duration == 5
+        assert input_data.generate_audio is True
+        assert input_data.camera_fixed is False
+        assert input_data.seed is None
+        assert input_data.end_image is None
+
+    def test_input_with_end_image(self):
+        """Test input with optional end image."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+        end_image = ImageArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/end.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedanceV15ProImageToVideoInput(
+            prompt="Smooth transition",
+            image=image,
+            end_image=end_image,
+        )
+
+        assert input_data.end_image == end_image
+
+    def test_invalid_aspect_ratio(self):
+        """Test validation fails for invalid aspect ratio."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            BytedanceSeedanceV15ProImageToVideoInput(
+                prompt="Test",
+                image=image,
+                aspect_ratio="auto",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_resolution(self):
+        """Test validation fails for invalid resolution."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            BytedanceSeedanceV15ProImageToVideoInput(
+                prompt="Test",
+                image=image,
+                resolution="1080p",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_duration_too_low(self):
+        """Test validation fails for duration below minimum."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            BytedanceSeedanceV15ProImageToVideoInput(
+                prompt="Test",
+                image=image,
+                duration=2,
+            )
+
+    def test_invalid_duration_too_high(self):
+        """Test validation fails for duration above maximum."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        with pytest.raises(ValidationError):
+            BytedanceSeedanceV15ProImageToVideoInput(
+                prompt="Test",
+                image=image,
+                duration=15,
+            )
+
+    def test_aspect_ratio_options(self):
+        """Test all valid aspect ratio options."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_ratios = ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
+
+        for ratio in valid_ratios:
+            input_data = BytedanceSeedanceV15ProImageToVideoInput(
+                prompt="Test",
+                image=image,
+                aspect_ratio=ratio,  # type: ignore[arg-type]
+            )
+            assert input_data.aspect_ratio == ratio
+
+    def test_resolution_options(self):
+        """Test all valid resolution options."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        valid_resolutions = ["480p", "720p"]
+
+        for resolution in valid_resolutions:
+            input_data = BytedanceSeedanceV15ProImageToVideoInput(
+                prompt="Test",
+                image=image,
+                resolution=resolution,  # type: ignore[arg-type]
+            )
+            assert input_data.resolution == resolution
+
+    def test_duration_range(self):
+        """Test valid duration values (4-12)."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        for duration in range(4, 13):
+            input_data = BytedanceSeedanceV15ProImageToVideoInput(
+                prompt="Test",
+                image=image,
+                duration=duration,
+            )
+            assert input_data.duration == duration
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalBytedanceSeedanceV15ProImageToVideoGenerator:
+    """Tests for FalBytedanceSeedanceV15ProImageToVideoGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalBytedanceSeedanceV15ProImageToVideoGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-bytedance-seedance-v1-5-pro-image-to-video"
+        assert self.generator.artifact_type == "video"
+        assert "SeedDance" in self.generator.description
+        assert "v1.5" in self.generator.description
+        assert "image-to-video" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == BytedanceSeedanceV15ProImageToVideoInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            image = ImageArtifact(
+                generation_id="gen1",
+                storage_url="https://example.com/image.png",
+                format="png",
+                width=1024,
+                height=768,
+            )
+
+            input_data = BytedanceSeedanceV15ProImageToVideoInput(
+                prompt="Test prompt",
+                image=image,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return VideoArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        duration=1,
+                        format="mp4",
+                        fps=None,
+                    )
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_720p(self):
+        """Test successful generation with 720p resolution."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1280,
+            height=720,
+        )
+
+        input_data = BytedanceSeedanceV15ProImageToVideoInput(
+            prompt="A skier glides over fresh snow",
+            image=image,
+            resolution="720p",
+            aspect_ratio="16:9",
+            duration=5,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.mp4"
+        fake_uploaded_image = "https://fal.media/files/image.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+
+            # Create async iterator that yields nothing (no events)
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+
+            # Mock the get() method to return result
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                        "file_name": "output.mp4",
+                        "file_size": 2048000,
+                    },
+                    "seed": 12345,
+                }
+            )
+
+            # Mock file upload
+            async def mock_upload(file_path):
+                return fake_uploaded_image
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1280,
+                height=720,
+                duration=5,
+                format="mp4",
+                fps=None,
+            )
+
+            # Execute generation
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify file upload was called
+            assert mock_fal_client.upload_file_async.call_count == 1
+
+            # Verify API call with uploaded URL
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/bytedance/seedance/v1.5/pro/image-to-video",
+                arguments={
+                    "prompt": "A skier glides over fresh snow",
+                    "image_url": fake_uploaded_image,
+                    "aspect_ratio": "16:9",
+                    "resolution": "720p",
+                    "duration": 5,
+                    "generate_audio": True,
+                    "camera_fixed": False,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_with_end_image(self):
+        """Test successful generation with end image."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1280,
+            height=720,
+        )
+        end_image = ImageArtifact(
+            generation_id="gen2",
+            storage_url="https://example.com/end.png",
+            format="png",
+            width=1280,
+            height=720,
+        )
+
+        input_data = BytedanceSeedanceV15ProImageToVideoInput(
+            prompt="Smooth transition",
+            image=image,
+            end_image=end_image,
+            resolution="720p",
+            duration=8,
+            seed=42,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.mp4"
+        fake_uploaded_urls = [
+            "https://fal.media/files/image.png",
+            "https://fal.media/files/end.png",
+        ]
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                    },
+                    "seed": 42,
+                }
+            )
+
+            upload_call_count = 0
+
+            async def mock_upload(file_path):
+                nonlocal upload_call_count
+                url = fake_uploaded_urls[upload_call_count]
+                upload_call_count += 1
+                return url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1280,
+                height=720,
+                duration=8,
+                format="mp4",
+                fps=None,
+            )
+
+            resolve_call_count = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    nonlocal resolve_call_count
+                    path = f"/tmp/fake_image_{resolve_call_count}.png"
+                    resolve_call_count += 1
+                    return path
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify file uploads were called for both images
+            assert mock_fal_client.upload_file_async.call_count == 2
+
+            # Verify API call includes end_image_url and seed
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["end_image_url"] == fake_uploaded_urls[1]
+            assert call_args[1]["arguments"]["seed"] == 42
+            assert call_args[1]["arguments"]["duration"] == 8
+
+    @pytest.mark.asyncio
+    async def test_generate_without_audio(self):
+        """Test generation with audio disabled."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1280,
+            height=720,
+        )
+
+        input_data = BytedanceSeedanceV15ProImageToVideoInput(
+            prompt="Silent scene",
+            image=image,
+            generate_audio=False,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.mp4"
+        fake_uploaded_image = "https://fal.media/files/image.png"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {"url": fake_output_url, "content_type": "video/mp4"},
+                    "seed": 99,
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(return_value=fake_uploaded_image)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1280,
+                height=720,
+                duration=5,
+                format="mp4",
+                fps=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            await self.generator.generate(input_data, DummyCtx())
+
+            # Verify generate_audio=False was passed
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["generate_audio"] is False
+
+    @pytest.mark.asyncio
+    async def test_generate_no_video_returned(self):
+        """Test generation fails when API returns no video."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1024,
+            height=768,
+        )
+
+        input_data = BytedanceSeedanceV15ProImageToVideoInput(
+            prompt="test",
+            image=image,
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})  # No video field
+
+            fake_uploaded_url = "https://fal.media/files/image.png"
+
+            async def mock_upload(file_path):
+                return fake_uploaded_url
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            mock_fal_client.upload_file_async = AsyncMock(side_effect=mock_upload)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No video returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_720p_5s_with_audio(self):
+        """Test cost estimation for 720p 5-second video with audio."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1280,
+            height=720,
+        )
+
+        input_data = BytedanceSeedanceV15ProImageToVideoInput(
+            prompt="Test prompt",
+            image=image,
+            resolution="720p",
+            duration=5,
+            generate_audio=True,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # tokens = (1280 * 720 * 30 * 5) / 1024 = 135000
+        # cost = (135000 / 1_000_000) * 2.4 = 0.324
+        expected_cost = 0.324
+        assert abs(cost - expected_cost) < 0.001
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_720p_5s_without_audio(self):
+        """Test cost estimation for 720p 5-second video without audio."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=1280,
+            height=720,
+        )
+
+        input_data = BytedanceSeedanceV15ProImageToVideoInput(
+            prompt="Test prompt",
+            image=image,
+            resolution="720p",
+            duration=5,
+            generate_audio=False,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # tokens = (1280 * 720 * 30 * 5) / 1024 = 135000
+        # cost = (135000 / 1_000_000) * 1.2 = 0.162
+        expected_cost = 0.162
+        assert abs(cost - expected_cost) < 0.001
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_480p_12s(self):
+        """Test cost estimation for 480p 12-second video with audio."""
+        image = ImageArtifact(
+            generation_id="gen1",
+            storage_url="https://example.com/image.png",
+            format="png",
+            width=854,
+            height=480,
+        )
+
+        input_data = BytedanceSeedanceV15ProImageToVideoInput(
+            prompt="Test prompt",
+            image=image,
+            resolution="480p",
+            duration=12,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # tokens = (854 * 480 * 30 * 12) / 1024 = 144506.25
+        # cost = (144506.25 / 1_000_000) * 2.4 = 0.346815
+        expected_cost = 0.346815
+        assert abs(cost - expected_cost) < 0.001
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = BytedanceSeedanceV15ProImageToVideoInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "image" in schema["properties"]
+        assert "aspect_ratio" in schema["properties"]
+        assert "resolution" in schema["properties"]
+        assert "duration" in schema["properties"]
+        assert "end_image" in schema["properties"]
+        assert "generate_audio" in schema["properties"]
+        assert "camera_fixed" in schema["properties"]
+        assert "seed" in schema["properties"]
+
+        # Check that required fields are marked
+        assert set(schema["required"]) == {"prompt", "image"}
+
+        # Check defaults
+        assert schema["properties"]["aspect_ratio"]["default"] == "16:9"
+        assert schema["properties"]["resolution"]["default"] == "720p"
+        assert schema["properties"]["duration"]["default"] == 5
+        assert schema["properties"]["generate_audio"]["default"] is True
+        assert schema["properties"]["camera_fixed"]["default"] is False

--- a/packages/backend/tests/generators/implementations/test_fal_bytedance_seedance_v1_5_pro_text_to_video.py
+++ b/packages/backend/tests/generators/implementations/test_fal_bytedance_seedance_v1_5_pro_text_to_video.py
@@ -1,0 +1,505 @@
+"""
+Tests for FalBytedanceSeedanceV15ProTextToVideoGenerator.
+"""
+
+import os
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import VideoArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.fal.video.fal_bytedance_seedance_v1_5_pro_text_to_video import (  # noqa: E501
+    BytedanceSeedanceV15ProTextToVideoInput,
+    FalBytedanceSeedanceV15ProTextToVideoGenerator,
+)
+
+
+class TestBytedanceSeedanceV15ProTextToVideoInput:
+    """Tests for BytedanceSeedanceV15ProTextToVideoInput schema."""
+
+    def test_valid_input(self):
+        """Test valid input creation."""
+        input_data = BytedanceSeedanceV15ProTextToVideoInput(
+            prompt="A skier glides over fresh snow",
+            aspect_ratio="16:9",
+            resolution="720p",
+            duration=5,
+            generate_audio=True,
+            camera_fixed=False,
+            seed=42,
+        )
+
+        assert input_data.prompt == "A skier glides over fresh snow"
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.resolution == "720p"
+        assert input_data.duration == 5
+        assert input_data.generate_audio is True
+        assert input_data.enable_safety_checker is True
+        assert input_data.camera_fixed is False
+        assert input_data.seed == 42
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = BytedanceSeedanceV15ProTextToVideoInput(
+            prompt="Test prompt",
+        )
+
+        assert input_data.aspect_ratio == "16:9"
+        assert input_data.resolution == "720p"
+        assert input_data.duration == 5
+        assert input_data.generate_audio is True
+        assert input_data.enable_safety_checker is True
+        assert input_data.camera_fixed is False
+        assert input_data.seed is None
+
+    def test_invalid_aspect_ratio(self):
+        """Test validation fails for invalid aspect ratio."""
+        with pytest.raises(ValidationError):
+            BytedanceSeedanceV15ProTextToVideoInput(
+                prompt="Test",
+                aspect_ratio="auto",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_resolution(self):
+        """Test validation fails for invalid resolution."""
+        with pytest.raises(ValidationError):
+            BytedanceSeedanceV15ProTextToVideoInput(
+                prompt="Test",
+                resolution="4k",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_duration_too_low(self):
+        """Test validation fails for duration below minimum."""
+        with pytest.raises(ValidationError):
+            BytedanceSeedanceV15ProTextToVideoInput(
+                prompt="Test",
+                duration=2,
+            )
+
+    def test_invalid_duration_too_high(self):
+        """Test validation fails for duration above maximum."""
+        with pytest.raises(ValidationError):
+            BytedanceSeedanceV15ProTextToVideoInput(
+                prompt="Test",
+                duration=15,
+            )
+
+    def test_aspect_ratio_options(self):
+        """Test all valid aspect ratio options."""
+        valid_ratios = ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
+
+        for ratio in valid_ratios:
+            input_data = BytedanceSeedanceV15ProTextToVideoInput(
+                prompt="Test",
+                aspect_ratio=ratio,  # type: ignore[arg-type]
+            )
+            assert input_data.aspect_ratio == ratio
+
+    def test_resolution_options(self):
+        """Test all valid resolution options."""
+        valid_resolutions = ["480p", "720p", "1080p"]
+
+        for resolution in valid_resolutions:
+            input_data = BytedanceSeedanceV15ProTextToVideoInput(
+                prompt="Test",
+                resolution=resolution,  # type: ignore[arg-type]
+            )
+            assert input_data.resolution == resolution
+
+    def test_duration_range(self):
+        """Test valid duration values (4-12)."""
+        for duration in range(4, 13):
+            input_data = BytedanceSeedanceV15ProTextToVideoInput(
+                prompt="Test",
+                duration=duration,
+            )
+            assert input_data.duration == duration
+
+
+async def _empty_async_event_iterator():
+    """Helper to create an empty async iterator for mock event streams."""
+    if False:
+        yield  # Makes this an async generator
+
+
+class TestFalBytedanceSeedanceV15ProTextToVideoGenerator:
+    """Tests for FalBytedanceSeedanceV15ProTextToVideoGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = FalBytedanceSeedanceV15ProTextToVideoGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "fal-bytedance-seedance-v1-5-pro-text-to-video"
+        assert self.generator.artifact_type == "video"
+        assert "SeedDance" in self.generator.description
+        assert "v1.5" in self.generator.description
+        assert "text-to-video" in self.generator.description.lower()
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == BytedanceSeedanceV15ProTextToVideoInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = BytedanceSeedanceV15ProTextToVideoInput(
+                prompt="Test prompt",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return VideoArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        duration=1,
+                        format="mp4",
+                        fps=None,
+                    )
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="FAL_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_successful_720p(self):
+        """Test successful generation with 720p resolution."""
+        input_data = BytedanceSeedanceV15ProTextToVideoInput(
+            prompt="A skier glides over fresh snow",
+            resolution="720p",
+            aspect_ratio="16:9",
+            duration=5,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.mp4"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            # Create mock handler with async iterator for events
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-123"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {
+                        "url": fake_output_url,
+                        "content_type": "video/mp4",
+                        "file_name": "output.mp4",
+                        "file_size": 2048000,
+                    },
+                    "seed": 12345,
+                }
+            )
+
+            # Create mock fal_client module
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            # Mock storage result
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=1280,
+                height=720,
+                duration=5,
+                format="mp4",
+                fps=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return "/tmp/fake_image.png"
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+            # Verify API call
+            mock_fal_client.submit_async.assert_called_once_with(
+                "fal-ai/bytedance/seedance/v1.5/pro/text-to-video",
+                arguments={
+                    "prompt": "A skier glides over fresh snow",
+                    "aspect_ratio": "16:9",
+                    "resolution": "720p",
+                    "duration": 5,
+                    "generate_audio": True,
+                    "enable_safety_checker": True,
+                    "camera_fixed": False,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_with_seed_and_1080p(self):
+        """Test successful generation with seed and 1080p resolution."""
+        input_data = BytedanceSeedanceV15ProTextToVideoInput(
+            prompt="Ocean waves at sunset",
+            resolution="1080p",
+            aspect_ratio="21:9",
+            duration=8,
+            seed=42,
+            generate_audio=False,
+        )
+
+        fake_output_url = "https://storage.googleapis.com/falserverless/output.mp4"
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-456"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(
+                return_value={
+                    "video": {"url": fake_output_url, "content_type": "video/mp4"},
+                    "seed": 42,
+                }
+            )
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_output_url,
+                width=2520,
+                height=1080,
+                duration=8,
+                format="mp4",
+                fps=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            result = await self.generator.generate(input_data, DummyCtx())
+
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+
+            # Verify API call includes seed and audio disabled
+            call_args = mock_fal_client.submit_async.call_args
+            assert call_args[1]["arguments"]["seed"] == 42
+            assert call_args[1]["arguments"]["generate_audio"] is False
+            assert call_args[1]["arguments"]["duration"] == 8
+            assert call_args[1]["arguments"]["resolution"] == "1080p"
+
+    @pytest.mark.asyncio
+    async def test_generate_no_video_returned(self):
+        """Test generation fails when API returns no video."""
+        input_data = BytedanceSeedanceV15ProTextToVideoInput(
+            prompt="test",
+        )
+
+        with patch.dict(os.environ, {"FAL_KEY": "fake-key"}):
+            import sys
+
+            mock_handler = MagicMock()
+            mock_handler.request_id = "test-request-789"
+            mock_handler.iter_events = MagicMock(return_value=_empty_async_event_iterator())
+            mock_handler.get = AsyncMock(return_value={})  # No video field
+
+            mock_fal_client = ModuleType("fal_client")
+            mock_fal_client.submit_async = AsyncMock(return_value=mock_handler)  # type: ignore[attr-defined]
+            sys.modules["fal_client"] = mock_fal_client
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="No video returned"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_720p_5s_with_audio(self):
+        """Test cost estimation for 720p 5-second video with audio."""
+        input_data = BytedanceSeedanceV15ProTextToVideoInput(
+            prompt="Test prompt",
+            resolution="720p",
+            duration=5,
+            generate_audio=True,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # tokens = (1280 * 720 * 30 * 5) / 1024 = 135000
+        # cost = (135000 / 1_000_000) * 2.4 = 0.324
+        expected_cost = 0.324
+        assert abs(cost - expected_cost) < 0.001
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_720p_5s_without_audio(self):
+        """Test cost estimation for 720p 5-second video without audio."""
+        input_data = BytedanceSeedanceV15ProTextToVideoInput(
+            prompt="Test prompt",
+            resolution="720p",
+            duration=5,
+            generate_audio=False,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # tokens = (1280 * 720 * 30 * 5) / 1024 = 135000
+        # cost = (135000 / 1_000_000) * 1.2 = 0.162
+        expected_cost = 0.162
+        assert abs(cost - expected_cost) < 0.001
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_1080p_12s(self):
+        """Test cost estimation for 1080p 12-second video with audio."""
+        input_data = BytedanceSeedanceV15ProTextToVideoInput(
+            prompt="Test prompt",
+            resolution="1080p",
+            duration=12,
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+
+        # tokens = (1920 * 1080 * 30 * 12) / 1024 = 729000
+        # cost = (729000 / 1_000_000) * 2.4 = 1.7496
+        expected_cost = 1.7496
+        assert abs(cost - expected_cost) < 0.01
+        assert isinstance(cost, float)
+
+    def test_calculate_dimensions(self):
+        """Test dimension calculation for various aspect ratios."""
+        gen = FalBytedanceSeedanceV15ProTextToVideoGenerator()
+
+        assert gen._calculate_dimensions("16:9", "1080p") == (1920, 1080)
+        assert gen._calculate_dimensions("16:9", "720p") == (1280, 720)
+        assert gen._calculate_dimensions("16:9", "480p") == (853, 480)
+        assert gen._calculate_dimensions("1:1", "720p") == (720, 720)
+        assert gen._calculate_dimensions("9:16", "720p") == (405, 720)
+        assert gen._calculate_dimensions("21:9", "1080p") == (2520, 1080)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = BytedanceSeedanceV15ProTextToVideoInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "aspect_ratio" in schema["properties"]
+        assert "resolution" in schema["properties"]
+        assert "duration" in schema["properties"]
+        assert "generate_audio" in schema["properties"]
+        assert "enable_safety_checker" in schema["properties"]
+        assert "camera_fixed" in schema["properties"]
+        assert "seed" in schema["properties"]
+
+        # Check that only prompt is required
+        assert schema["required"] == ["prompt"]
+
+        # Check defaults
+        assert schema["properties"]["aspect_ratio"]["default"] == "16:9"
+        assert schema["properties"]["resolution"]["default"] == "720p"
+        assert schema["properties"]["duration"]["default"] == 5
+        assert schema["properties"]["generate_audio"]["default"] is True
+        assert schema["properties"]["enable_safety_checker"]["default"] is True
+        assert schema["properties"]["camera_fixed"]["default"] is False


### PR DESCRIPTION
This pull request adds support for two new high-quality video generation models from ByteDance SeedDance v1.5 Pro, via Fal AI, to the backend. Specifically, it introduces both image-to-video and text-to-video generators, including their configuration, input schemas, API integration, cost estimation, and progress reporting. The generators are registered for use in the system and included in the module exports.

**New ByteDance SeedDance v1.5 Pro Generators:**

* Added new generator classes for ByteDance SeedDance v1.5 Pro:
  - `FalBytedanceSeedanceV15ProImageToVideoGenerator` for image-to-video generation, supporting features like aspect ratio, resolution, duration, optional end image, audio generation, and reproducibility via seed. Includes cost estimation and progress streaming.
  - `FalBytedanceSeedanceV15ProTextToVideoGenerator` for text-to-video generation, supporting various aspect ratios, resolutions (including 1080p), duration, audio, safety checker, camera lock, and seed. Includes dynamic dimension calculation, cost estimation, and progress streaming.

**Configuration and Registration:**

* Registered the new generators in the system configuration (`generators.yaml`) so they are available for use.
* Imported and included the new generator classes in the `__init__.py` file and updated the `__all__` list for proper module export. [[1]](diffhunk://#diff-0af385b438a0f68b3bd956550c83c952cce8919da6542b36af455b602b1b2906R7-R12) [[2]](diffhunk://#diff-0af385b438a0f68b3bd956550c83c952cce8919da6542b36af455b602b1b2906R56-R57)