### PR TITLE
Add Kie Suno Sounds generator (#272)

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -270,6 +270,9 @@ generators:
   - class: "boards.generators.implementations.kie.video.veo3.KieVeo3Generator"
     enabled: true
 
+  - class: "boards.generators.implementations.kie.audio.suno_sounds.KieSunoSoundsGenerator"
+    enabled: true
+
   # OpenAI generators
   - class: "boards.generators.implementations.openai.image.dalle3.OpenAIDallE3Generator"
     enabled: true

--- a/packages/backend/src/boards/generators/implementations/kie/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/kie/__init__.py
@@ -1,5 +1,6 @@
 """Kie.ai generator implementations."""
 
+from .audio.suno_sounds import KieSunoSoundsGenerator, SunoSoundsInput
 from .audio.suno_v5_5 import KieSunoV55Generator, SunoV55Input
 from .image.nano_banana_edit import KieNanoBananaEditGenerator, NanoBananaEditInput
 from .image.qwen_image_2 import KieQwenImage2Generator, QwenImage2Input
@@ -7,6 +8,8 @@ from .video.runway_aleph import KieRunwayAlephGenerator, KieRunwayAlephInput
 from .video.veo3 import KieVeo3Generator, KieVeo3Input
 
 __all__ = [
+    "KieSunoSoundsGenerator",
+    "SunoSoundsInput",
     "KieSunoV55Generator",
     "SunoV55Input",
     "KieNanoBananaEditGenerator",

--- a/packages/backend/src/boards/generators/implementations/kie/audio/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/kie/audio/__init__.py
@@ -1,3 +1,9 @@
+from .suno_sounds import KieSunoSoundsGenerator, SunoSoundsInput
 from .suno_v5_5 import KieSunoV55Generator, SunoV55Input
 
-__all__ = ["KieSunoV55Generator", "SunoV55Input"]
+__all__ = [
+    "KieSunoSoundsGenerator",
+    "SunoSoundsInput",
+    "KieSunoV55Generator",
+    "SunoV55Input",
+]

--- a/packages/backend/src/boards/generators/implementations/kie/audio/suno_sounds.py
+++ b/packages/backend/src/boards/generators/implementations/kie/audio/suno_sounds.py
@@ -8,7 +8,6 @@ See: https://docs.kie.ai/suno-api/generate-sounds
 """
 
 import asyncio
-import json
 from typing import Any, Literal
 
 import httpx
@@ -211,22 +210,18 @@ class KieSunoSoundsGenerator(KieDedicatedAPIGenerator):
         result_data = await self._poll_for_completion(task_id, api_key, context)
 
         # Extract audio items from response
-        # Suno returns results in data.data[] array
-        audio_items = result_data.get("data")
-        if not audio_items:
-            # Also try parsing resultJson if present
-            result_json = result_data.get("resultJson")
-            if result_json and isinstance(result_json, str):
-                parsed = json.loads(result_json)
-                audio_items = parsed.get("data", [])
+        # Suno Sounds returns results in data.response.sunoData[] array
+        # (same pattern as Suno V5.5 music generation)
+        response_data = result_data.get("response", {})
+        audio_items = response_data.get("sunoData", [])
 
-        if not audio_items or not isinstance(audio_items, list):
-            raise ValueError(f"No audio data returned from Kie.ai API. Response: {result_data}")
+        if not audio_items:
+            raise ValueError(f"No sunoData in response. Response: {result_data}")
 
         # Store each audio artifact
         artifacts = []
         for idx, item in enumerate(audio_items):
-            audio_url = item.get("audio_url")
+            audio_url = item.get("audioUrl")
             if not audio_url:
                 continue
 

--- a/packages/backend/src/boards/generators/implementations/kie/audio/suno_sounds.py
+++ b/packages/backend/src/boards/generators/implementations/kie/audio/suno_sounds.py
@@ -1,0 +1,253 @@
+"""
+Kie.ai Suno Sounds generator for custom audio and sound effects.
+
+Generate audio and sound effects from text prompts with loop playback
+and adjustable tempo/key using Kie.ai's Suno Sounds model (Dedicated API).
+
+See: https://docs.kie.ai/suno-api/generate-sounds
+"""
+
+import asyncio
+import json
+from typing import Any, Literal
+
+import httpx
+from pydantic import BaseModel, Field
+
+from .....progress.models import ProgressUpdate
+from ....base import GeneratorExecutionContext, GeneratorResult
+from ..base import KieDedicatedAPIGenerator
+
+# All valid sound key values
+SoundKey = Literal[
+    "Any",
+    "C",
+    "C#",
+    "D",
+    "D#",
+    "E",
+    "F",
+    "F#",
+    "G",
+    "G#",
+    "A",
+    "A#",
+    "B",
+    "Cm",
+    "C#m",
+    "Dm",
+    "D#m",
+    "Em",
+    "Fm",
+    "F#m",
+    "Gm",
+    "G#m",
+    "Am",
+    "A#m",
+    "Bm",
+]
+
+# Task statuses indicating the task is still in progress
+_PROCESSING_STATUSES = {"PENDING", "TEXT_SUCCESS", "FIRST_SUCCESS"}
+
+# Task statuses indicating failure
+_FAILED_STATUSES = {
+    "CREATE_TASK_FAILED",
+    "GENERATE_AUDIO_FAILED",
+    "CALLBACK_EXCEPTION",
+    "SENSITIVE_WORD_ERROR",
+}
+
+
+class SunoSoundsInput(BaseModel):
+    """Input schema for Kie.ai Suno Sounds generation.
+
+    Generates custom audio and sound effects from text prompts with
+    optional loop playback and adjustable tempo/key controls.
+    """
+
+    prompt: str = Field(
+        description="Description of the sound to generate",
+        max_length=500,
+    )
+    model: Literal["V5", "V5_5"] | None = Field(
+        default=None,
+        description="Model version to use",
+    )
+    sound_loop: bool = Field(
+        default=False,
+        description="Enable looping/cycle playback",
+    )
+    sound_tempo: int | None = Field(
+        default=None,
+        description="BPM (beats per minute). Auto if not set.",
+        ge=1,
+        le=300,
+    )
+    sound_key: SoundKey = Field(
+        default="Any",
+        description="Musical key/pitch for the generated sound",
+    )
+    grab_lyrics: bool = Field(
+        default=False,
+        description="Capture lyric subtitles for output",
+    )
+
+
+class KieSunoSoundsGenerator(KieDedicatedAPIGenerator):
+    """Generator for custom audio and sound effects using Suno Sounds."""
+
+    name = "kie-suno-sounds"
+    artifact_type = "audio"
+    description = "Kie.ai: Suno Sounds - Custom audio and sound effects from prompts"
+
+    # Dedicated API configuration
+    model_id = "ai-music-api/sounds"
+
+    def get_input_schema(self) -> type[SunoSoundsInput]:
+        return SunoSoundsInput
+
+    def _get_status_url(self, task_id: str) -> str:
+        """Get the Suno Sounds status check URL."""
+        return f"https://api.kie.ai/api/v1/generate/record-info?taskId={task_id}"
+
+    async def _poll_for_completion(
+        self,
+        task_id: str,
+        api_key: str,
+        context: GeneratorExecutionContext,
+        max_polls: int = 180,
+        poll_interval: int = 10,
+    ) -> dict[str, Any]:
+        """Poll Suno Sounds API for task completion using string status values.
+
+        The Suno API uses string-based statuses instead of the standard
+        Dedicated API successFlag pattern:
+        - Processing: PENDING, TEXT_SUCCESS, FIRST_SUCCESS
+        - Success: SUCCESS
+        - Failed: CREATE_TASK_FAILED, GENERATE_AUDIO_FAILED, etc.
+        """
+        status_url = self._get_status_url(task_id)
+
+        async with httpx.AsyncClient() as client:
+            for poll_count in range(max_polls):
+                if poll_count > 0:
+                    await asyncio.sleep(poll_interval)
+
+                status_response = await client.get(
+                    status_url,
+                    headers={"Authorization": f"Bearer {api_key}"},
+                    timeout=30.0,
+                )
+
+                if status_response.status_code != 200:
+                    raise ValueError(
+                        f"Status check failed: {status_response.status_code} {status_response.text}"
+                    )
+
+                status_result = status_response.json()
+                self._validate_response(status_result)
+
+                task_data = status_result.get("data", {})
+                status = task_data.get("status")
+                callback_type = task_data.get("callbackType")
+
+                if status == "SUCCESS" or callback_type == "complete":
+                    return task_data
+                elif status in _FAILED_STATUSES:
+                    error_msg = task_data.get("errorMsg") or task_data.get("failMsg") or status
+                    raise ValueError(f"Generation failed: {error_msg}")
+
+                # Publish progress
+                progress = min(90, (poll_count / max_polls) * 100)
+                await context.publish_progress(
+                    ProgressUpdate(
+                        job_id=task_id,
+                        status="processing",
+                        progress=progress,
+                        phase="processing",
+                    )
+                )
+            else:
+                timeout_minutes = (max_polls * poll_interval) / 60
+                raise ValueError(f"Generation timed out after {timeout_minutes} minutes")
+
+    async def generate(
+        self, inputs: SunoSoundsInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate audio using Kie.ai Suno Sounds."""
+        api_key = self._get_api_key()
+
+        # Prepare request body
+        body: dict[str, Any] = {
+            "prompt": inputs.prompt,
+            "soundLoop": inputs.sound_loop,
+            "soundKey": inputs.sound_key,
+            "grabLyrics": inputs.grab_lyrics,
+        }
+
+        if inputs.model is not None:
+            body["model"] = inputs.model
+
+        if inputs.sound_tempo is not None:
+            body["soundTempo"] = inputs.sound_tempo
+
+        # Submit task to Suno Sounds endpoint
+        submit_url = "https://api.kie.ai/api/v1/generate/sounds"
+        result = await self._make_request(submit_url, "POST", api_key, json=body)
+
+        # Extract task ID
+        task_id = result.get("taskId")
+        if not task_id:
+            data = result.get("data", {})
+            task_id = data.get("taskId")
+
+        if not task_id:
+            raise ValueError(f"No taskId returned from Kie.ai API. Response: {result}")
+
+        await context.set_external_job_id(task_id)
+
+        # Poll for completion
+        result_data = await self._poll_for_completion(task_id, api_key, context)
+
+        # Extract audio items from response
+        # Suno returns results in data.data[] array
+        audio_items = result_data.get("data")
+        if not audio_items:
+            # Also try parsing resultJson if present
+            result_json = result_data.get("resultJson")
+            if result_json and isinstance(result_json, str):
+                parsed = json.loads(result_json)
+                audio_items = parsed.get("data", [])
+
+        if not audio_items or not isinstance(audio_items, list):
+            raise ValueError(f"No audio data returned from Kie.ai API. Response: {result_data}")
+
+        # Store each audio artifact
+        artifacts = []
+        for idx, item in enumerate(audio_items):
+            audio_url = item.get("audio_url")
+            if not audio_url:
+                continue
+
+            duration = item.get("duration")
+
+            artifact = await context.store_audio_result(
+                storage_url=audio_url,
+                format="mp3",
+                duration=duration,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        if not artifacts:
+            raise ValueError("No audio URLs found in Kie.ai API response")
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: SunoSoundsInput) -> float:
+        """Estimate cost for Suno Sounds generation.
+
+        Pricing: 2.5 credits per generation (~$0.0125 USD).
+        """
+        return 0.0125

--- a/packages/backend/tests/generators/implementations/test_kie_suno_sounds.py
+++ b/packages/backend/tests/generators/implementations/test_kie_suno_sounds.py
@@ -1,0 +1,565 @@
+"""
+Tests for KieSunoSoundsGenerator.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import AudioArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.kie.audio.suno_sounds import (
+    KieSunoSoundsGenerator,
+    SunoSoundsInput,
+)
+
+
+class TestSunoSoundsInput:
+    """Tests for SunoSoundsInput schema."""
+
+    def test_valid_input_minimal(self):
+        """Test valid input with just prompt."""
+        input_data = SunoSoundsInput(
+            prompt="dramatic thunder rolling across a stormy sky",
+        )
+
+        assert input_data.prompt == "dramatic thunder rolling across a stormy sky"
+        assert input_data.model is None
+        assert input_data.sound_loop is False
+        assert input_data.sound_tempo is None
+        assert input_data.sound_key == "Any"
+        assert input_data.grab_lyrics is False
+
+    def test_valid_input_all_fields(self):
+        """Test valid input with all fields set."""
+        input_data = SunoSoundsInput(
+            prompt="upbeat electronic beat",
+            model="V5",
+            sound_loop=True,
+            sound_tempo=120,
+            sound_key="D#m",
+            grab_lyrics=True,
+        )
+
+        assert input_data.prompt == "upbeat electronic beat"
+        assert input_data.model == "V5"
+        assert input_data.sound_loop is True
+        assert input_data.sound_tempo == 120
+        assert input_data.sound_key == "D#m"
+        assert input_data.grab_lyrics is True
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = SunoSoundsInput(prompt="test")
+
+        assert input_data.model is None
+        assert input_data.sound_loop is False
+        assert input_data.sound_tempo is None
+        assert input_data.sound_key == "Any"
+        assert input_data.grab_lyrics is False
+
+    def test_prompt_max_length(self):
+        """Test validation for prompt max length."""
+        long_prompt = "a" * 501
+
+        with pytest.raises(ValidationError):
+            SunoSoundsInput(prompt=long_prompt)
+
+    def test_prompt_at_max_length(self):
+        """Test prompt at exactly max length is valid."""
+        prompt = "a" * 500
+        input_data = SunoSoundsInput(prompt=prompt)
+        assert len(input_data.prompt) == 500
+
+    def test_invalid_model(self):
+        """Test validation fails for invalid model."""
+        with pytest.raises(ValidationError):
+            SunoSoundsInput(
+                prompt="test",
+                model="V4",  # type: ignore[arg-type]
+            )
+
+    def test_valid_model_options(self):
+        """Test all valid model options."""
+        for model in ["V5", "V5_5"]:
+            input_data = SunoSoundsInput(prompt="test", model=model)  # type: ignore[arg-type]
+            assert input_data.model == model
+
+    def test_sound_tempo_min(self):
+        """Test sound_tempo minimum value."""
+        input_data = SunoSoundsInput(prompt="test", sound_tempo=1)
+        assert input_data.sound_tempo == 1
+
+    def test_sound_tempo_max(self):
+        """Test sound_tempo maximum value."""
+        input_data = SunoSoundsInput(prompt="test", sound_tempo=300)
+        assert input_data.sound_tempo == 300
+
+    def test_sound_tempo_below_min(self):
+        """Test validation fails for tempo below minimum."""
+        with pytest.raises(ValidationError):
+            SunoSoundsInput(prompt="test", sound_tempo=0)
+
+    def test_sound_tempo_above_max(self):
+        """Test validation fails for tempo above maximum."""
+        with pytest.raises(ValidationError):
+            SunoSoundsInput(prompt="test", sound_tempo=301)
+
+    def test_invalid_sound_key(self):
+        """Test validation fails for invalid sound key."""
+        with pytest.raises(ValidationError):
+            SunoSoundsInput(
+                prompt="test",
+                sound_key="X",  # type: ignore[arg-type]
+            )
+
+    def test_valid_sound_keys(self):
+        """Test all valid major and minor keys."""
+        major_keys = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+        minor_keys = ["Cm", "C#m", "Dm", "D#m", "Em", "Fm", "F#m", "Gm", "G#m", "Am", "A#m", "Bm"]
+
+        for key in ["Any"] + major_keys + minor_keys:
+            input_data = SunoSoundsInput(prompt="test", sound_key=key)  # type: ignore[arg-type]
+            assert input_data.sound_key == key
+
+
+class TestKieSunoSoundsGenerator:
+    """Tests for KieSunoSoundsGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = KieSunoSoundsGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "kie-suno-sounds"
+        assert self.generator.artifact_type == "audio"
+        assert "Suno Sounds" in self.generator.description
+        assert self.generator.api_pattern == "dedicated"
+        assert self.generator.model_id == "ai-music-api/sounds"
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == SunoSoundsInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = SunoSoundsInput(prompt="Test prompt")
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    return AudioArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        format="mp3",
+                        duration=None,
+                        sample_rate=None,
+                        channels=None,
+                    )
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="KIE_API_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self):
+        """Test successful audio generation."""
+        input_data = SunoSoundsInput(
+            prompt="dramatic thunder rolling",
+            sound_loop=True,
+            sound_tempo=120,
+            sound_key="D#m",
+        )
+
+        fake_audio_url = "https://storage.kie.ai/output.mp3"
+        fake_task_id = "task_suno_123456"
+
+        with patch.dict(os.environ, {"KIE_API_KEY": "fake-key"}):
+            mock_client = AsyncMock()
+
+            # Mock task submission response
+            submit_response = MagicMock()
+            submit_response.status_code = 200
+            submit_response.json.return_value = {
+                "code": 200,
+                "msg": "success",
+                "data": {"taskId": fake_task_id},
+            }
+
+            # Mock status check response (return success immediately)
+            status_response = MagicMock()
+            status_response.status_code = 200
+            status_response.json.return_value = {
+                "code": 200,
+                "msg": "All generated successfully.",
+                "data": {
+                    "callbackType": "complete",
+                    "task_id": fake_task_id,
+                    "status": "SUCCESS",
+                    "data": [
+                        {
+                            "id": "audio-id-1",
+                            "audio_url": fake_audio_url,
+                            "stream_audio_url": "https://storage.kie.ai/stream.mp3",
+                            "image_url": "https://storage.kie.ai/cover.jpeg",
+                            "prompt": "dramatic thunder rolling",
+                            "model_name": "chirp-v3-5",
+                            "title": "Thunder Storm",
+                            "tags": "ambient, nature",
+                            "createTime": "2025-01-01 00:00:00",
+                            "duration": 198.44,
+                        }
+                    ],
+                },
+            }
+
+            async def mock_post(url, **kwargs):
+                return submit_response
+
+            async def mock_get(url, **kwargs):
+                return status_response
+
+            mock_client.post = AsyncMock(side_effect=mock_post)
+            mock_client.get = AsyncMock(side_effect=mock_get)
+
+            mock_artifact = AudioArtifact(
+                generation_id="test_gen",
+                storage_url=fake_audio_url,
+                format="mp3",
+                duration=198.44,
+                sample_rate=None,
+                channels=None,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    return mock_artifact
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            mock_client_cm = MagicMock()
+            mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+
+            with patch("httpx.AsyncClient", return_value=mock_client_cm):
+                result = await self.generator.generate(input_data, DummyCtx())
+
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+    @pytest.mark.asyncio
+    async def test_generate_multiple_outputs(self):
+        """Test generation returning multiple audio clips."""
+        input_data = SunoSoundsInput(prompt="upbeat electronic beat")
+
+        fake_task_id = "task_suno_multi"
+
+        with patch.dict(os.environ, {"KIE_API_KEY": "fake-key"}):
+            mock_client = AsyncMock()
+
+            submit_response = MagicMock()
+            submit_response.status_code = 200
+            submit_response.json.return_value = {
+                "code": 200,
+                "msg": "success",
+                "data": {"taskId": fake_task_id},
+            }
+
+            status_response = MagicMock()
+            status_response.status_code = 200
+            status_response.json.return_value = {
+                "code": 200,
+                "msg": "All generated successfully.",
+                "data": {
+                    "status": "SUCCESS",
+                    "task_id": fake_task_id,
+                    "data": [
+                        {
+                            "id": "audio-1",
+                            "audio_url": "https://storage.kie.ai/out1.mp3",
+                            "duration": 120.5,
+                        },
+                        {
+                            "id": "audio-2",
+                            "audio_url": "https://storage.kie.ai/out2.mp3",
+                            "duration": 130.2,
+                        },
+                    ],
+                },
+            }
+
+            async def mock_post(url, **kwargs):
+                return submit_response
+
+            async def mock_get(url, **kwargs):
+                return status_response
+
+            mock_client.post = AsyncMock(side_effect=mock_post)
+            mock_client.get = AsyncMock(side_effect=mock_get)
+
+            call_count = 0
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    nonlocal call_count
+                    idx = call_count
+                    call_count += 1
+                    return AudioArtifact(
+                        generation_id="test_gen",
+                        storage_url=f"https://storage.kie.ai/out{idx + 1}.mp3",
+                        format="mp3",
+                        duration=120.5 if idx == 0 else 130.2,
+                        sample_rate=None,
+                        channels=None,
+                    )
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            mock_client_cm = MagicMock()
+            mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+
+            with patch("httpx.AsyncClient", return_value=mock_client_cm):
+                result = await self.generator.generate(input_data, DummyCtx())
+
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 2
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error(self):
+        """Test generation fails when API returns error."""
+        input_data = SunoSoundsInput(prompt="test")
+
+        with patch.dict(os.environ, {"KIE_API_KEY": "fake-key"}):
+            mock_client = AsyncMock()
+
+            submit_response = MagicMock()
+            submit_response.status_code = 200
+            submit_response.json.return_value = {
+                "code": 400,
+                "msg": "Validation error: prompt too short",
+            }
+
+            async def mock_post(url, **kwargs):
+                return submit_response
+
+            mock_client.post = AsyncMock(side_effect=mock_post)
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            mock_client_cm = MagicMock()
+            mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+
+            with patch("httpx.AsyncClient", return_value=mock_client_cm):
+                with pytest.raises(ValueError, match="Validation error"):
+                    await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_task_failure(self):
+        """Test generation fails when task status indicates failure."""
+        input_data = SunoSoundsInput(prompt="test")
+
+        fake_task_id = "task_suno_fail"
+
+        with patch.dict(os.environ, {"KIE_API_KEY": "fake-key"}):
+            mock_client = AsyncMock()
+
+            submit_response = MagicMock()
+            submit_response.status_code = 200
+            submit_response.json.return_value = {
+                "code": 200,
+                "msg": "success",
+                "data": {"taskId": fake_task_id},
+            }
+
+            status_response = MagicMock()
+            status_response.status_code = 200
+            status_response.json.return_value = {
+                "code": 200,
+                "msg": "failed",
+                "data": {
+                    "status": "GENERATE_AUDIO_FAILED",
+                    "errorMsg": "Audio generation failed due to content policy",
+                },
+            }
+
+            async def mock_post(url, **kwargs):
+                return submit_response
+
+            async def mock_get(url, **kwargs):
+                return status_response
+
+            mock_client.post = AsyncMock(side_effect=mock_post)
+            mock_client.get = AsyncMock(side_effect=mock_get)
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            mock_client_cm = MagicMock()
+            mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+
+            with patch("httpx.AsyncClient", return_value=mock_client_cm):
+                with pytest.raises(ValueError, match="content policy"):
+                    await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost(self):
+        """Test cost estimation."""
+        input_data = SunoSoundsInput(prompt="test")
+
+        cost = await self.generator.estimate_cost(input_data)
+        assert cost == 0.0125
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = SunoSoundsInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "prompt" in schema["properties"]
+        assert "model" in schema["properties"]
+        assert "sound_loop" in schema["properties"]
+        assert "sound_tempo" in schema["properties"]
+        assert "sound_key" in schema["properties"]
+        assert "grab_lyrics" in schema["properties"]
+
+        # Check that prompt has max length
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop["maxLength"] == 500
+
+        # Check sound_tempo constraints
+        tempo_prop = schema["properties"]["sound_tempo"]
+        # Check for constraints in the schema (may be nested in anyOf for optional)
+        if "anyOf" in tempo_prop:
+            int_schema = next(s for s in tempo_prop["anyOf"] if s.get("type") == "integer")
+            assert int_schema["minimum"] == 1
+            assert int_schema["maximum"] == 300
+        else:
+            assert tempo_prop["minimum"] == 1
+            assert tempo_prop["maximum"] == 300
+
+    def test_status_url(self):
+        """Test status URL generation."""
+        url = self.generator._get_status_url("test-task-123")
+        assert url == "https://api.kie.ai/api/v1/generate/record-info?taskId=test-task-123"

--- a/packages/backend/tests/generators/implementations/test_kie_suno_sounds.py
+++ b/packages/backend/tests/generators/implementations/test_kie_suno_sounds.py
@@ -223,20 +223,23 @@ class TestKieSunoSoundsGenerator:
                     "callbackType": "complete",
                     "task_id": fake_task_id,
                     "status": "SUCCESS",
-                    "data": [
-                        {
-                            "id": "audio-id-1",
-                            "audio_url": fake_audio_url,
-                            "stream_audio_url": "https://storage.kie.ai/stream.mp3",
-                            "image_url": "https://storage.kie.ai/cover.jpeg",
-                            "prompt": "dramatic thunder rolling",
-                            "model_name": "chirp-v3-5",
-                            "title": "Thunder Storm",
-                            "tags": "ambient, nature",
-                            "createTime": "2025-01-01 00:00:00",
-                            "duration": 198.44,
-                        }
-                    ],
+                    "response": {
+                        "taskId": fake_task_id,
+                        "sunoData": [
+                            {
+                                "id": "audio-id-1",
+                                "audioUrl": fake_audio_url,
+                                "streamAudioUrl": "https://storage.kie.ai/stream.mp3",
+                                "imageUrl": "https://storage.kie.ai/cover.jpeg",
+                                "prompt": "dramatic thunder rolling",
+                                "modelName": "chirp-v3-5",
+                                "title": "Thunder Storm",
+                                "tags": "ambient, nature",
+                                "createTime": 1700000000000,
+                                "duration": 198.44,
+                            }
+                        ],
+                    },
                 },
             }
 
@@ -322,18 +325,21 @@ class TestKieSunoSoundsGenerator:
                 "data": {
                     "status": "SUCCESS",
                     "task_id": fake_task_id,
-                    "data": [
-                        {
-                            "id": "audio-1",
-                            "audio_url": "https://storage.kie.ai/out1.mp3",
-                            "duration": 120.5,
-                        },
-                        {
-                            "id": "audio-2",
-                            "audio_url": "https://storage.kie.ai/out2.mp3",
-                            "duration": 130.2,
-                        },
-                    ],
+                    "response": {
+                        "taskId": fake_task_id,
+                        "sunoData": [
+                            {
+                                "id": "audio-1",
+                                "audioUrl": "https://storage.kie.ai/out1.mp3",
+                                "duration": 120.5,
+                            },
+                            {
+                                "id": "audio-2",
+                                "audioUrl": "https://storage.kie.ai/out2.mp3",
+                                "duration": 130.2,
+                            },
+                        ],
+                    },
                 },
             }
 

--- a/packages/backend/tests/generators/implementations/test_kie_suno_sounds_live.py
+++ b/packages/backend/tests/generators/implementations/test_kie_suno_sounds_live.py
@@ -1,0 +1,70 @@
+"""
+Live API tests for KieSunoSoundsGenerator.
+
+These tests make actual API calls to the Kie.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_kie to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"KIE_API_KEY": "..."}'
+    pytest tests/generators/implementations/test_kie_suno_sounds_live.py -v -m live_api
+
+Or using direct environment variable:
+    export KIE_API_KEY="..."
+    pytest tests/generators/implementations/test_kie_suno_sounds_live.py -v -m live_kie
+
+Or run all Kie live tests:
+    pytest -m live_kie -v
+"""
+
+import os
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.implementations.kie.audio.suno_sounds import (
+    KieSunoSoundsGenerator,
+    SunoSoundsInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_kie]
+
+
+@pytest.fixture
+def skip_if_no_kie_key():
+    """Skip test if KIE_API_KEY is not available."""
+    if not os.getenv("KIE_API_KEY"):
+        pytest.skip("KIE_API_KEY not set - skipping live API test")
+
+
+class TestSunoSoundsGeneratorLive:
+    """Live API tests for KieSunoSoundsGenerator using real Kie.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = KieSunoSoundsGenerator()
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_basic(self, skip_if_no_kie_key, dummy_context, cost_logger):
+        """
+        Test basic sound generation with minimal parameters.
+
+        This test makes a real API call to Kie.ai and will consume credits.
+        Uses minimal/cheap settings to reduce cost.
+        """
+        estimated_cost = await self.generator.estimate_cost(SunoSoundsInput(prompt="test"))
+        cost_logger(self.generator.name, estimated_cost)
+
+        inputs = SunoSoundsInput(
+            prompt="gentle rain on a tin roof",
+        )
+
+        result = await self.generator.generate(inputs, dummy_context)
+
+        assert result.outputs is not None
+        assert len(result.outputs) >= 1
+
+        artifact = result.outputs[0]
+        assert artifact.storage_url is not None
+        assert artifact.format == "mp3"


### PR DESCRIPTION
## Summary
- Add `kie-suno-sounds` generator using Kie.ai's `ai-music-api/sounds` model (Dedicated API)
- Generates custom audio and sound effects from text prompts with loop playback and adjustable tempo/key
- Supports parameters: prompt, model (V5/V5_5), sound_loop, sound_tempo (1-300 BPM), sound_key (major/minor keys), grab_lyrics
- Overrides `_poll_for_completion` for Suno's string-based status polling (PENDING/SUCCESS/FAILED) vs standard `successFlag`
- Cost: ~$0.0125 per generation (2.5 credits)

## Test plan
- [x] 23 unit tests passing (input validation, metadata, generation success/failure, cost estimation, JSON schema)
- [x] Live API test file created (requires KIE_API_KEY)
- [x] Pyright type checking passes (0 errors)
- [x] Ruff linting passes
- [ ] Manual live API test with real KIE_API_KEY

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)