### PR TITLE
feat: add Kie Grok Imagine Extend video generator

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -273,6 +273,9 @@ generators:
   - class: "boards.generators.implementations.kie.audio.suno_sounds.KieSunoSoundsGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.kie.video.grok_imagine_extend.KieGrokImagineExtendGenerator"
+    enabled: true
+
   # OpenAI generators
   - class: "boards.generators.implementations.openai.image.dalle3.OpenAIDallE3Generator"
     enabled: true

--- a/packages/backend/src/boards/generators/implementations/kie/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/kie/__init__.py
@@ -4,10 +4,13 @@ from .audio.suno_sounds import KieSunoSoundsGenerator, SunoSoundsInput
 from .audio.suno_v5_5 import KieSunoV55Generator, SunoV55Input
 from .image.nano_banana_edit import KieNanoBananaEditGenerator, NanoBananaEditInput
 from .image.qwen_image_2 import KieQwenImage2Generator, QwenImage2Input
+from .video.grok_imagine_extend import GrokImagineExtendInput, KieGrokImagineExtendGenerator
 from .video.runway_aleph import KieRunwayAlephGenerator, KieRunwayAlephInput
 from .video.veo3 import KieVeo3Generator, KieVeo3Input
 
 __all__ = [
+    "GrokImagineExtendInput",
+    "KieGrokImagineExtendGenerator",
     "KieSunoSoundsGenerator",
     "SunoSoundsInput",
     "KieSunoV55Generator",

--- a/packages/backend/src/boards/generators/implementations/kie/base.py
+++ b/packages/backend/src/boards/generators/implementations/kie/base.py
@@ -199,7 +199,7 @@ class KieMarketAPIGenerator(KieBaseGenerator):
 
                 if state == "success":
                     return task_data
-                elif state == "failed":
+                elif state in ["failed", "fail"]:
                     error_msg = task_data.get("failMsg", "Unknown error")
                     raise ValueError(f"Generation failed: {error_msg}")
                 elif state not in ["waiting", "pending", "processing", None]:

--- a/packages/backend/src/boards/generators/implementations/kie/video/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/kie/video/__init__.py
@@ -1,9 +1,12 @@
 """Kie.ai video generators."""
 
+from .grok_imagine_extend import GrokImagineExtendInput, KieGrokImagineExtendGenerator
 from .runway_aleph import KieRunwayAlephGenerator, KieRunwayAlephInput
 from .veo3 import KieVeo3Generator, KieVeo3Input
 
 __all__ = [
+    "GrokImagineExtendInput",
+    "KieGrokImagineExtendGenerator",
     "KieRunwayAlephGenerator",
     "KieRunwayAlephInput",
     "KieVeo3Generator",

--- a/packages/backend/src/boards/generators/implementations/kie/video/grok_imagine_extend.py
+++ b/packages/backend/src/boards/generators/implementations/kie/video/grok_imagine_extend.py
@@ -1,0 +1,163 @@
+"""
+Kie.ai Grok Imagine Extend video extension generator.
+
+Extend previously generated Grok Imagine videos with additional content
+using text prompts via Kie.ai's Market API.
+
+Based on Kie.ai's grok-imagine/extend model (Market API).
+See: https://kie.ai/grok-imagine?model=grok-imagine%2Fextend
+"""
+
+import json
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from ....base import GeneratorExecutionContext, GeneratorResult
+from ..base import KieMarketAPIGenerator
+
+
+class GrokImagineExtendInput(BaseModel):
+    """Input schema for Grok Imagine Extend video extension.
+
+    Extends a previously generated Grok Imagine video by appending
+    new content based on a text prompt. The task_id must reference
+    a successfully completed Kie.ai video generation task.
+    """
+
+    task_id: str = Field(
+        description="Task ID from a previously successful Kie.ai video generation task. "
+        "Only Kie AI-generated task IDs are supported.",
+        max_length=100,
+    )
+    prompt: str = Field(
+        description="Text prompt describing the desired video motion for the extension. "
+        "Supports both English and Chinese.",
+        max_length=5000,
+    )
+    extend_at: str | None = Field(
+        default=None,
+        description="Starting point of the extension in the original video (e.g. '0')",
+    )
+    extend_times: Literal["6", "10"] = Field(
+        default="6",
+        description="Duration of the extended video in seconds: '6' or '10'",
+    )
+
+
+class KieGrokImagineExtendGenerator(KieMarketAPIGenerator):
+    """Grok Imagine Extend video generator using Kie.ai Market API."""
+
+    name = "kie-grok-imagine-extend"
+    artifact_type = "video"
+    description = "Kie.ai: Grok Imagine Extend - Extend AI-generated videos with text prompts"
+
+    # Market API configuration
+    model_id = "grok-imagine/extend"
+
+    def get_input_schema(self) -> type[GrokImagineExtendInput]:
+        return GrokImagineExtendInput
+
+    async def generate(
+        self, inputs: GrokImagineExtendInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Extend a video using Kie.ai Grok Imagine Extend model."""
+        # Get API key using base class method
+        api_key = self._get_api_key()
+
+        # Prepare request body for Market API
+        input_params: dict[str, str] = {
+            "task_id": inputs.task_id,
+            "prompt": inputs.prompt,
+            "extend_times": inputs.extend_times,
+        }
+
+        if inputs.extend_at is not None:
+            input_params["extend_at"] = inputs.extend_at
+
+        body = {
+            "model": self.model_id,
+            "input": input_params,
+        }
+
+        # Submit task using base class method
+        submit_url = "https://api.kie.ai/api/v1/jobs/createTask"
+        result = await self._make_request(submit_url, "POST", api_key, json=body)
+
+        # Extract task ID
+        data = result.get("data", {})
+        task_id = data.get("taskId")
+
+        if not task_id:
+            raise ValueError(f"No taskId returned from Kie.ai API. Response: {result}")
+
+        # Store external job ID
+        await context.set_external_job_id(task_id)
+
+        # Poll for completion using base class method
+        task_data = await self._poll_for_completion(task_id, api_key, context)
+
+        # Extract outputs from resultJson (Market API pattern)
+        result_json = task_data.get("resultJson")
+        if result_json:
+            result_data = json.loads(result_json)
+        else:
+            result_data = task_data.get("result")
+
+        if not result_data:
+            raise ValueError("No result data returned from Kie.ai API")
+
+        # Extract video URLs from result
+        video_urls: list[str] = []
+        if isinstance(result_data, dict):
+            if "resultUrls" in result_data:
+                video_urls = result_data["resultUrls"]
+            elif "video_urls" in result_data:
+                video_urls = result_data["video_urls"]
+            elif "url" in result_data:
+                video_urls = [result_data["url"]]
+
+        if not video_urls:
+            raise ValueError(f"No video URLs found in result: {result_data}")
+
+        # Determine duration from extend_times
+        duration = float(inputs.extend_times)
+
+        # Default to 720p dimensions (common for video extensions)
+        width = 1280
+        height = 720
+
+        # Store each video using output_index
+        artifacts = []
+        for idx, video_url in enumerate(video_urls):
+            if not video_url:
+                raise ValueError(f"Video {idx} missing URL in Kie.ai response")
+
+            artifact = await context.store_video_result(
+                storage_url=video_url,
+                format="mp4",
+                width=width,
+                height=height,
+                duration=duration,
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: GrokImagineExtendInput) -> float:
+        """Estimate cost for Grok Imagine Extend generation.
+
+        Pricing (at $0.005/credit):
+        - 6s 480p = 10 credits = $0.05
+        - 6s 720p = 20 credits = $0.10
+        - 10s 480p = 20 credits = $0.10
+        - 10s 720p = 30 credits = $0.15
+
+        Uses 720p pricing as default estimate since resolution
+        is not a user-configurable parameter.
+        """
+        if inputs.extend_times == "10":
+            return 0.15  # 30 credits at $0.005/credit (720p)
+        else:  # "6"
+            return 0.10  # 20 credits at $0.005/credit (720p)

--- a/packages/backend/tests/generators/implementations/test_kie_grok_imagine_extend.py
+++ b/packages/backend/tests/generators/implementations/test_kie_grok_imagine_extend.py
@@ -1,0 +1,460 @@
+"""
+Tests for KieGrokImagineExtendGenerator.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from boards.generators.artifacts import VideoArtifact
+from boards.generators.base import GeneratorExecutionContext, GeneratorResult
+from boards.generators.implementations.kie.video.grok_imagine_extend import (
+    GrokImagineExtendInput,
+    KieGrokImagineExtendGenerator,
+)
+
+
+class TestGrokImagineExtendInput:
+    """Tests for GrokImagineExtendInput schema."""
+
+    def test_valid_input_minimal(self):
+        """Test valid input with minimal required fields."""
+        input_data = GrokImagineExtendInput(
+            task_id="task_grok_12345678",
+            prompt="The camera slowly pans forward",
+        )
+
+        assert input_data.task_id == "task_grok_12345678"
+        assert input_data.prompt == "The camera slowly pans forward"
+        assert input_data.extend_at is None
+        assert input_data.extend_times == "6"
+
+    def test_valid_input_all_fields(self):
+        """Test valid input with all fields specified."""
+        input_data = GrokImagineExtendInput(
+            task_id="task_grok_12345678",
+            prompt="The camera slowly pans forward",
+            extend_at="0",
+            extend_times="10",
+        )
+
+        assert input_data.task_id == "task_grok_12345678"
+        assert input_data.prompt == "The camera slowly pans forward"
+        assert input_data.extend_at == "0"
+        assert input_data.extend_times == "10"
+
+    def test_input_defaults(self):
+        """Test default values."""
+        input_data = GrokImagineExtendInput(
+            task_id="task_123",
+            prompt="Test prompt",
+        )
+
+        assert input_data.extend_at is None
+        assert input_data.extend_times == "6"
+
+    def test_invalid_extend_times(self):
+        """Test validation fails for invalid extend_times."""
+        with pytest.raises(ValidationError):
+            GrokImagineExtendInput(
+                task_id="task_123",
+                prompt="Test",
+                extend_times="5",  # type: ignore[arg-type]
+            )
+
+    def test_task_id_max_length(self):
+        """Test validation for task_id max length."""
+        long_task_id = "a" * 101
+
+        with pytest.raises(ValidationError):
+            GrokImagineExtendInput(
+                task_id=long_task_id,
+                prompt="Test",
+            )
+
+    def test_prompt_max_length(self):
+        """Test validation for prompt max length."""
+        long_prompt = "a" * 5001
+
+        with pytest.raises(ValidationError):
+            GrokImagineExtendInput(
+                task_id="task_123",
+                prompt=long_prompt,
+            )
+
+    def test_extend_times_options(self):
+        """Test all valid extend_times options."""
+        for times in ["6", "10"]:
+            input_data = GrokImagineExtendInput(
+                task_id="task_123",
+                prompt="Test",
+                extend_times=times,  # type: ignore[arg-type]
+            )
+            assert input_data.extend_times == times
+
+
+class TestKieGrokImagineExtendGenerator:
+    """Tests for KieGrokImagineExtendGenerator."""
+
+    def setup_method(self):
+        """Set up generator for testing."""
+        self.generator = KieGrokImagineExtendGenerator()
+
+    def test_generator_metadata(self):
+        """Test generator metadata."""
+        assert self.generator.name == "kie-grok-imagine-extend"
+        assert self.generator.artifact_type == "video"
+        assert "Grok Imagine Extend" in self.generator.description
+        assert self.generator.api_pattern == "market"
+        assert self.generator.model_id == "grok-imagine/extend"
+
+    def test_input_schema(self):
+        """Test input schema."""
+        schema_class = self.generator.get_input_schema()
+        assert schema_class == GrokImagineExtendInput
+
+    @pytest.mark.asyncio
+    async def test_generate_missing_api_key(self):
+        """Test generation fails when API key is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            input_data = GrokImagineExtendInput(
+                task_id="task_123",
+                prompt="Test prompt",
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return VideoArtifact(
+                        generation_id="test_gen",
+                        storage_url="",
+                        width=1,
+                        height=1,
+                        duration=1.0,
+                        format="mp4",
+                        fps=30,
+                    )
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            with pytest.raises(ValueError, match="KIE_API_KEY"):
+                await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_generate_success_6s(self):
+        """Test successful 6-second video extension."""
+        input_data = GrokImagineExtendInput(
+            task_id="task_grok_12345678",
+            prompt="The camera slowly pans forward",
+            extend_times="6",
+        )
+
+        fake_video_url = "https://storage.kie.ai/extended_output.mp4"
+        fake_task_id = "task_extend_123456"
+
+        with patch.dict(os.environ, {"KIE_API_KEY": "fake-key"}):
+            mock_client = AsyncMock()
+
+            # Mock task submission response
+            submit_response = MagicMock()
+            submit_response.status_code = 200
+            submit_response.json.return_value = {
+                "code": 200,
+                "msg": "success",
+                "data": {"taskId": fake_task_id},
+            }
+
+            # Mock status check response (return success immediately)
+            status_response = MagicMock()
+            status_response.status_code = 200
+            status_response.json.return_value = {
+                "code": 200,
+                "msg": "success",
+                "data": {
+                    "taskId": fake_task_id,
+                    "state": "success",
+                    "resultJson": '{"resultUrls": ["' + fake_video_url + '"]}',
+                },
+            }
+
+            # Configure mock client
+            async def mock_post(url, **kwargs):
+                return submit_response
+
+            async def mock_get(url, **kwargs):
+                return status_response
+
+            mock_client.post = AsyncMock(side_effect=mock_post)
+            mock_client.get = AsyncMock(side_effect=mock_get)
+
+            # Mock storage result
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_video_url,
+                width=1280,
+                height=720,
+                duration=6.0,
+                format="mp4",
+                fps=30,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            # Mock httpx.AsyncClient context manager
+            mock_client_cm = MagicMock()
+            mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+
+            with patch("httpx.AsyncClient", return_value=mock_client_cm):
+                result = await self.generator.generate(input_data, DummyCtx())
+
+            # Verify result
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+    @pytest.mark.asyncio
+    async def test_generate_success_10s_with_extend_at(self):
+        """Test successful 10-second video extension with extend_at."""
+        input_data = GrokImagineExtendInput(
+            task_id="task_grok_12345678",
+            prompt="Zoom into the scene",
+            extend_at="0",
+            extend_times="10",
+        )
+
+        fake_video_url = "https://storage.kie.ai/extended_10s.mp4"
+        fake_task_id = "task_extend_789"
+
+        with patch.dict(os.environ, {"KIE_API_KEY": "fake-key"}):
+            mock_client = AsyncMock()
+
+            submit_response = MagicMock()
+            submit_response.status_code = 200
+            submit_response.json.return_value = {
+                "code": 200,
+                "msg": "success",
+                "data": {"taskId": fake_task_id},
+            }
+
+            status_response = MagicMock()
+            status_response.status_code = 200
+            status_response.json.return_value = {
+                "code": 200,
+                "msg": "success",
+                "data": {
+                    "taskId": fake_task_id,
+                    "state": "success",
+                    "resultJson": '{"resultUrls": ["' + fake_video_url + '"]}',
+                },
+            }
+
+            async def mock_post(url, **kwargs):
+                return submit_response
+
+            async def mock_get(url, **kwargs):
+                return status_response
+
+            mock_client.post = AsyncMock(side_effect=mock_post)
+            mock_client.get = AsyncMock(side_effect=mock_get)
+
+            mock_artifact = VideoArtifact(
+                generation_id="test_gen",
+                storage_url=fake_video_url,
+                width=1280,
+                height=720,
+                duration=10.0,
+                format="mp4",
+                fps=30,
+            )
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    return mock_artifact
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            mock_client_cm = MagicMock()
+            mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+
+            with patch("httpx.AsyncClient", return_value=mock_client_cm):
+                result = await self.generator.generate(input_data, DummyCtx())
+
+            assert isinstance(result, GeneratorResult)
+            assert len(result.outputs) == 1
+            assert result.outputs[0] == mock_artifact
+
+    @pytest.mark.asyncio
+    async def test_generate_api_error(self):
+        """Test generation fails when API returns error."""
+        input_data = GrokImagineExtendInput(
+            task_id="task_123",
+            prompt="test",
+        )
+
+        with patch.dict(os.environ, {"KIE_API_KEY": "fake-key"}):
+            mock_client = AsyncMock()
+
+            submit_response = MagicMock()
+            submit_response.status_code = 200
+            submit_response.json.return_value = {
+                "code": 400,
+                "msg": "Invalid task_id: task not found",
+            }
+
+            async def mock_post(url, **kwargs):
+                return submit_response
+
+            mock_client.post = AsyncMock(side_effect=mock_post)
+
+            class DummyCtx(GeneratorExecutionContext):
+                generation_id = "test_gen"
+                provider_correlation_id = "corr"
+                tenant_id = "test_tenant"
+                board_id = "test_board"
+
+                async def resolve_artifact(self, artifact):
+                    return ""
+
+                async def store_image_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_video_result(self, **kwargs):
+                    raise NotImplementedError
+
+                async def store_audio_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def store_text_result(self, *args, **kwargs):
+                    raise NotImplementedError
+
+                async def publish_progress(self, update):
+                    return None
+
+                async def set_external_job_id(self, external_id: str) -> None:
+                    return None
+
+            mock_client_cm = MagicMock()
+            mock_client_cm.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+
+            with patch("httpx.AsyncClient", return_value=mock_client_cm):
+                with pytest.raises(ValueError, match="Invalid task_id"):
+                    await self.generator.generate(input_data, DummyCtx())
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_6s(self):
+        """Test cost estimation for 6-second extension."""
+        input_data = GrokImagineExtendInput(
+            task_id="task_123",
+            prompt="Test prompt",
+            extend_times="6",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+        assert cost == 0.10
+        assert isinstance(cost, float)
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_10s(self):
+        """Test cost estimation for 10-second extension."""
+        input_data = GrokImagineExtendInput(
+            task_id="task_123",
+            prompt="Test prompt",
+            extend_times="10",
+        )
+
+        cost = await self.generator.estimate_cost(input_data)
+        assert cost == 0.15
+        assert isinstance(cost, float)
+
+    def test_json_schema_generation(self):
+        """Test that input schema can generate JSON schema for frontend."""
+        schema = GrokImagineExtendInput.model_json_schema()
+
+        assert schema["type"] == "object"
+        assert "task_id" in schema["properties"]
+        assert "prompt" in schema["properties"]
+        assert "extend_at" in schema["properties"]
+        assert "extend_times" in schema["properties"]
+
+        # Check task_id has max length
+        task_id_prop = schema["properties"]["task_id"]
+        assert task_id_prop["maxLength"] == 100
+
+        # Check prompt has max length
+        prompt_prop = schema["properties"]["prompt"]
+        assert prompt_prop["maxLength"] == 5000
+
+        # Check extend_at is optional
+        assert "task_id" in schema.get("required", [])
+        assert "prompt" in schema.get("required", [])

--- a/packages/backend/tests/generators/implementations/test_kie_grok_imagine_extend_live.py
+++ b/packages/backend/tests/generators/implementations/test_kie_grok_imagine_extend_live.py
@@ -1,0 +1,115 @@
+"""
+Live API tests for KieGrokImagineExtendGenerator.
+
+These tests make actual API calls to the Kie.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_kie to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"KIE_API_KEY": "..."}'
+    pytest tests/generators/implementations/test_kie_grok_imagine_extend_live.py -v -m live_api
+
+Or using direct environment variable:
+    export KIE_API_KEY="..."
+    pytest tests/generators/implementations/test_kie_grok_imagine_extend_live.py -v -m live_kie
+
+Or run all Kie live tests:
+    pytest -m live_kie -v
+
+Note: These tests require a valid task_id from a previously completed
+Kie.ai Grok Imagine video generation task.
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import VideoArtifact
+from boards.generators.implementations.kie.video.grok_imagine_extend import (
+    GrokImagineExtendInput,
+    KieGrokImagineExtendGenerator,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_kie]
+
+
+class TestGrokImagineExtendGeneratorLive:
+    """Live API tests for KieGrokImagineExtendGenerator using real Kie.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = KieGrokImagineExtendGenerator()
+        # Sync API keys from settings to os.environ for use in generator
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_extend_6s(self, skip_if_no_kie_key, dummy_context, cost_logger):
+        """
+        Test basic 6-second video extension.
+
+        This test makes a real API call to Kie.ai and will consume credits.
+        Requires a valid task_id from a previous Grok Imagine generation.
+
+        NOTE: You must replace the task_id below with a valid one from your
+        Kie.ai account before running this test.
+        """
+        # Replace with a valid task_id from a completed Grok Imagine generation
+        test_task_id = "REPLACE_WITH_VALID_TASK_ID"
+
+        if test_task_id == "REPLACE_WITH_VALID_TASK_ID":
+            pytest.skip("No valid task_id provided for live test")
+
+        inputs = GrokImagineExtendInput(
+            task_id=test_task_id,
+            prompt="The camera slowly pans forward revealing more of the scene",
+            extend_times="6",
+        )
+
+        # Log estimated cost
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        # Execute generation
+        result = await self.generator.generate(inputs, dummy_context)
+
+        # Verify result structure
+        assert result.outputs is not None
+        assert len(result.outputs) >= 1
+
+        # Verify artifact properties
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.format == "mp4"
+        assert artifact.storage_url.startswith("http")
+
+    @pytest.mark.asyncio
+    async def test_estimate_cost_matches_pricing(self, skip_if_no_kie_key):
+        """
+        Test that cost estimation is reasonable.
+
+        This doesn't make an API call, just verifies the cost estimate logic.
+        """
+        # Test 6s extension
+        inputs_6s = GrokImagineExtendInput(
+            task_id="task_123",
+            prompt="test",
+            extend_times="6",
+        )
+        cost_6s = await self.generator.estimate_cost(inputs_6s)
+        assert cost_6s > 0.0
+        assert cost_6s < 0.50  # Sanity check
+        assert cost_6s == 0.10
+
+        # Test 10s extension
+        inputs_10s = GrokImagineExtendInput(
+            task_id="task_123",
+            prompt="test",
+            extend_times="10",
+        )
+        cost_10s = await self.generator.estimate_cost(inputs_10s)
+        assert cost_10s > 0.0
+        assert cost_10s < 0.50  # Sanity check
+        assert cost_10s == 0.15
+
+        # 10s should cost more than 6s
+        assert cost_10s > cost_6s

--- a/packages/backend/tests/generators/implementations/test_kie_grok_imagine_extend_live.py
+++ b/packages/backend/tests/generators/implementations/test_kie_grok_imagine_extend_live.py
@@ -16,10 +16,14 @@ Or using direct environment variable:
 Or run all Kie live tests:
     pytest -m live_kie -v
 
-Note: These tests require a valid task_id from a previously completed
-Kie.ai Grok Imagine video generation task.
+Note: This test first creates a base video via the grok-imagine Market API,
+then extends it. Both steps consume credits.
 """
 
+import asyncio
+import os
+
+import httpx
 import pytest
 
 from boards.config import initialize_generator_api_keys
@@ -32,13 +36,72 @@ from boards.generators.implementations.kie.video.grok_imagine_extend import (
 pytestmark = [pytest.mark.live_api, pytest.mark.live_kie]
 
 
+async def _create_base_video(api_key: str) -> str:
+    """Create a base video via Kie.ai grok-imagine Market API and return its task_id.
+
+    This submits a simple text-to-video generation using the grok-imagine model,
+    then polls until completion. The returned task_id can be used for extend.
+    """
+    submit_url = "https://api.kie.ai/api/v1/jobs/createTask"
+    body = {
+        "model": "grok-imagine/text-to-video",
+        "input": {
+            "prompt": "A gentle ocean wave rolling onto a sandy beach",
+            "aspect_ratio": "16:9",
+            "duration": 6,
+            "resolution": "480p",
+        },
+    }
+
+    async with httpx.AsyncClient() as client:
+        # Submit the base generation
+        response = await client.post(
+            submit_url,
+            json=body,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+        assert response.status_code == 200, f"Submit failed: {response.status_code} {response.text}"
+        result = response.json()
+        assert result.get("code") == 200, f"API error: {result}"
+
+        task_id = result.get("data", {}).get("taskId")
+        assert task_id, f"No taskId in response: {result}"
+
+        # Poll for completion
+        status_url = f"https://api.kie.ai/api/v1/jobs/recordInfo?taskId={task_id}"
+        for _ in range(120):  # Up to 20 minutes
+            await asyncio.sleep(10)
+            status_response = await client.get(
+                status_url,
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=30.0,
+            )
+            assert status_response.status_code == 200
+            status_result = status_response.json()
+            task_data = status_result.get("data", {})
+            state = task_data.get("state")
+
+            if state == "success":
+                return task_id
+            elif state in ["failed", "fail"]:
+                fail_msg = task_data.get("failMsg", "Unknown error")
+                pytest.fail(f"Base video generation failed: {fail_msg}")
+
+        pytest.fail("Base video generation timed out after 20 minutes")
+    # unreachable but satisfies type checker
+    return ""
+
+
 class TestGrokImagineExtendGeneratorLive:
     """Live API tests for KieGrokImagineExtendGenerator using real Kie.ai API."""
 
     def setup_method(self):
         """Set up generator and ensure API keys are synced to environment."""
         self.generator = KieGrokImagineExtendGenerator()
-        # Sync API keys from settings to os.environ for use in generator
         initialize_generator_api_keys()
 
     @pytest.mark.asyncio
@@ -46,29 +109,25 @@ class TestGrokImagineExtendGeneratorLive:
         """
         Test basic 6-second video extension.
 
-        This test makes a real API call to Kie.ai and will consume credits.
-        Requires a valid task_id from a previous Grok Imagine generation.
-
-        NOTE: You must replace the task_id below with a valid one from your
-        Kie.ai account before running this test.
+        This test first generates a base video using grok-imagine,
+        then extends it using grok-imagine/extend. Both steps consume credits.
         """
-        # Replace with a valid task_id from a completed Grok Imagine generation
-        test_task_id = "REPLACE_WITH_VALID_TASK_ID"
+        api_key = os.environ["KIE_API_KEY"]
 
-        if test_task_id == "REPLACE_WITH_VALID_TASK_ID":
-            pytest.skip("No valid task_id provided for live test")
+        # Step 1: Create a base video to get a valid task_id
+        base_task_id = await _create_base_video(api_key)
 
+        # Step 2: Extend the generated video
         inputs = GrokImagineExtendInput(
-            task_id=test_task_id,
+            task_id=base_task_id,
             prompt="The camera slowly pans forward revealing more of the scene",
             extend_times="6",
         )
 
-        # Log estimated cost
+        # Log estimated cost (extend only; base video cost is separate)
         estimated_cost = await self.generator.estimate_cost(inputs)
         cost_logger(self.generator.name, estimated_cost)
 
-        # Execute generation
         result = await self.generator.generate(inputs, dummy_context)
 
         # Verify result structure
@@ -79,37 +138,5 @@ class TestGrokImagineExtendGeneratorLive:
         artifact = result.outputs[0]
         assert isinstance(artifact, VideoArtifact)
         assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
         assert artifact.format == "mp4"
-        assert artifact.storage_url.startswith("http")
-
-    @pytest.mark.asyncio
-    async def test_estimate_cost_matches_pricing(self, skip_if_no_kie_key):
-        """
-        Test that cost estimation is reasonable.
-
-        This doesn't make an API call, just verifies the cost estimate logic.
-        """
-        # Test 6s extension
-        inputs_6s = GrokImagineExtendInput(
-            task_id="task_123",
-            prompt="test",
-            extend_times="6",
-        )
-        cost_6s = await self.generator.estimate_cost(inputs_6s)
-        assert cost_6s > 0.0
-        assert cost_6s < 0.50  # Sanity check
-        assert cost_6s == 0.10
-
-        # Test 10s extension
-        inputs_10s = GrokImagineExtendInput(
-            task_id="task_123",
-            prompt="test",
-            extend_times="10",
-        )
-        cost_10s = await self.generator.estimate_cost(inputs_10s)
-        assert cost_10s > 0.0
-        assert cost_10s < 0.50  # Sanity check
-        assert cost_10s == 0.15
-
-        # 10s should cost more than 6s
-        assert cost_10s > cost_6s


### PR DESCRIPTION
## Summary
- Adds a new KIE Market API generator (`kie-grok-imagine-extend`) for extending previously generated Grok Imagine videos with text-prompted motion
- Supports 6s and 10s extension durations, with optional `extend_at` start position
- Takes a `task_id` from a prior Kie.ai video generation (not file uploads)
- Pricing: 6s=$0.10, 10s=$0.15 (720p estimates at $0.005/credit)

Closes #271

## Test plan
- [x] 16 unit tests passing (input validation, metadata, generation success/error, cost estimation, JSON schema)
- [x] Pyright type checking: 0 errors
- [x] Ruff linting: all checks passed
- [ ] Live API test requires a valid Kie.ai task_id — placeholder provided for manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)