### PR TITLE
feat: add KIE Seedance 2.0 video generators

### DIFF
--- a/packages/backend/baseline-config/generators.yaml
+++ b/packages/backend/baseline-config/generators.yaml
@@ -267,6 +267,12 @@ generators:
   - class: "boards.generators.implementations.kie.video.runway_aleph.KieRunwayAlephGenerator"
     enabled: true
 
+  - class: "boards.generators.implementations.kie.video.seedance2.KieSeedance2Generator"
+    enabled: true
+
+  - class: "boards.generators.implementations.kie.video.seedance2_fast.KieSeedance2FastGenerator"
+    enabled: true
+
   - class: "boards.generators.implementations.kie.video.veo3.KieVeo3Generator"
     enabled: true
 

--- a/packages/backend/src/boards/generators/implementations/kie/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/kie/__init__.py
@@ -5,6 +5,8 @@ from .audio.suno_v5_5 import KieSunoV55Generator, SunoV55Input
 from .image.nano_banana_edit import KieNanoBananaEditGenerator, NanoBananaEditInput
 from .image.qwen_image_2 import KieQwenImage2Generator, QwenImage2Input
 from .video.runway_aleph import KieRunwayAlephGenerator, KieRunwayAlephInput
+from .video.seedance2 import KieSeedance2Generator, KieSeedance2Input
+from .video.seedance2_fast import KieSeedance2FastGenerator, KieSeedance2FastInput
 from .video.veo3 import KieVeo3Generator, KieVeo3Input
 
 __all__ = [
@@ -18,6 +20,10 @@ __all__ = [
     "QwenImage2Input",
     "KieRunwayAlephGenerator",
     "KieRunwayAlephInput",
+    "KieSeedance2FastGenerator",
+    "KieSeedance2FastInput",
+    "KieSeedance2Generator",
+    "KieSeedance2Input",
     "KieVeo3Generator",
     "KieVeo3Input",
 ]

--- a/packages/backend/src/boards/generators/implementations/kie/base.py
+++ b/packages/backend/src/boards/generators/implementations/kie/base.py
@@ -199,7 +199,7 @@ class KieMarketAPIGenerator(KieBaseGenerator):
 
                 if state == "success":
                     return task_data
-                elif state == "failed":
+                elif state in ["failed", "fail"]:
                     error_msg = task_data.get("failMsg", "Unknown error")
                     raise ValueError(f"Generation failed: {error_msg}")
                 elif state not in ["waiting", "pending", "processing", None]:

--- a/packages/backend/src/boards/generators/implementations/kie/video/__init__.py
+++ b/packages/backend/src/boards/generators/implementations/kie/video/__init__.py
@@ -1,11 +1,17 @@
 """Kie.ai video generators."""
 
 from .runway_aleph import KieRunwayAlephGenerator, KieRunwayAlephInput
+from .seedance2 import KieSeedance2Generator, KieSeedance2Input
+from .seedance2_fast import KieSeedance2FastGenerator, KieSeedance2FastInput
 from .veo3 import KieVeo3Generator, KieVeo3Input
 
 __all__ = [
     "KieRunwayAlephGenerator",
     "KieRunwayAlephInput",
+    "KieSeedance2FastGenerator",
+    "KieSeedance2FastInput",
+    "KieSeedance2Generator",
+    "KieSeedance2Input",
     "KieVeo3Generator",
     "KieVeo3Input",
 ]

--- a/packages/backend/src/boards/generators/implementations/kie/video/seedance2.py
+++ b/packages/backend/src/boards/generators/implementations/kie/video/seedance2.py
@@ -1,0 +1,263 @@
+"""
+Kie.ai Seedance 2.0 text-to-video and multimodal video generator.
+
+Generate high-quality videos from text prompts with optional image, video, and audio
+inputs using ByteDance's Seedance 2.0 model via Kie.ai's Market API.
+
+Features flawless real human generation, identity consistency, cinematic coherence,
+multimodal inputs (text/image/video/audio), and native audio output.
+
+Based on Kie.ai's Seedance 2.0 API.
+See: https://docs.kie.ai/market/bytedance/seedance-2
+"""
+
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import AudioArtifact, ImageArtifact, VideoArtifact
+from ....base import GeneratorExecutionContext, GeneratorResult
+from ..base import KieMarketAPIGenerator
+
+
+class KieSeedance2Input(BaseModel):
+    """Input schema for Kie.ai Seedance 2.0 video generation.
+
+    Supports text-to-video, image-to-video, video-to-video, and audio-driven modes.
+    Artifact fields are automatically detected via type introspection and resolved
+    from generation IDs to artifact objects.
+    """
+
+    prompt: str = Field(
+        description="Text prompt describing the video to generate (3-2500 characters)",
+        min_length=3,
+        max_length=2500,
+    )
+    reference_image_sources: list[ImageArtifact] | None = Field(
+        default=None,
+        description="Optional reference images for guidance (max 9, max 10MB each)",
+        min_length=1,
+        max_length=9,
+    )
+    reference_video_sources: list[VideoArtifact] | None = Field(
+        default=None,
+        description="Optional reference videos (max 3, total duration <= 15s, max 10MB each)",
+        min_length=1,
+        max_length=3,
+    )
+    reference_audio_sources: list[AudioArtifact] | None = Field(
+        default=None,
+        description="Optional reference audio files (max 3, total duration <= 15s, max 10MB each)",
+        min_length=1,
+        max_length=3,
+    )
+    first_frame_image: list[ImageArtifact] | None = Field(
+        default=None,
+        description="Optional first frame image for the video",
+        min_length=1,
+        max_length=1,
+    )
+    last_frame_image: list[ImageArtifact] | None = Field(
+        default=None,
+        description="Optional last frame image for the video",
+        min_length=1,
+        max_length=1,
+    )
+    resolution: Literal["480p", "720p"] = Field(
+        default="720p",
+        description="Output video resolution",
+    )
+    aspect_ratio: Literal["16:9", "9:16", "1:1", "4:3", "3:4", "21:9"] = Field(
+        default="16:9",
+        description="Aspect ratio of the generated video",
+    )
+    duration: Literal[4, 8, 12] = Field(
+        default=8,
+        description="Duration of the generated video in seconds",
+    )
+    generate_audio: bool = Field(
+        default=True,
+        description="Whether to generate AI audio synced with the video",
+    )
+
+
+class KieSeedance2Generator(KieMarketAPIGenerator):
+    """Seedance 2.0 video generator using Kie.ai Market API."""
+
+    name = "kie-seedance-2"
+    artifact_type = "video"
+    description = "Kie.ai: ByteDance Seedance 2.0 - High-quality AI video generation"
+
+    # Market API configuration
+    model_id = "bytedance/seedance-2"
+
+    def get_input_schema(self) -> type[KieSeedance2Input]:
+        return KieSeedance2Input
+
+    async def generate(
+        self, inputs: KieSeedance2Input, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate video using Kie.ai Seedance 2.0 model."""
+        api_key = self._get_api_key()
+
+        # Build the input parameters
+        input_params: dict[str, Any] = {
+            "prompt": inputs.prompt,
+            "resolution": inputs.resolution,
+            "aspect_ratio": inputs.aspect_ratio,
+            "duration": inputs.duration,
+            "generate_audio": inputs.generate_audio,
+        }
+
+        # Upload artifact inputs if provided
+        from ..utils import upload_artifacts_to_kie
+
+        if inputs.reference_image_sources:
+            image_urls = await upload_artifacts_to_kie(inputs.reference_image_sources, context)
+            input_params["reference_image_urls"] = image_urls
+
+        if inputs.reference_video_sources:
+            video_urls = await upload_artifacts_to_kie(inputs.reference_video_sources, context)
+            input_params["reference_video_urls"] = video_urls
+
+        if inputs.reference_audio_sources:
+            audio_urls = await upload_artifacts_to_kie(inputs.reference_audio_sources, context)
+            input_params["reference_audio_urls"] = audio_urls
+
+        if inputs.first_frame_image:
+            first_frame_urls = await upload_artifacts_to_kie(inputs.first_frame_image, context)
+            input_params["first_frame_url"] = first_frame_urls[0]
+
+        if inputs.last_frame_image:
+            last_frame_urls = await upload_artifacts_to_kie(inputs.last_frame_image, context)
+            input_params["last_frame_url"] = last_frame_urls[0]
+
+        # Prepare request body for Market API
+        body = {
+            "model": self.model_id,
+            "input": input_params,
+        }
+
+        # Submit task using Market API endpoint
+        submit_url = "https://api.kie.ai/api/v1/jobs/createTask"
+        result = await self._make_request(submit_url, "POST", api_key, json=body)
+
+        # Extract task ID
+        data = result.get("data", {})
+        task_id = data.get("taskId")
+
+        if not task_id:
+            raise ValueError(f"No taskId returned from Kie.ai API. Response: {result}")
+
+        await context.set_external_job_id(task_id)
+
+        # Poll for completion using Market API base class method
+        task_data = await self._poll_for_completion(task_id, api_key, context)
+
+        # Extract video URLs from result
+        result_json = task_data.get("resultJson")
+        if result_json:
+            result_data = json.loads(result_json)
+        else:
+            result_data = task_data.get("result")
+
+        if not result_data:
+            raise ValueError("No result data returned from Kie.ai API")
+
+        # Extract video URLs from response
+        video_urls = _extract_video_urls(result_data)
+
+        # Determine video dimensions based on resolution and aspect ratio
+        width, height = _calculate_dimensions(inputs.resolution, inputs.aspect_ratio)
+
+        # Store each video using output_index
+        artifacts = []
+        for idx, video_url in enumerate(video_urls):
+            if not video_url:
+                raise ValueError(f"Video {idx} missing URL in Kie.ai response")
+
+            artifact = await context.store_video_result(
+                storage_url=video_url,
+                format="mp4",
+                width=width,
+                height=height,
+                duration=float(inputs.duration),
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: KieSeedance2Input) -> float:
+        """Estimate cost for Seedance 2.0 video generation.
+
+        Pricing per second varies by resolution and whether video input is used:
+        - 480p: $0.095/sec (text) | $0.0575/sec (with video input)
+        - 720p: $0.205/sec (text) | $0.125/sec (with video input)
+        """
+        has_video_input = inputs.reference_video_sources is not None
+
+        if inputs.resolution == "480p":
+            rate = 0.0575 if has_video_input else 0.095
+        else:  # 720p
+            rate = 0.125 if has_video_input else 0.205
+
+        return rate * inputs.duration
+
+
+def _extract_video_urls(result_data: dict[str, Any] | Any) -> list[str]:
+    """Extract video URLs from Market API result data."""
+    if not isinstance(result_data, dict):
+        raise ValueError(f"Unexpected result data format: {type(result_data)}")
+
+    # Try common response patterns
+    if "resultUrls" in result_data:
+        return result_data["resultUrls"]
+    if "video_urls" in result_data:
+        return result_data["video_urls"]
+    if "videos" in result_data:
+        videos = result_data["videos"]
+        if videos and isinstance(videos[0], str):
+            return [str(v) for v in videos]
+        return [str(v["url"]) for v in videos if isinstance(v, dict) and "url" in v]
+    if "url" in result_data:
+        return [result_data["url"]]
+
+    raise ValueError(f"No video URLs found in result: {result_data}")
+
+
+def _calculate_dimensions(resolution: str, aspect_ratio: str) -> tuple[int, int]:
+    """Calculate pixel dimensions from resolution and aspect ratio."""
+    # Base heights for each resolution
+    if resolution == "480p":
+        base_height = 480
+    else:  # 720p
+        base_height = 720
+
+    aspect_ratios: dict[str, tuple[int, int]] = {
+        "16:9": (16, 9),
+        "9:16": (9, 16),
+        "1:1": (1, 1),
+        "4:3": (4, 3),
+        "3:4": (3, 4),
+        "21:9": (21, 9),
+    }
+
+    w_ratio, h_ratio = aspect_ratios.get(aspect_ratio, (16, 9))
+
+    # Calculate width from height and aspect ratio, round to nearest even number
+    if h_ratio >= w_ratio:
+        # Portrait or square: height is the larger dimension
+        height = base_height
+        width = int(height * w_ratio / h_ratio)
+    else:
+        # Landscape: width is the larger dimension based on height
+        height = base_height
+        width = int(height * w_ratio / h_ratio)
+
+    # Ensure dimensions are even (required for video encoding)
+    width = width + (width % 2)
+    height = height + (height % 2)
+
+    return width, height

--- a/packages/backend/src/boards/generators/implementations/kie/video/seedance2.py
+++ b/packages/backend/src/boards/generators/implementations/kie/video/seedance2.py
@@ -108,6 +108,7 @@ class KieSeedance2Generator(KieMarketAPIGenerator):
             "aspect_ratio": inputs.aspect_ratio,
             "duration": inputs.duration,
             "generate_audio": inputs.generate_audio,
+            "web_search": False,
         }
 
         # Upload artifact inputs if provided

--- a/packages/backend/src/boards/generators/implementations/kie/video/seedance2_fast.py
+++ b/packages/backend/src/boards/generators/implementations/kie/video/seedance2_fast.py
@@ -1,0 +1,207 @@
+"""
+Kie.ai Seedance 2.0 Fast text-to-video and multimodal video generator.
+
+Generate videos quickly from text prompts with optional image, video, and audio
+inputs using ByteDance's Seedance 2.0 Fast model via Kie.ai's Market API.
+
+Optimized for speed and cost efficiency compared to standard Seedance 2.0,
+with the same multimodal input support and native audio output.
+
+Based on Kie.ai's Seedance 2.0 Fast API.
+See: https://docs.kie.ai/market/bytedance/seedance-2-fast
+"""
+
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from ....artifacts import AudioArtifact, ImageArtifact, VideoArtifact
+from ....base import GeneratorExecutionContext, GeneratorResult
+from ..base import KieMarketAPIGenerator
+from .seedance2 import _calculate_dimensions, _extract_video_urls
+
+
+class KieSeedance2FastInput(BaseModel):
+    """Input schema for Kie.ai Seedance 2.0 Fast video generation.
+
+    Supports text-to-video, image-to-video, video-to-video, and audio-driven modes.
+    Artifact fields are automatically detected via type introspection and resolved
+    from generation IDs to artifact objects.
+    """
+
+    prompt: str = Field(
+        description="Text prompt describing the video to generate (3-2500 characters)",
+        min_length=3,
+        max_length=2500,
+    )
+    reference_image_sources: list[ImageArtifact] | None = Field(
+        default=None,
+        description="Optional reference images for guidance (max 9, max 10MB each)",
+        min_length=1,
+        max_length=9,
+    )
+    reference_video_sources: list[VideoArtifact] | None = Field(
+        default=None,
+        description="Optional reference videos (max 3, total duration <= 15s, max 10MB each)",
+        min_length=1,
+        max_length=3,
+    )
+    reference_audio_sources: list[AudioArtifact] | None = Field(
+        default=None,
+        description="Optional reference audio files (max 3, total duration <= 15s, max 10MB each)",
+        min_length=1,
+        max_length=3,
+    )
+    first_frame_image: list[ImageArtifact] | None = Field(
+        default=None,
+        description="Optional first frame image for the video",
+        min_length=1,
+        max_length=1,
+    )
+    last_frame_image: list[ImageArtifact] | None = Field(
+        default=None,
+        description="Optional last frame image for the video",
+        min_length=1,
+        max_length=1,
+    )
+    resolution: Literal["480p", "720p"] = Field(
+        default="720p",
+        description="Output video resolution",
+    )
+    aspect_ratio: Literal["16:9", "9:16", "1:1", "4:3", "3:4", "21:9"] = Field(
+        default="16:9",
+        description="Aspect ratio of the generated video",
+    )
+    duration: Literal[4, 8, 12] = Field(
+        default=8,
+        description="Duration of the generated video in seconds",
+    )
+    generate_audio: bool = Field(
+        default=True,
+        description="Whether to generate AI audio synced with the video",
+    )
+
+
+class KieSeedance2FastGenerator(KieMarketAPIGenerator):
+    """Seedance 2.0 Fast video generator using Kie.ai Market API."""
+
+    name = "kie-seedance-2-fast"
+    artifact_type = "video"
+    description = "Kie.ai: ByteDance Seedance 2.0 Fast - Fast AI video generation with native audio"
+
+    # Market API configuration
+    model_id = "bytedance/seedance-2-fast"
+
+    def get_input_schema(self) -> type[KieSeedance2FastInput]:
+        return KieSeedance2FastInput
+
+    async def generate(
+        self, inputs: KieSeedance2FastInput, context: GeneratorExecutionContext
+    ) -> GeneratorResult:
+        """Generate video using Kie.ai Seedance 2.0 Fast model."""
+        api_key = self._get_api_key()
+
+        # Build the input parameters
+        input_params: dict[str, Any] = {
+            "prompt": inputs.prompt,
+            "resolution": inputs.resolution,
+            "aspect_ratio": inputs.aspect_ratio,
+            "duration": inputs.duration,
+            "generate_audio": inputs.generate_audio,
+        }
+
+        # Upload artifact inputs if provided
+        from ..utils import upload_artifacts_to_kie
+
+        if inputs.reference_image_sources:
+            image_urls = await upload_artifacts_to_kie(inputs.reference_image_sources, context)
+            input_params["reference_image_urls"] = image_urls
+
+        if inputs.reference_video_sources:
+            video_urls = await upload_artifacts_to_kie(inputs.reference_video_sources, context)
+            input_params["reference_video_urls"] = video_urls
+
+        if inputs.reference_audio_sources:
+            audio_urls = await upload_artifacts_to_kie(inputs.reference_audio_sources, context)
+            input_params["reference_audio_urls"] = audio_urls
+
+        if inputs.first_frame_image:
+            first_frame_urls = await upload_artifacts_to_kie(inputs.first_frame_image, context)
+            input_params["first_frame_url"] = first_frame_urls[0]
+
+        if inputs.last_frame_image:
+            last_frame_urls = await upload_artifacts_to_kie(inputs.last_frame_image, context)
+            input_params["last_frame_url"] = last_frame_urls[0]
+
+        # Prepare request body for Market API
+        body = {
+            "model": self.model_id,
+            "input": input_params,
+        }
+
+        # Submit task using Market API endpoint
+        submit_url = "https://api.kie.ai/api/v1/jobs/createTask"
+        result = await self._make_request(submit_url, "POST", api_key, json=body)
+
+        # Extract task ID
+        data = result.get("data", {})
+        task_id = data.get("taskId")
+
+        if not task_id:
+            raise ValueError(f"No taskId returned from Kie.ai API. Response: {result}")
+
+        await context.set_external_job_id(task_id)
+
+        # Poll for completion using Market API base class method
+        task_data = await self._poll_for_completion(task_id, api_key, context)
+
+        # Extract video URLs from result
+        result_json = task_data.get("resultJson")
+        if result_json:
+            result_data = json.loads(result_json)
+        else:
+            result_data = task_data.get("result")
+
+        if not result_data:
+            raise ValueError("No result data returned from Kie.ai API")
+
+        # Extract video URLs from response
+        video_urls = _extract_video_urls(result_data)
+
+        # Determine video dimensions based on resolution and aspect ratio
+        width, height = _calculate_dimensions(inputs.resolution, inputs.aspect_ratio)
+
+        # Store each video using output_index
+        artifacts = []
+        for idx, video_url in enumerate(video_urls):
+            if not video_url:
+                raise ValueError(f"Video {idx} missing URL in Kie.ai response")
+
+            artifact = await context.store_video_result(
+                storage_url=video_url,
+                format="mp4",
+                width=width,
+                height=height,
+                duration=float(inputs.duration),
+                output_index=idx,
+            )
+            artifacts.append(artifact)
+
+        return GeneratorResult(outputs=artifacts)
+
+    async def estimate_cost(self, inputs: KieSeedance2FastInput) -> float:
+        """Estimate cost for Seedance 2.0 Fast video generation.
+
+        Pricing per second varies by resolution and whether video input is used:
+        - 480p: $0.0775/sec (text) | $0.045/sec (with video input)
+        - 720p: $0.165/sec (text) | $0.10/sec (with video input)
+        """
+        has_video_input = inputs.reference_video_sources is not None
+
+        if inputs.resolution == "480p":
+            rate = 0.045 if has_video_input else 0.0775
+        else:  # 720p
+            rate = 0.10 if has_video_input else 0.165
+
+        return rate * inputs.duration

--- a/packages/backend/src/boards/generators/implementations/kie/video/seedance2_fast.py
+++ b/packages/backend/src/boards/generators/implementations/kie/video/seedance2_fast.py
@@ -109,6 +109,7 @@ class KieSeedance2FastGenerator(KieMarketAPIGenerator):
             "aspect_ratio": inputs.aspect_ratio,
             "duration": inputs.duration,
             "generate_audio": inputs.generate_audio,
+            "web_search": False,
         }
 
         # Upload artifact inputs if provided

--- a/packages/backend/tests/generators/implementations/test_kie_seedance2_fast_live.py
+++ b/packages/backend/tests/generators/implementations/test_kie_seedance2_fast_live.py
@@ -1,0 +1,71 @@
+"""
+Live API tests for KieSeedance2FastGenerator.
+
+These tests make actual API calls to the Kie.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_kie to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"KIE_API_KEY": "..."}'
+    pytest tests/generators/implementations/test_kie_seedance2_fast_live.py -v -m live_api
+
+Or using direct environment variable:
+    export KIE_API_KEY="..."
+    pytest tests/generators/implementations/test_kie_seedance2_fast_live.py -v -m live_kie
+
+Or run all Kie live tests:
+    pytest -m live_kie -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import VideoArtifact
+from boards.generators.implementations.kie.video.seedance2_fast import (
+    KieSeedance2FastGenerator,
+    KieSeedance2FastInput,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_kie]
+
+
+class TestKieSeedance2FastGeneratorLive:
+    """Live API tests for KieSeedance2FastGenerator using real Kie.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = KieSeedance2FastGenerator()
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_text_to_video_basic(
+        self, skip_if_no_kie_key, dummy_context, cost_logger
+    ):
+        """
+        Test basic text-to-video generation with Seedance 2.0 Fast.
+
+        This test makes a real API call to Kie.ai and will consume credits.
+        Uses minimal/cheap settings to reduce cost.
+        """
+        inputs = KieSeedance2FastInput(
+            prompt="A flower blooming in a garden",
+            resolution="480p",
+            aspect_ratio="16:9",
+            duration=4,
+            generate_audio=False,
+        )
+
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        result = await self.generator.generate(inputs, dummy_context)
+
+        assert result.outputs is not None
+        assert len(result.outputs) >= 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.format == "mp4"
+        assert artifact.duration == 4.0

--- a/packages/backend/tests/generators/implementations/test_kie_seedance2_live.py
+++ b/packages/backend/tests/generators/implementations/test_kie_seedance2_live.py
@@ -1,0 +1,71 @@
+"""
+Live API tests for KieSeedance2Generator.
+
+These tests make actual API calls to the Kie.ai service and consume API credits.
+They are marked with @pytest.mark.live_api and @pytest.mark.live_kie to
+ensure they are never run by default.
+
+To run these tests:
+    export BOARDS_GENERATOR_API_KEYS='{"KIE_API_KEY": "..."}'
+    pytest tests/generators/implementations/test_kie_seedance2_live.py -v -m live_api
+
+Or using direct environment variable:
+    export KIE_API_KEY="..."
+    pytest tests/generators/implementations/test_kie_seedance2_live.py -v -m live_kie
+
+Or run all Kie live tests:
+    pytest -m live_kie -v
+"""
+
+import pytest
+
+from boards.config import initialize_generator_api_keys
+from boards.generators.artifacts import VideoArtifact
+from boards.generators.implementations.kie.video.seedance2 import (
+    KieSeedance2Generator,
+    KieSeedance2Input,
+)
+
+pytestmark = [pytest.mark.live_api, pytest.mark.live_kie]
+
+
+class TestKieSeedance2GeneratorLive:
+    """Live API tests for KieSeedance2Generator using real Kie.ai API."""
+
+    def setup_method(self):
+        """Set up generator and ensure API keys are synced to environment."""
+        self.generator = KieSeedance2Generator()
+        initialize_generator_api_keys()
+
+    @pytest.mark.asyncio
+    async def test_generate_text_to_video_basic(
+        self, skip_if_no_kie_key, dummy_context, cost_logger
+    ):
+        """
+        Test basic text-to-video generation with Seedance 2.0.
+
+        This test makes a real API call to Kie.ai and will consume credits.
+        Uses minimal/cheap settings to reduce cost.
+        """
+        inputs = KieSeedance2Input(
+            prompt="A flower blooming in a garden",
+            resolution="480p",
+            aspect_ratio="16:9",
+            duration=4,
+            generate_audio=False,
+        )
+
+        estimated_cost = await self.generator.estimate_cost(inputs)
+        cost_logger(self.generator.name, estimated_cost)
+
+        result = await self.generator.generate(inputs, dummy_context)
+
+        assert result.outputs is not None
+        assert len(result.outputs) >= 1
+
+        artifact = result.outputs[0]
+        assert isinstance(artifact, VideoArtifact)
+        assert artifact.storage_url is not None
+        assert artifact.storage_url.startswith("https://")
+        assert artifact.format == "mp4"
+        assert artifact.duration == 4.0


### PR DESCRIPTION
## Summary
- Add `KieSeedance2Generator` and `KieSeedance2FastGenerator` for ByteDance's Seedance 2.0 model via Kie.ai Market API
- Supports multimodal inputs: text prompts, reference images (up to 9), reference videos (up to 3), reference audio (up to 3), and first/last frame control
- Resolution-aware per-second cost estimation accounting for video input discounts
- Configurable duration (4/8/12s), resolution (480p/720p), aspect ratio, and native audio generation

## Test plan
- [ ] Verify generators load correctly in the registry with `generators.yaml`
- [ ] Test text-to-video generation with Seedance 2.0 standard
- [ ] Test text-to-video generation with Seedance 2.0 Fast
- [ ] Test image-to-video with reference image inputs
- [ ] Verify cost estimation for different resolution/duration/input combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)